### PR TITLE
feat: add mobile push notifications for overdue tasks and 2-day deadline reminders

### DIFF
--- a/src/app/api/cron/deadline-reminders/route.ts
+++ b/src/app/api/cron/deadline-reminders/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '@/lib/db';
+import { logger } from '@/lib/logger';
+import { NotificationService } from '@/lib/services/notification.service';
+import { env } from '@/lib/env';
+
+/**
+ * Cron job: send push notifications to task assignees whose task is due in ~2 days.
+ *
+ * Trigger with: POST /api/cron/deadline-reminders
+ * Authorization: Bearer <CRON_SECRET>
+ *
+ * Recommended schedule: once daily (e.g. 08:00)
+ */
+export async function POST(req: NextRequest) {
+  const authHeader = req.headers.get('authorization');
+  const cronSecret = env.CRON_SECRET;
+
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const now = new Date();
+  // Window: tasks due between 40 h and 48 h from now so we catch the ~2-day mark
+  // regardless of what time of day the cron runs.
+  const windowStart = new Date(now.getTime() + 40 * 60 * 60 * 1000);
+  const windowEnd = new Date(now.getTime() + 48 * 60 * 60 * 1000);
+
+  const tasks = await prisma.task.findMany({
+    where: {
+      dueDate: { gte: windowStart, lte: windowEnd },
+      status: { notIn: ['Completed'] },
+      assignedToId: { not: null },
+    },
+    select: {
+      id: true,
+      title: true,
+      dueDate: true,
+      assignedToId: true,
+      project: { select: { projectNumber: true } },
+    },
+  });
+
+  if (tasks.length === 0) {
+    return NextResponse.json({ sent: 0 });
+  }
+
+  let sent = 0;
+  let failed = 0;
+
+  await Promise.allSettled(
+    tasks.map(async (task) => {
+      try {
+        const projectLabel = task.project ? ` (${task.project.projectNumber})` : '';
+        await NotificationService.createNotification({
+          userId: task.assignedToId!,
+          type: 'DEADLINE_WARNING',
+          title: 'Task Due in 2 Days',
+          message: `Your task "${task.title}"${projectLabel} is due in 2 days. Please make sure it is completed on time.`,
+          relatedEntityType: 'task',
+          relatedEntityId: task.id,
+          deadlineAt: task.dueDate ?? undefined,
+          metadata: { taskTitle: task.title, projectLabel, source: 'cron' },
+        });
+        sent++;
+      } catch (error) {
+        failed++;
+        logger.error({ error, taskId: task.id }, 'Failed to send deadline reminder');
+      }
+    })
+  );
+
+  logger.info({ sent, failed, windowStart, windowEnd }, 'Deadline reminders cron completed');
+  return NextResponse.json({ sent, failed });
+}

--- a/src/app/api/notifications/notify-task/route.ts
+++ b/src/app/api/notifications/notify-task/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import prisma from '@/lib/db';
+import { withApiContext } from '@/lib/api-utils';
+import { logger } from '@/lib/logger';
+import { NotificationService } from '@/lib/services/notification.service';
+
+const notifySchema = z.object({
+  taskId: z.string().min(1),
+});
+
+export const POST = withApiContext(async (req, session) => {
+  const body = await req.json();
+  const parsed = notifySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input', details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const { taskId } = parsed.data;
+
+  const task = await prisma.task.findUnique({
+    where: { id: taskId },
+    select: {
+      id: true,
+      title: true,
+      dueDate: true,
+      status: true,
+      assignedToId: true,
+      assignedTo: { select: { id: true, name: true } },
+      project: { select: { projectNumber: true, name: true } },
+    },
+  });
+
+  if (!task) {
+    return NextResponse.json({ error: 'Task not found' }, { status: 404 });
+  }
+
+  if (!task.assignedToId || !task.assignedTo) {
+    return NextResponse.json({ error: 'Task has no assignee' }, { status: 400 });
+  }
+
+  if (task.status === 'Completed') {
+    return NextResponse.json({ error: 'Task is already completed' }, { status: 400 });
+  }
+
+  try {
+    const dueDate = task.dueDate ? new Date(task.dueDate) : new Date();
+    const now = new Date();
+    const hoursRemaining = Math.floor((dueDate.getTime() - now.getTime()) / (1000 * 60 * 60));
+    const isOverdue = hoursRemaining < 0;
+
+    const projectLabel = task.project ? ` (${task.project.projectNumber})` : '';
+
+    await NotificationService.createNotification({
+      userId: task.assignedToId,
+      type: 'DEADLINE_WARNING',
+      title: isOverdue ? 'Task Overdue — Action Required' : 'Task Due Soon — Please Update',
+      message: isOverdue
+        ? `Your task "${task.title}"${projectLabel} is overdue. Please update the status immediately.`
+        : `Your task "${task.title}"${projectLabel} is due soon. Please update the status.`,
+      relatedEntityType: 'task',
+      relatedEntityId: task.id,
+      deadlineAt: task.dueDate ?? undefined,
+      metadata: {
+        taskTitle: task.title,
+        projectLabel,
+        isOverdue,
+        sentBy: session!.userId,
+      },
+    });
+
+    logger.info({ taskId, assignedToId: task.assignedToId, sentBy: session!.userId }, 'Task push notification sent');
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    logger.error({ error, taskId }, 'Failed to send task push notification');
+    return NextResponse.json({ error: 'Failed to send notification' }, { status: 500 });
+  }
+});

