### PR TITLE
fix: set task status to In Progress on reject/duplicate and route completions to Approvals

### DIFF
--- a/src/app/api/notifications/[id]/action/route.ts
+++ b/src/app/api/notifications/[id]/action/route.ts
@@ -4,6 +4,7 @@ import prisma from '@/lib/db';
 import { cookies } from 'next/headers';
 import { verifySession } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
+import NotificationService from '@/lib/services/notification.service';
 
 const actionSchema = z.object({
   action: z.enum(['complete', 'approve', 'reject']),
@@ -66,10 +67,36 @@ export async function POST(
         updateData.approvedById = null;
       }
 
-      await prisma.task.update({
+      const updatedTask = await prisma.task.update({
         where: { id: entityId },
         data: updateData,
+        select: { id: true, title: true, assignedToId: true },
       });
+
+      // Notify the assignee of the requester's decision
+      if ((action === 'approve' || action === 'reject') && updatedTask.assignedToId && updatedTask.assignedToId !== session.sub) {
+        try {
+          if (action === 'approve') {
+            await NotificationService.notifyApproved({
+              userId: updatedTask.assignedToId,
+              entityType: 'task',
+              entityId: updatedTask.id,
+              entityName: updatedTask.title,
+              approverName: session.name,
+            });
+          } else {
+            await NotificationService.notifyRejected({
+              userId: updatedTask.assignedToId,
+              entityType: 'task',
+              entityId: updatedTask.id,
+              entityName: updatedTask.title,
+              rejectorName: session.name,
+            });
+          }
+        } catch (notifError) {
+          logger.error({ error: notifError, taskId: entityId, action }, 'Failed to notify assignee of task decision');
+        }
+      }
     } else {
       return NextResponse.json({ error: 'Unsupported entity type for this action' }, { status: 400 });
     }

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -303,7 +303,7 @@ export async function PATCH(
     },
   });
 
-  // Send notification to requester when task is completed
+  // Send approval request to requester when task is completed
   if (parsed.data.status === 'Completed' && task.status !== 'Completed') {
     try {
       const requesterId = (updatedTask as any).requesterId || task.createdById;
@@ -311,9 +311,9 @@ export async function PATCH(
       if (requesterId && requesterId !== session.sub) {
         await NotificationService.createNotification({
           userId: requesterId,
-          type: 'TASK_COMPLETED',
-          title: 'Task Completed',
-          message: `${session.name} completed the task: "${updatedTask.title}"`,
+          type: 'APPROVAL_REQUIRED',
+          title: 'Task Awaiting Your Approval',
+          message: `${session.name} completed the task: "${updatedTask.title}" — please approve or reject`,
           relatedEntityType: 'task',
           relatedEntityId: updatedTask.id,
           metadata: {

--- a/src/components/tasks-client.tsx
+++ b/src/components/tasks-client.tsx
@@ -635,7 +635,7 @@ export function TasksClient({ initialTasks, userId, allUsers, allProjects, allBu
             priority: task.priority,
             dueDate: task.dueDate ? new Date(task.dueDate).toISOString().split('T')[0] : null,
             taskInputDate: new Date().toISOString().split('T')[0],
-            status: 'Pending',
+            status: 'In Progress',
             isPrivate: task.isPrivate,
             remark: `Revision of rejected task. Original rejection reason: ${rejectionDialog.reason || 'Not specified'}`,
             revision: task.revision ? `${task.revision}-R` : 'R1',
@@ -676,7 +676,7 @@ export function TasksClient({ initialTasks, userId, allUsers, allProjects, allBu
           priority: task.priority,
           dueDate: task.dueDate ? new Date(task.dueDate).toISOString().split('T')[0] : null,
           taskInputDate: new Date().toISOString().split('T')[0],
-          status: 'Pending',
+          status: 'In Progress',
           isPrivate: task.isPrivate,
         }),
       });


### PR DESCRIPTION
- Change hardcoded 'Pending' to 'In Progress' when duplicating a task or
  creating a revision after rejection, so tasks are immediately actionable
- Change TASK_COMPLETED notification type to APPROVAL_REQUIRED when notifying
  the requester on task completion, so it surfaces in the Approvals tab with
  Approve/Reject action buttons
- Notify the task assignee (APPROVED/REJECTED) when the requester acts on the
  completion approval from the notification center

https://claude.ai/code/session_01WdAr95jzkzDuN2B2f7FLni