### PR TITLE
feat: global TopBar with notification bell/logout, actionable notifications, full-width dashboard (v15.22.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [15.22.0] - 2026-03-15
+
+### Global Notification Bar & Dashboard Layout Improvements
+
+#### New Features
+- **Global TopBar** — Notification bell and logout button are now permanently visible in the top-right corner on every system page, giving users instant access regardless of which page they are on
+- **Actionable Notification Dropdown** — The notification panel now supports inline actions directly from the dropdown list:
+  - **Complete** button on task-assigned notifications to mark the task done immediately
+  - **Approve / Reject** buttons on approval-request notifications to act without navigating away
+- **Clear on Read** — Clicking any notification marks it as read and removes it from the dropdown list, keeping the list clean and focused on unread items
+- **Clear All** — New trash icon in the notification panel header archives all notifications at once (POST `/api/notifications/bulk-archive`)
+- **Unread Count Badge** — The panel header now displays the current unread count next to the "Notifications" title
+- **New bulk-archive API** — `POST /api/notifications/bulk-archive` archives all unread notifications for the authenticated user
+
+#### Improvements
+- **Dashboard Full-Width Layout** — Removed `container mx-auto` constraint from the dashboard page; content now uses the full available width with consistent padding
+- **Widget Grid Enhancement** — Updated widget grid from `sm:grid-cols-2 lg:grid-cols-3` to `md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4`, better utilizing wide-screen space and allowing four widgets per row on large monitors
+- **Dashboard Header Simplified** — Removed the redundant per-page logout button from the dashboard since logout is now always accessible via the global TopBar
+- **Notification Panel Polish** — Unread indicator dot, smaller timestamps, tighter spacing, and improved dark-mode-aware highlight colors
+
+---
+
 ## [15.21.0] - 2026-03-15
 
 ### Task Management UX & Delayed Tasks Improvements

--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ A comprehensive Enterprise Resource Planning (ERP) system specifically designed 
 - **Google Sheets Sync**: Automated data export and synchronization
 - **PTS Sync**: External project tracking system integration
 - **Scheduled Jobs**: Automated cron-based background processing
-- **Notifications**: Real-time in-app user notifications
+- **Notifications**: Real-time in-app user notifications with actionable dropdown (complete, approve, reject inline)
+- **Global TopBar**: Persistent notification bell and logout button visible on every page
 
 ### Mobile App & Push Notifications (PWA)
 - **Progressive Web App**: Installable on mobile devices via browser — no app store needed
@@ -438,6 +439,6 @@ Proprietary software — All rights reserved by Hexa Steel®.
 
 ---
 
-**Version**: 15.20.0
+**Version**: 15.22.0
 **Last Updated**: March 2026
 **Repository**: https://github.com/refedo/OTS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexa-steel-ots",
-  "version": "15.21.0",
+  "version": "15.22.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/api/notifications/bulk-archive/route.ts
+++ b/src/app/api/notifications/bulk-archive/route.ts
@@ -1,0 +1,56 @@
+/**
+ * Archive all notifications for the current user (Clear All)
+ * POST /api/notifications/bulk-archive
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { verifySession } from '@/lib/jwt';
+import prisma from '@/lib/db';
+import { logger } from '@/lib/logger';
+
+async function getUserIdFromRequest(request: NextRequest): Promise<string | null> {
+  const authHeader = request.headers.get('authorization');
+  if (authHeader?.startsWith('Bearer ')) {
+    const token = authHeader.replace('Bearer ', '');
+    const session = verifySession(token);
+    return session?.sub || null;
+  }
+
+  const cookieName = process.env.COOKIE_NAME || 'ots_session';
+  const token = request.cookies.get(cookieName)?.value;
+  if (token) {
+    const session = verifySession(token);
+    return session?.sub || null;
+  }
+
+  return null;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const userId = await getUserIdFromRequest(request);
+    if (!userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const result = await prisma.notification.updateMany({
+      where: {
+        userId,
+        isArchived: false,
+      },
+      data: {
+        isArchived: true,
+        archivedAt: new Date(),
+        isRead: true,
+        readAt: new Date(),
+      },
+    });
+
+    logger.info({ userId, count: result.count }, 'Bulk archived notifications');
+
+    return NextResponse.json({ success: true, count: result.count });
+  } catch (error: unknown) {
+    logger.error({ error }, 'Failed to bulk archive notifications');
+    return NextResponse.json({ error: 'Failed to clear notifications' }, { status: 500 });
+  }
+}

--- a/src/app/changelog/_page-client.tsx
+++ b/src/app/changelog/_page-client.tsx
@@ -23,10 +23,41 @@ type ChangelogVersion = {
 // Version order: Major versions first, then their minor versions
 const hardcodedVersions: ChangelogVersion[] = [
   {
-    version: '15.21.0',
+    version: '15.22.0',
     date: 'March 15, 2026',
     type: 'minor',
     status: 'current',
+    mainTitle: 'Global Notification Bar & Dashboard Layout Improvements',
+    highlights: [
+      'Notification bell and logout button now visible on every system page via a fixed global TopBar',
+      'Notification dropdown is now fully actionable — complete tasks, approve or reject requests inline',
+      'Clicking a notification marks it as read and removes it from the list automatically',
+      'New "Clear All" button archives all notifications at once',
+      'Dashboard widgets now use full screen width for better space utilization',
+    ],
+    changes: {
+      added: [
+        'Global TopBar — persistent notification bell and logout button fixed to the top-right corner on every authenticated page',
+        'Actionable notifications — Complete button on task notifications; Approve / Reject buttons on approval notifications',
+        'Clear All (bulk archive) — trash icon in notification panel header archives all notifications at once',
+        'New API: POST /api/notifications/bulk-archive — archives all unread notifications for the user',
+        'Unread count badge shown in the notification panel header',
+      ],
+      fixed: [],
+      changed: [
+        'Clicking any notification marks it as read and removes it from the dropdown list immediately',
+        'Dashboard page no longer has a dedicated logout button (replaced by global TopBar)',
+        'Dashboard container changed from max-width constrained to full-width layout for better widget space utilization',
+        'Widget grid updated to md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 for optimal use of large screens',
+        'Notification panel has smaller, denser layout with unread dot indicators and improved dark mode colors',
+      ],
+    },
+  },
+  {
+    version: '15.21.0',
+    date: 'March 15, 2026',
+    type: 'minor',
+    status: 'previous',
     mainTitle: 'Task Management UX & Delayed Tasks Improvements',
     highlights: [
       'Delayed tasks in widget and login dialog are now clickable — navigate directly to task details',

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,8 +1,6 @@
 import { cookies } from 'next/headers';
 import { verifySession } from '@/lib/jwt';
-import { redirect } from 'next/navigation';
-import { Button } from '@/components/ui/button';
-import { LogOut, Sparkles } from 'lucide-react';
+import { Sparkles } from 'lucide-react';
 import WidgetContainer from '@/components/dashboard/WidgetContainer';
 import type { Metadata } from 'next';
 export const metadata: Metadata = {
@@ -16,42 +14,18 @@ export default async function DashboardPage() {
   const token = store.get(cookieName)?.value;
   const session = token ? verifySession(token) : null;
 
-  async function logout() {
-    'use server';
-    const cookieStore = await cookies();
-    const secure = process.env.COOKIE_SECURE === 'true';
-    const domain = process.env.COOKIE_DOMAIN || undefined;
-    cookieStore.set(cookieName, '', {
-      httpOnly: true,
-      path: '/',
-      sameSite: 'lax',
-      secure,
-      domain,
-      maxAge: 0
-    });
-    redirect('/login');
-  }
-
   return (
     <main className="min-h-screen bg-gradient-to-br from-background via-background to-muted/20">
-      <div className="container mx-auto p-6 lg:p-8 space-y-8 max-lg:pt-20">
+      <div className="w-full p-4 lg:p-6 space-y-6 max-lg:pt-16">
         {/* Header */}
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-          <div>
-            <h1 className="text-3xl font-bold tracking-tight flex items-center gap-2">
-              <Sparkles className="size-7 text-primary" />
-              Welcome back, {session?.name || 'User'}
-            </h1>
-            <p className="text-muted-foreground mt-1">
-              Your personalized dashboard with real-time insights
-            </p>
-          </div>
-          <form action={logout}>
-            <Button variant="outline" size="default">
-              <LogOut className="size-4" />
-              Logout
-            </Button>
-          </form>
+        <div>
+          <h1 className="text-2xl lg:text-3xl font-bold tracking-tight flex items-center gap-2">
+            <Sparkles className="size-6 lg:size-7 text-primary" />
+            Welcome back, {session?.name || 'User'}
+          </h1>
+          <p className="text-muted-foreground mt-1">
+            Your personalized dashboard with real-time insights
+          </p>
         </div>
 
         {/* Widget Container */}

