### PR TITLE
fix: lazily initialize OpenAI client to prevent build-time crash

### DIFF
--- a/src/app/api/ai-assistant/route.ts
+++ b/src/app/api/ai-assistant/route.ts
@@ -6,10 +6,9 @@ import { buildAIContext, ContextType } from '@/lib/ai-assistant/contextBuilder';
 import OpenAI from 'openai';
 import { z } from 'zod';
 
-// Initialize OpenAI client
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-});
+function getOpenAIClient() {
+  return new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+}
 
 // Request validation schema
 const requestSchema = z.object({
@@ -184,7 +183,7 @@ ${message}`;
     ];
 
     // 8. Call OpenAI API with function calling
-    const completion = await openai.chat.completions.create({
+    const completion = await getOpenAIClient().chat.completions.create({
       model: 'gpt-4-turbo-preview', // Supports 128k tokens
       messages,
       temperature: 0.7,

--- a/src/app/api/ai/generate-modules/route.ts
+++ b/src/app/api/ai/generate-modules/route.ts
@@ -3,9 +3,9 @@ import { cookies } from 'next/headers';
 import { verifySession } from '@/lib/jwt';
 import OpenAI from 'openai';
 
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-});
+function getOpenAIClient() {
+  return new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+}
 
 export async function POST(request: NextRequest) {
   try {
@@ -24,7 +24,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Description is required' }, { status: 400 });
     }
 
-    const completion = await openai.chat.completions.create({
+    const completion = await getOpenAIClient().chat.completions.create({
       model: 'gpt-4o-mini',
       messages: [
         {

--- a/src/app/api/ai/generate-title/route.ts
+++ b/src/app/api/ai/generate-title/route.ts
@@ -3,9 +3,9 @@ import { cookies } from 'next/headers';
 import { verifySession } from '@/lib/jwt';
 import OpenAI from 'openai';
 
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-});
+function getOpenAIClient() {
+  return new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+}
 
 export async function POST(request: NextRequest) {
   try {
@@ -24,7 +24,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Description is required' }, { status: 400 });
     }
 
-    const completion = await openai.chat.completions.create({
+    const completion = await getOpenAIClient().chat.completions.create({
       model: 'gpt-4o-mini',
       messages: [
         {

--- a/src/app/api/ai/generate-value/route.ts
+++ b/src/app/api/ai/generate-value/route.ts
@@ -3,9 +3,9 @@ import { cookies } from 'next/headers';
 import { verifySession } from '@/lib/jwt';
 import OpenAI from 'openai';
 
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-});
+function getOpenAIClient() {
+  return new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+}
 
 export async function POST(request: NextRequest) {
   try {
@@ -24,7 +24,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Description is required' }, { status: 400 });
     }
 
-    const completion = await openai.chat.completions.create({
+    const completion = await getOpenAIClient().chat.completions.create({
       model: 'gpt-4o-mini',
       messages: [
         {

--- a/src/app/api/notifications/summary/route.ts
+++ b/src/app/api/notifications/summary/route.ts
@@ -8,9 +8,9 @@ import { verifySession } from '@/lib/jwt';
 import NotificationService from '@/lib/services/notification.service';
 import OpenAI from 'openai';
 
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-});
+function getOpenAIClient() {
+  return new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+}
 
 async function getUserIdFromRequest(request: NextRequest): Promise<string | null> {
   const authHeader = request.headers.get('authorization');
@@ -96,7 +96,7 @@ Provide a brief summary (max 200 words) highlighting:
 3. Task assignments
 4. Upcoming deadlines`;
 
-    const completion = await openai.chat.completions.create({
+    const completion = await getOpenAIClient().chat.completions.create({
       model: 'gpt-4o-mini',
       messages: [
         {


### PR DESCRIPTION
The OpenAI SDK throws if OPENAI_API_KEY is not set. During Next.js build, route modules are imported for page data collection, causing the build to fail when the env var isn't available. Moving client creation into a function defers it to request time.

https://claude.ai/code/session_011D3eJVR89fWDxKrUBtLcwX