--- a/src/app/notifications/_page-client.tsx
+++ b/src/app/notifications/_page-client.tsx
@@ -194,6 +194,8 @@ export default function NotificationsPage() {
   const [isSummaryCollapsed, setIsSummaryCollapsed] = useState(false);
   const [canViewAllTasks, setCanViewAllTasks] = useState(false);
   const [delayedShowAll, setDelayedShowAll] = useState(false);
+  const [sendingPush, setSendingPush] = useState<Set<string>>(new Set());
+  const [pushedTasks, setPushedTasks] = useState<Set<string>>(new Set());
 
   // Handle tab and severity parameters from URL
   useEffect(() => {
@@ -226,6 +228,28 @@ export default function NotificationsPage() {
       // Silently fail
     } finally {
       setLoadingDelayedTasks(false);
+    }
+  };
+
+  const sendPushNotification = async (taskId: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (sendingPush.has(taskId) || pushedTasks.has(taskId)) return;
+    setSendingPush((prev) => new Set(prev).add(taskId));
+    try {
+      const res = await fetch('/api/notifications/notify-task', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ taskId }),
+      });
+      if (res.ok) {
+        setPushedTasks((prev) => new Set(prev).add(taskId));
+      }
+    } finally {
+      setSendingPush((prev) => {
+        const next = new Set(prev);
+        next.delete(taskId);
+        return next;
+      });
     }
   };
 
@@ -875,20 +899,36 @@ export default function NotificationsPage() {
                         </div>
 
                         {/* Contact Actions */}
-                        {task.assignedTo && task.assignedTo.email && (
-                          <div className="flex items-center gap-2 mt-3 pt-3 border-t">
+                        {task.assignedTo && (
+                          <div className="flex items-center gap-2 mt-3 pt-3 border-t flex-wrap">
                             <span className="text-xs text-muted-foreground mr-2">Notify:</span>
+                            {task.assignedTo.email && (
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                className="h-7 text-xs"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  window.location.href = `mailto:${task.assignedTo!.email}?subject=Task Overdue: ${task.title}&body=Dear ${task.assignedTo!.name},%0D%0A%0D%0AThis is a reminder that the following task is ${task.delayDays} days overdue:%0D%0A%0D%0ATask: ${task.title}%0D%0ADue Date: ${new Date(task.dueDate).toLocaleDateString()}%0D%0A%0D%0APlease update the status or complete the task as soon as possible.`;
+                                }}
+                              >
+                                <Mail className="h-3 w-3 mr-1" />
+                                Email
+                              </Button>
+                            )}
                             <Button
-                              variant="outline"
+                              variant={pushedTasks.has(task.id) ? 'default' : 'outline'}
                               size="sm"
                               className="h-7 text-xs"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                window.location.href = `mailto:${task.assignedTo!.email}?subject=Task Overdue: ${task.title}&body=Dear ${task.assignedTo!.name},%0D%0A%0D%0AThis is a reminder that the following task is ${task.delayDays} days overdue:%0D%0A%0D%0ATask: ${task.title}%0D%0ADue Date: ${new Date(task.dueDate).toLocaleDateString()}%0D%0A%0D%0APlease update the status or complete the task as soon as possible.`;
-                              }}
+                              disabled={sendingPush.has(task.id) || pushedTasks.has(task.id)}
+                              onClick={(e) => sendPushNotification(task.id, e)}
                             >
-                              <Mail className="h-3 w-3 mr-1" />
-                              Email
+                              <Bell className="h-3 w-3 mr-1" />
+                              {sendingPush.has(task.id)
+                                ? 'Sending…'
+                                : pushedTasks.has(task.id)
+                                ? 'Sent'
+                                : 'Push'}
                             </Button>
                           </div>
                         )}


### PR DESCRIPTION
- Add Push button in delayed-tasks list that sends an in-app + Web Push
  notification to the assigned user asking them to update task status
- Add POST /api/notifications/notify-task endpoint that creates a
  DEADLINE_WARNING notification (triggers push via PushService)
- Add POST /api/cron/deadline-reminders endpoint (CRON_SECRET protected)
  that scans tasks due in ~2 days and sends push reminders automatically;
  schedule it daily at 08:00 to give assignees advance notice

https://claude.ai/code/session_01TcRZoQgRqf1o1dE4L8Th3X