--- a/src/components/NotificationPanel.tsx
+++ b/src/components/NotificationPanel.tsx
@@ -2,10 +2,12 @@
 
 /**
  * Notification Panel Component
- * Displays list of notifications with tabs and actions
+ * Actionable dropdown with complete/approve/reject actions per notification.
+ * Clicking a notification marks it as read and removes it from the list.
+ * "Clear All" archives all notifications.
  */
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import {
   Bell,
@@ -15,8 +17,11 @@ import {
   CheckCircle,
   XCircle,
   Info,
-  Archive,
   ExternalLink,
+  Trash2,
+  Check,
+  X,
+  ThumbsUp,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -34,21 +39,28 @@ interface Notification {
   deadlineAt?: string;
   relatedEntityType?: string;
   relatedEntityId?: string;
-  metadata?: any;
+  metadata?: Record<string, unknown>;
 }
 
 interface NotificationPanelProps {
   onClose?: () => void;
 }
 
+const TYPE_FILTERS: Record<string, string> = {
+  notifications: 'isArchived=false',
+  tasks: 'type=TASK_ASSIGNED&isArchived=false',
+  approvals: 'type=APPROVAL_REQUIRED&isArchived=false',
+};
+
 export default function NotificationPanel({ onClose }: NotificationPanelProps) {
   const router = useRouter();
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [loading, setLoading] = useState(true);
   const [activeTab, setActiveTab] = useState('notifications');
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
   const { refreshUnreadCount } = useNotifications();
 
-  const fetchNotifications = async (filters: string = '') => {
+  const fetchNotifications = useCallback(async (filters: string = '') => {
     try {
       setLoading(true);
       const response = await fetch(`/api/notifications?${filters}`);
@@ -56,91 +68,28 @@ export default function NotificationPanel({ onClose }: NotificationPanelProps) {
         const data = await response.json();
         setNotifications(data.notifications || []);
       }
-    } catch (error) {
-      console.error('Error fetching notifications:', error);
     } finally {
       setLoading(false);
     }
-  };
-
-  useEffect(() => {
-    fetchNotifications();
   }, []);
 
-  const handleTabChange = (tab: string) => {
-    setActiveTab(tab);
-    let filters = '';
+  useEffect(() => {
+    fetchNotifications(TYPE_FILTERS[activeTab] ?? TYPE_FILTERS.notifications);
+  }, [activeTab, fetchNotifications]);
 
-    switch (tab) {
-      case 'tasks':
-        filters = 'type=TASK_ASSIGNED&isArchived=false';
-        break;
-      case 'approvals':
-        filters = 'type=APPROVAL_REQUIRED&isArchived=false';
-        break;
-      case 'deadlines':
-        filters = 'type=DEADLINE_WARNING&isArchived=false';
-        break;
-      default:
-        filters = 'isArchived=false';
-    }
-
-    fetchNotifications(filters);
+  const removeFromList = (id: string) => {
+    setNotifications((prev) => prev.filter((n) => n.id !== id));
+    refreshUnreadCount();
   };
 
-  const markAsRead = async (id: string) => {
-    try {
-      const response = await fetch(`/api/notifications/${id}/read`, {
-        method: 'PATCH',
-      });
-
-      if (response.ok) {
-        setNotifications((prev) =>
-          prev.map((n) => (n.id === id ? { ...n, isRead: true } : n))
-        );
-        refreshUnreadCount();
-      }
-    } catch (error) {
-      console.error('Error marking as read:', error);
-    }
+  const markAsReadAndRemove = async (id: string) => {
+    await fetch(`/api/notifications/${id}/read`, { method: 'PATCH' });
+    removeFromList(id);
   };
 
-  const archiveNotification = async (id: string) => {
-    try {
-      const response = await fetch(`/api/notifications/${id}/archive`, {
-        method: 'PATCH',
-      });
+  const handleNotificationClick = async (notification: Notification) => {
+    await markAsReadAndRemove(notification.id);
 
-      if (response.ok) {
-        setNotifications((prev) => prev.filter((n) => n.id !== id));
-        refreshUnreadCount();
-      }
-    } catch (error) {
-      console.error('Error archiving notification:', error);
-    }
-  };
-
-  const markAllAsRead = async () => {
-    try {
-      const response = await fetch('/api/notifications/bulk-read', {
-        method: 'POST',
-      });
-
-      if (response.ok) {
-        fetchNotifications();
-        refreshUnreadCount();
-      }
-    } catch (error) {
-      console.error('Error marking all as read:', error);
-    }
-  };
-
-  const handleNotificationClick = (notification: Notification) => {
-    if (!notification.isRead) {
-      markAsRead(notification.id);
-    }
-
-    // Navigate to related entity
     if (notification.relatedEntityType && notification.relatedEntityId) {
       const routes: Record<string, string> = {
         task: '/tasks',
@@ -149,13 +98,45 @@ export default function NotificationPanel({ onClose }: NotificationPanelProps) {
         ncr: '/qc/ncr',
         document: '/documents',
       };
-
       const basePath = routes[notification.relatedEntityType];
       if (basePath) {
         router.push(`${basePath}?id=${notification.relatedEntityId}`);
         onClose?.();
       }
     }
+  };
+
+  const handleAction = async (
+    e: React.MouseEvent,
+    notification: Notification,
+    action: 'complete' | 'approve' | 'reject'
+  ) => {
+    e.stopPropagation();
+    setActionLoading(`${notification.id}-${action}`);
+    try {
+      const response = await fetch(`/api/notifications/${notification.id}/action`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action }),
+      });
+      if (response.ok) {
+        removeFromList(notification.id);
+      }
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const markAllAsRead = async () => {
+    await fetch('/api/notifications/bulk-read', { method: 'POST' });
+    fetchNotifications(TYPE_FILTERS[activeTab] ?? TYPE_FILTERS.notifications);
+    refreshUnreadCount();
+  };
+
+  const clearAll = async () => {
+    await fetch('/api/notifications/bulk-archive', { method: 'POST' });
+    setNotifications([]);
+    refreshUnreadCount();
   };
 
   const getNotificationIcon = (type: string) => {
@@ -177,124 +158,194 @@ export default function NotificationPanel({ onClose }: NotificationPanelProps) {
     }
   };
 
-  const formatTimeAgo = (dateString: string) => {
-    const date = new Date(dateString);
-    const now = new Date();
-    const seconds = Math.floor((now.getTime() - date.getTime()) / 1000);
+  const getIconBg = (type: string) => {
+    switch (type) {
+      case 'APPROVED': return 'bg-green-100';
+      case 'REJECTED': return 'bg-red-100';
+      case 'DEADLINE_WARNING': return 'bg-orange-100';
+      case 'APPROVAL_REQUIRED': return 'bg-orange-100';
+      default: return 'bg-blue-100';
+    }
+  };
 
+  const formatTimeAgo = (dateString: string) => {
+    const seconds = Math.floor((Date.now() - new Date(dateString).getTime()) / 1000);
     if (seconds < 60) return 'Just now';
     if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
     if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
     if (seconds < 604800) return `${Math.floor(seconds / 86400)}d ago`;
-    return date.toLocaleDateString();
+    return new Date(dateString).toLocaleDateString();
   };
 
   const getDeadlineBadge = (deadlineAt?: string) => {
     if (!deadlineAt) return null;
-
-    const deadline = new Date(deadlineAt);
-    const now = new Date();
-    const hoursRemaining = Math.floor((deadline.getTime() - now.getTime()) / (1000 * 60 * 60));
-
-    if (hoursRemaining < 0) {
-      return <span className="text-xs font-semibold text-red-600">Overdue</span>;
-    } else if (hoursRemaining < 24) {
-      return <span className="text-xs font-semibold text-red-600">{hoursRemaining}h left</span>;
-    } else if (hoursRemaining < 48) {
-      return (
-        <span className="text-xs font-semibold text-orange-600">
-          {Math.floor(hoursRemaining / 24)}d left
-        </span>
-      );
-    }
-
+    const hoursRemaining = Math.floor((new Date(deadlineAt).getTime() - Date.now()) / (1000 * 60 * 60));
+    if (hoursRemaining < 0) return <span className="text-xs font-semibold text-red-600">Overdue</span>;
+    if (hoursRemaining < 24) return <span className="text-xs font-semibold text-red-600">{hoursRemaining}h left</span>;
+    if (hoursRemaining < 48) return <span className="text-xs font-semibold text-orange-600">{Math.floor(hoursRemaining / 24)}d left</span>;
     return null;
   };
 
+  const canComplete = (n: Notification) =>
+    n.relatedEntityType === 'task' && n.type === 'TASK_ASSIGNED';
+  const canApproveReject = (n: Notification) =>
+    n.relatedEntityType === 'task' && n.type === 'APPROVAL_REQUIRED';
+
+  const unreadCount = notifications.filter((n) => !n.isRead).length;
+
   return (
-    <div className="flex flex-col h-[500px]">
+    <div className="flex flex-col h-[520px]">
       {/* Header */}
       <div className="px-4 py-3 border-b">
         <div className="flex items-center justify-between">
-          <h3 className="font-semibold text-base">Notifications</h3>
-          <Button 
-            variant="link" 
-            size="sm" 
-            onClick={markAllAsRead}
-            className="text-blue-600 hover:text-blue-700 p-0 h-auto font-normal"
-          >
-            Mark as read
-          </Button>
+          <h3 className="font-semibold text-base">
+            Notifications
+            {unreadCount > 0 && (
+              <span className="ml-2 inline-flex h-5 min-w-[20px] items-center justify-center rounded-full bg-red-500 px-1.5 text-xs font-bold text-white">
+                {unreadCount}
+              </span>
+            )}
+          </h3>
+          <div className="flex items-center gap-1">
+            {notifications.length > 0 && (
+              <>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={markAllAsRead}
+                  className="text-xs text-blue-600 hover:text-blue-700 h-7 px-2"
+                >
+                  Mark all read
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={clearAll}
+                  className="text-xs text-red-500 hover:text-red-600 h-7 px-2"
+                  title="Clear all notifications"
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </Button>
+              </>
+            )}
+          </div>
         </div>
       </div>
 
       {/* Tabs */}
-      <Tabs value={activeTab} onValueChange={handleTabChange} className="flex-1 flex flex-col">
-        <TabsList className="w-full justify-start rounded-none border-b px-4 bg-transparent h-auto p-0">
-          <TabsTrigger 
-            value="notifications" 
-            className="rounded-none border-b-2 border-transparent data-[state=active]:border-blue-600 data-[state=active]:bg-transparent px-4 py-2"
+      <Tabs
+        value={activeTab}
+        onValueChange={setActiveTab}
+        className="flex-1 flex flex-col overflow-hidden"
+      >
+        <TabsList className="w-full justify-start rounded-none border-b px-4 bg-transparent h-auto p-0 shrink-0">
+          <TabsTrigger
+            value="notifications"
+            className="rounded-none border-b-2 border-transparent data-[state=active]:border-blue-600 data-[state=active]:bg-transparent px-3 py-2 text-xs"
           >
-            Notifications
+            All
           </TabsTrigger>
-          <TabsTrigger 
-            value="tasks" 
-            className="rounded-none border-b-2 border-transparent data-[state=active]:border-blue-600 data-[state=active]:bg-transparent px-4 py-2"
+          <TabsTrigger
+            value="tasks"
+            className="rounded-none border-b-2 border-transparent data-[state=active]:border-blue-600 data-[state=active]:bg-transparent px-3 py-2 text-xs"
           >
             Tasks
           </TabsTrigger>
-          <TabsTrigger 
-            value="approvals" 
-            className="rounded-none border-b-2 border-transparent data-[state=active]:border-blue-600 data-[state=active]:bg-transparent px-4 py-2"
+          <TabsTrigger
+            value="approvals"
+            className="rounded-none border-b-2 border-transparent data-[state=active]:border-blue-600 data-[state=active]:bg-transparent px-3 py-2 text-xs"
           >
             Approvals
           </TabsTrigger>
         </TabsList>
 
-        <TabsContent value={activeTab} className="flex-1 m-0">
+        <TabsContent value={activeTab} className="flex-1 m-0 overflow-hidden">
           <ScrollArea className="h-full">
             {loading ? (
-              <div className="p-8 text-center text-muted-foreground">Loading...</div>
+              <div className="p-8 text-center text-muted-foreground text-sm">Loading...</div>
             ) : notifications.length === 0 ? (
               <div className="p-8 text-center text-muted-foreground">
-                <Bell className="h-12 w-12 mx-auto mb-2 opacity-20" />
-                <p>No notifications</p>
+                <Bell className="h-10 w-10 mx-auto mb-2 opacity-20" />
+                <p className="text-sm">No notifications</p>
               </div>
             ) : (
               <div className="divide-y">
                 {notifications.map((notification) => (
                   <div
                     key={notification.id}
-                    className={`p-4 hover:bg-gray-50 cursor-pointer transition-colors border-l-4 ${
-                      !notification.isRead ? 'border-l-green-500 bg-green-50/30' : 'border-l-transparent'
+                    className={`p-3 hover:bg-muted/50 cursor-pointer transition-colors border-l-4 ${
+                      !notification.isRead
+                        ? 'border-l-blue-500 bg-blue-50/30 dark:bg-blue-950/20'
+                        : 'border-l-transparent'
                     }`}
                     onClick={() => handleNotificationClick(notification)}
                   >
                     <div className="flex gap-3">
                       <div className="flex-shrink-0 mt-0.5">
-                        <div className={`w-10 h-10 rounded-full flex items-center justify-center ${
-                          notification.type === 'APPROVED' ? 'bg-green-100' :
-                          notification.type === 'REJECTED' ? 'bg-blue-100' :
-                          notification.type === 'DEADLINE_WARNING' ? 'bg-orange-100' :
-                          'bg-blue-100'
-                        }`}>
+                        <div
+                          className={`w-8 h-8 rounded-full flex items-center justify-center ${getIconBg(notification.type)}`}
+                        >
                           {getNotificationIcon(notification.type)}
                         </div>
                       </div>
                       <div className="flex-1 min-w-0">
-                        <div className="flex items-start justify-between gap-2">
-                          <div className="flex-1">
-                            <h4 className="font-semibold text-sm text-gray-900 mb-0.5">
-                              {notification.title}
-                            </h4>
-                            <p className="text-sm text-gray-600 line-clamp-2 mb-1">
-                              {notification.message}
-                            </p>
-                            <span className="text-xs text-gray-500">
-                              {formatTimeAgo(notification.createdAt)}
-                            </span>
-                          </div>
+                        <div className="flex items-start justify-between gap-1">
+                          <h4 className="font-medium text-xs text-foreground leading-tight">
+                            {notification.title}
+                            {!notification.isRead && (
+                              <span className="ml-1.5 inline-block w-1.5 h-1.5 rounded-full bg-blue-500 align-middle" />
+                            )}
+                          </h4>
+                          <span className="text-[10px] text-muted-foreground shrink-0">
+                            {formatTimeAgo(notification.createdAt)}
+                          </span>
                         </div>
+                        <p className="text-xs text-muted-foreground line-clamp-2 mt-0.5">
+                          {notification.message}
+                        </p>
+                        {getDeadlineBadge(notification.deadlineAt)}
+
+                        {/* Action buttons */}
+                        {(canComplete(notification) || canApproveReject(notification)) && (
+                          <div className="flex gap-1.5 mt-2" onClick={(e) => e.stopPropagation()}>
+                            {canComplete(notification) && (
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                className="h-6 px-2 text-[10px] text-green-700 border-green-300 hover:bg-green-50 hover:text-green-800"
+                                disabled={actionLoading === `${notification.id}-complete`}
+                                onClick={(e) => handleAction(e, notification, 'complete')}
+                              >
+                                <Check className="h-3 w-3 mr-1" />
+                                Complete
+                              </Button>
+                            )}
+                            {canApproveReject(notification) && (
+                              <>
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  className="h-6 px-2 text-[10px] text-green-700 border-green-300 hover:bg-green-50 hover:text-green-800"
+                                  disabled={actionLoading === `${notification.id}-approve`}
+                                  onClick={(e) => handleAction(e, notification, 'approve')}
+                                >
+                                  <ThumbsUp className="h-3 w-3 mr-1" />
+                                  Approve
+                                </Button>
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  className="h-6 px-2 text-[10px] text-red-600 border-red-300 hover:bg-red-50 hover:text-red-700"
+                                  disabled={actionLoading === `${notification.id}-reject`}
+                                  onClick={(e) => handleAction(e, notification, 'reject')}
+                                >
+                                  <X className="h-3 w-3 mr-1" />
+                                  Reject
+                                </Button>
+                              </>
+                            )}
+                          </div>
+                        )}
                       </div>
                     </div>
                   </div>
@@ -307,17 +358,18 @@ export default function NotificationPanel({ onClose }: NotificationPanelProps) {
 
       {/* Footer */}
       <Separator />
-      <div className="p-3">
+      <div className="p-2">
         <Button
           variant="ghost"
-          className="w-full justify-between"
+          size="sm"
+          className="w-full justify-between text-xs"
           onClick={() => {
             router.push('/notifications');
             onClose?.();
           }}
         >
           View all notifications
-          <ExternalLink className="h-4 w-4" />
+          <ExternalLink className="h-3.5 w-3.5" />
         </Button>
       </div>
     </div>

--- a/src/components/ResponsiveLayout.tsx
+++ b/src/components/ResponsiveLayout.tsx
@@ -4,6 +4,7 @@ import { AppSidebar } from '@/components/app-sidebar';
 import { NotificationProvider } from '@/contexts/NotificationContext';
 import { SidebarProvider, useSidebar } from '@/contexts/SidebarContext';
 import { RouteGuard } from '@/components/RouteGuard';
+import TopBar from '@/components/TopBar';
 
 function LayoutContent({ children }: { children: React.ReactNode }) {
   const { collapsed } = useSidebar();
@@ -11,7 +12,8 @@ function LayoutContent({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex min-h-screen">
       <AppSidebar />
-      <main className={`flex-1 p-4 transition-all duration-300 ${collapsed ? 'ml-16' : 'ml-64'}`}>
+      <TopBar />
+      <main className={`flex-1 transition-all duration-300 ${collapsed ? 'lg:ml-16' : 'lg:ml-64'} pt-14`}>
         <RouteGuard>{children}</RouteGuard>
       </main>
     </div>

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { LogOut } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import NotificationBell from '@/components/NotificationBell';
+
+export default function TopBar() {
+  const router = useRouter();
+
+  const handleLogout = async () => {
+    try {
+      const tracker = (window as any).__sessionActivityTracker;
+      if (tracker) {
+        tracker.stop();
+        delete (window as any).__sessionActivityTracker;
+      }
+
+      localStorage.clear();
+      sessionStorage.clear();
+
+      fetch('/api/auth/logout', { method: 'POST', credentials: 'include' }).catch(() => {});
+
+      const loginUrl =
+        process.env.NODE_ENV === 'production'
+          ? 'https://ots.hexasteel.sa/login?t=' + Date.now()
+          : '/login?t=' + Date.now();
+
+      window.location.href = loginUrl;
+    } catch {
+      const loginUrl =
+        process.env.NODE_ENV === 'production'
+          ? 'https://ots.hexasteel.sa/login?t=' + Date.now()
+          : '/login?t=' + Date.now();
+      window.location.href = loginUrl;
+    }
+  };
+
+  return (
+    <div className="fixed top-0 right-0 z-50 flex items-center gap-1 p-2 lg:p-3">
+      <NotificationBell />
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={handleLogout}
+        title="Logout"
+        className="text-muted-foreground hover:text-destructive hover:bg-destructive/10"
+      >
+        <LogOut className="h-5 w-5" />
+      </Button>
+    </div>
+  );
+}

--- a/src/components/dashboard/WidgetContainer.tsx
+++ b/src/components/dashboard/WidgetContainer.tsx
@@ -84,7 +84,7 @@ function SortableWidget({ widget, children }: { widget: Widget; children: React.
     <div
       ref={setNodeRef}
       style={style}
-      className={`relative group ${widget.widgetSize === 'large' ? 'sm:col-span-2' : 'col-span-1'}`}
+      className={`relative group ${widget.widgetSize === 'large' ? 'md:col-span-2' : 'col-span-1'}`}
       {...attributes}
     >
       {/* Drag Handle */}
@@ -293,7 +293,7 @@ export default function WidgetContainer() {
         </Dialog>
       </div>
 
-      {/* Widgets Grid - Mobile optimized with drag and drop */}
+      {/* Widgets Grid - Responsive, full-width layout with drag and drop */}
       <DndContext
         sensors={sensors}
         collisionDetection={closestCenter}
@@ -303,7 +303,7 @@ export default function WidgetContainer() {
           items={widgets.map(w => w.id)}
           strategy={verticalListSortingStrategy}
         >
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-4">
             {widgets.map((widget) => {
               const WidgetComponent = WIDGET_COMPONENTS[widget.widgetType];
               if (!WidgetComponent) return null;

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
  */
 
 export const APP_VERSION = {
-  version: '15.21.0',
+  version: '15.22.0',
   date: 'March 15, 2026',
   type: 'minor' as const,
   name: 'Hexa Steel Operation Tracking System',


### PR DESCRIPTION
- Add TopBar component with notification bell and logout fixed to top-right on all system pages
- Rewrite NotificationPanel: inline Complete/Approve/Reject actions per notification type
- Clicking a notification marks it as read and removes it from the dropdown list
- Add Clear All button (bulk-archive API POST /api/notifications/bulk-archive)
- Remove container mx-auto from dashboard for full-width widget layout
- Update widget grid to md:2 / xl:3 / 2xl:4 columns for better screen utilization
- Remove redundant per-page logout button from dashboard page
- Bump version to 15.22.0, update CHANGELOG.md, README.md, /changelog page

https://claude.ai/code/session_01My4Es88yG845c5PTgviqrz