### PR TITLE
fix: prevent build-time crashes from puppeteer and PrismaClient

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,8 @@ jobs:
           NODE_ENV: production
           NEXT_PUBLIC_BASE_PATH: "/ots"
           NEXT_PUBLIC_APP_URL: "https://hexasteel.sa/ots"
+          # Dummy values so Prisma Client can initialise without a real DB during build
+          DATABASE_URL: "mysql://placeholder:placeholder@localhost:3306/placeholder"
 
       - name: Create deployment package
         run: |

--- a/next.config.ts
+++ b/next.config.ts
@@ -51,6 +51,9 @@ const nextConfig: NextConfig = {
     root: __dirname,
   },
   
+  // Keep heavy server-only packages out of the webpack bundle
+  serverExternalPackages: ['puppeteer'],
+
   // Build optimizations
   experimental: {
     // Disable CSS optimization to avoid critters module error

--- a/src/lib/services/deadline-scheduler.service.ts
+++ b/src/lib/services/deadline-scheduler.service.ts
@@ -5,10 +5,8 @@
  */
 
 import cron from 'node-cron';
-import { PrismaClient } from '@prisma/client';
+import prisma from '@/lib/prisma';
 import NotificationService from './notification.service';
-
-const prisma = new PrismaClient();
 
 export class DeadlineSchedulerService {
   private static isRunning = false;

--- a/src/lib/services/notification.service.ts
+++ b/src/lib/services/notification.service.ts
@@ -4,9 +4,8 @@
  * Part of the Hexa Steel OTS Notification Center Module
  */
 
-import { PrismaClient, NotificationType, Notification } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import { NotificationType, Notification } from '@prisma/client';
+import prisma from '@/lib/prisma';
 
 export interface CreateNotificationParams {
   userId: string;

--- a/src/lib/services/project-import.service.ts
+++ b/src/lib/services/project-import.service.ts
@@ -3,7 +3,7 @@
  * Handles database operations for importing projects from Excel
  */
 
-import { PrismaClient } from '@prisma/client';
+import prisma from '@/lib/prisma';
 import {
   ParsedExcelData,
   ImportSummary,
@@ -11,8 +11,6 @@ import {
   ProjectRow,
   BuildingRow,
 } from '@/lib/types/project-migration';
-
-const prisma = new PrismaClient();
 
 // ============================================
 // HELPER FUNCTIONS

--- a/src/modules/reporting/reportController.ts
+++ b/src/modules/reporting/reportController.ts
@@ -4,7 +4,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { reportEngine } from './reportEngine';
+import { getReportEngine } from './reportEngine';
 import { ReportGenerationRequest, ReportGenerationResponse } from './reportTypes';
 
 /**
@@ -60,7 +60,7 @@ export async function generateReportHandler(
     }
 
     // Generate report
-    const result = await reportEngine.generateReport({
+    const result = await getReportEngine().generateReport({
       reportType,
       projectId,
       language,

--- a/src/modules/reporting/reportEngine.ts
+++ b/src/modules/reporting/reportEngine.ts
@@ -3,11 +3,11 @@
  * Professional PDF report generation using Puppeteer
  */
 
-import puppeteer, { Browser, Page } from 'puppeteer';
+import type { Browser, Page } from 'puppeteer';
 import Handlebars from 'handlebars';
 import fs from 'fs/promises';
 import path from 'path';
-import { PrismaClient } from '@prisma/client';
+import prisma from '@/lib/prisma';
 import {
   ReportGenerationRequest,
   ReportGenerationResponse,
@@ -19,8 +19,6 @@ import {
   DeliveryNoteData,
   PuppeteerConfig,
 } from './reportTypes';
-
-const prisma = new PrismaClient();
 
 /**
  * Hexa Reporting Engine Class
@@ -62,6 +60,7 @@ export class HexaReportingEngine {
    */
   private async initBrowser(): Promise<Browser> {
     if (!this.browser) {
+      const puppeteer = (await import('puppeteer')).default;
       this.browser = await puppeteer.launch({
         headless: true,
         args: [
@@ -776,5 +775,14 @@ export class HexaReportingEngine {
   }
 }
 
-// Export singleton instance
-export const reportEngine = new HexaReportingEngine();
+// Lazy singleton – avoid instantiating at module scope during next build
+let _reportEngine: HexaReportingEngine | null = null;
+export function getReportEngine(): HexaReportingEngine {
+  if (!_reportEngine) {
+    _reportEngine = new HexaReportingEngine();
+  }
+  return _reportEngine;
+}
+
+/** @deprecated Use getReportEngine() instead */
+export const reportEngine = undefined as unknown as HexaReportingEngine;


### PR DESCRIPTION
- Dynamically import puppeteer in reportEngine.ts to avoid bundling Chromium during next build
- Replace top-level PrismaClient instantiations with shared singleton from src/lib/prisma.ts (notification, deadline-scheduler, project-import, reportEngine services)
- Make reportEngine a lazy singleton via getReportEngine()
- Add puppeteer to serverExternalPackages in next.config.ts
- Provide dummy DATABASE_URL in CI build step so Prisma Client can initialise without a real database

https://claude.ai/code/session_011D3eJVR89fWDxKrUBtLcwX