### PR TITLE
fix: resolve 403 error on parts upload and make Part Mark optional

### DIFF
--- a/src/app/api/production/assembly-parts/route.ts
+++ b/src/app/api/production/assembly-parts/route.ts
@@ -5,13 +5,14 @@ import { cookies } from 'next/headers';
 import { getCurrentUserPermissions } from '@/lib/permission-checker';
 import { verifySession } from '@/lib/jwt';
 import { logActivity, logSystemEvent } from '@/lib/api-utils';
+import { logger } from '@/lib/logger';
 
 const assemblyPartSchema = z.object({
   projectId: z.string().uuid(),
   buildingId: z.string().uuid().optional().nullable(),
   assemblyMark: z.string().min(1),
   subAssemblyMark: z.string().optional().nullable(),
-  partMark: z.string().min(1),
+  partMark: z.string().optional().nullable(),
   quantity: z.number().int().min(1),
   name: z.string().min(1),
   profile: z.string().optional().nullable(),
@@ -24,9 +25,9 @@ const assemblyPartSchema = z.object({
 });
 
 async function generatePartDesignation(
-  projectId: string, 
-  buildingId: string | null, 
-  partMark: string
+  projectId: string,
+  buildingId: string | null,
+  partMark: string | null | undefined
 ): Promise<string> {
   // Get project number
   const project = await prisma.project.findUnique({
@@ -49,7 +50,9 @@ async function generatePartDesignation(
   }
 
   // Base designation: ProjectNumber-BuildingDesignation-PartMark (e.g., "274-EXT-A1")
-  const baseDesignation = `${project.projectNumber}${buildingDesignation}-${partMark}`;
+  const baseDesignation = partMark
+    ? `${project.projectNumber}${buildingDesignation}-${partMark}`
+    : `${project.projectNumber}${buildingDesignation}`;
   
   // Check if this designation already exists
   const existingPart = await prisma.assemblyPart.findUnique({
@@ -212,7 +215,7 @@ export async function GET(req: Request) {
       },
     });
   } catch (error) {
-    console.error('Error fetching assembly parts:', error);
+    logger.error({ error }, 'Error fetching assembly parts');
     return NextResponse.json({ 
       error: 'Failed to fetch assembly parts', 
       message: error instanceof Error ? error.message : 'Unknown error' 
@@ -231,7 +234,7 @@ export async function POST(req: Request) {
     }
 
     const permissions = await getCurrentUserPermissions();
-    if (!permissions.includes('production.upload_parts')) {
+    if (!permissions.includes('production.create_parts')) {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
 
@@ -264,6 +267,7 @@ export async function POST(req: Request) {
           const assemblyPart = await prisma.assemblyPart.create({
             data: {
               ...parsed.data,
+              partMark: parsed.data.partMark ?? '',
               partDesignation,
               createdById: session.sub,
             },
@@ -322,6 +326,7 @@ export async function POST(req: Request) {
     const assemblyPart = await prisma.assemblyPart.create({
       data: {
         ...parsed.data,
+        partMark: parsed.data.partMark ?? '',
         partDesignation,
         createdById: session.sub,
       },
@@ -348,7 +353,7 @@ export async function POST(req: Request) {
 
     return NextResponse.json(assemblyPart, { status: 201 });
   } catch (error) {
-    console.error('Error creating assembly part:', error);
+    logger.error({ error }, 'Error creating assembly part');
     return NextResponse.json({ 
       error: 'Failed to create assembly part', 
       message: error instanceof Error ? error.message : 'Unknown error' 

--- a/src/app/production/upload/_page-client.tsx
+++ b/src/app/production/upload/_page-client.tsx
@@ -24,7 +24,7 @@ const DB_FIELDS = [
   { value: '', label: '-- Do Not Import --' },
   { value: 'assemblyMark', label: 'Assembly Mark *', required: true },
   { value: 'subAssemblyMark', label: 'Sub-Assembly Mark' },
-  { value: 'partMark', label: 'Part Mark *', required: true },
+  { value: 'partMark', label: 'Part Mark' },
   { value: 'quantity', label: 'Quantity *', required: true },
   { value: 'name', label: 'Name *', required: true },
   { value: 'profile', label: 'Profile' },
@@ -182,7 +182,7 @@ export default function UploadPartsPage() {
     }
 
     // Validate required mappings
-    const requiredFields = ['assemblyMark', 'partMark', 'quantity', 'name'];
+    const requiredFields = ['assemblyMark', 'quantity', 'name'];
     const mappedFields = Object.values(columnMapping);
     const missingFields = requiredFields.filter(field => !mappedFields.includes(field));
     
@@ -245,15 +245,18 @@ export default function UploadPartsPage() {
         const result = await response.json();
         setUploadResult(result);
         toast({ title: 'Upload Complete', description: `${result.success} parts uploaded successfully` });
-        
+
         if (result.failed === 0) {
           setTimeout(() => {
             router.push('/production/assembly-parts');
           }, 2000);
         }
       } else {
-        const error = await response.json();
-        toast({ title: 'Upload Failed', description: error.error || 'Upload failed', variant: 'destructive' });
+        const errorBody = await response.json().catch(() => ({}));
+        const description = response.status === 403
+          ? 'You do not have permission to upload parts. Contact your administrator.'
+          : errorBody.error || `Upload failed (${response.status})`;
+        toast({ title: 'Upload Failed', description, variant: 'destructive' });
       }
     } catch (error) {
       console.error('Error uploading file:', error);
@@ -289,10 +292,10 @@ export default function UploadPartsPage() {
                 1. Download the Excel template and fill in your assembly parts data
               </p>
               <p className="text-sm text-muted-foreground">
-                2. Required columns: Assembly Mark, Part Mark, Quantity, Name
+                2. Required columns: Assembly Mark, Quantity, Name
               </p>
               <p className="text-sm text-muted-foreground">
-                3. Optional columns: Sub-Assembly Mark, Profile, Grade, Length, Weight, Area
+                3. Optional columns: Part Mark, Sub-Assembly Mark, Profile, Grade, Length, Weight, Area
               </p>
               <p className="text-sm text-muted-foreground">
                 4. Select project and building, then upload your completed file


### PR DESCRIPTION
- Fix wrong permission key: production.upload_parts → production.create_parts
  (upload_parts never existed; create_parts is the correct permission)
- Make Part Mark optional in Zod schema and remove from required field validation
- Handle null/empty Part Mark in generatePartDesignation to avoid trailing dash
- Coerce null partMark to '' to satisfy Prisma non-nullable String constraint
- Show descriptive error message for 403 (permission denied) in the UI
- Replace console.error with logger per project conventions

https://claude.ai/code/session_01GEZC9LGBHUEvQbeVRcNXva