### PR TITLE
feat(governance): comprehensive Governance Centre overhaul

### DIFF
--- a/src/app/api/governance/audit/route.ts
+++ b/src/app/api/governance/audit/route.ts
@@ -1,13 +1,18 @@
 /**
  * Governance API - Audit Trail
- * 
- * READ-ONLY endpoints for viewing audit logs.
+ *
+ * READ-ONLY endpoints for viewing audit logs with full filtering support.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { verifySession } from '@/lib/jwt';
-import { auditService } from '@/lib/services/governance';
+import prisma from '@/lib/db';
+import { logger } from '@/lib/logger';
+import { Prisma } from '@prisma/client';
+
+const USER_SOURCES = ['UI', 'API'];
+const SYSTEM_SOURCES = ['SYNC', 'AI', 'SYSTEM', 'CRON'];
 
 export async function GET(req: NextRequest) {
   try {
@@ -24,29 +29,52 @@ export async function GET(req: NextRequest) {
     const entityId = searchParams.get('entityId');
     const action = searchParams.get('action');
     const userId = searchParams.get('userId');
-    const limit = parseInt(searchParams.get('limit') || '50');
+    const sourceType = searchParams.get('sourceType'); // 'user' | 'system'
+    const dateFrom = searchParams.get('dateFrom');
+    const dateTo = searchParams.get('dateTo');
+    const limit = Math.min(parseInt(searchParams.get('limit') || '20'), 100);
     const offset = parseInt(searchParams.get('offset') || '0');
 
-    // If entityType and entityId provided, get specific trail
-    if (entityType && entityId) {
-      const result = await auditService.getTrail(entityType, entityId, { limit, offset });
-      return NextResponse.json(result);
-    }
+    const where: Prisma.AuditLogWhereInput = {
+      ...(entityType && entityType !== 'all' && { entityType }),
+      ...(entityId && { entityId }),
+      ...(action && action !== 'all' && { action: action as Prisma.EnumAuditActionFilter }),
+      ...(userId && { performedById: userId }),
+      ...((dateFrom || dateTo) && {
+        performedAt: {
+          ...(dateFrom && { gte: new Date(dateFrom) }),
+          ...(dateTo && { lte: new Date(dateTo) }),
+        },
+      }),
+      ...(sourceType === 'user' && {
+        OR: [
+          { sourceModule: null },
+          { sourceModule: { in: USER_SOURCES } },
+        ],
+      }),
+      ...(sourceType === 'system' && {
+        sourceModule: { in: SYSTEM_SOURCES },
+      }),
+    };
 
-    // Otherwise get recent logs with optional filters
-    const logs = await auditService.getRecent({
-      entityType: entityType || undefined,
-      action: action as any || undefined,
-      userId: userId || undefined,
-      limit,
-    });
+    const [logs, total] = await Promise.all([
+      prisma.auditLog.findMany({
+        where,
+        orderBy: { performedAt: 'desc' },
+        take: limit,
+        skip: offset,
+        include: {
+          performedBy: {
+            select: { id: true, name: true },
+          },
+        },
+      }),
+      prisma.auditLog.count({ where }),
+    ]);
 
-    return NextResponse.json({ logs });
+    return NextResponse.json({ logs, total });
   } catch (error) {
-    console.error('[Governance API] Audit error:', error);
-    return NextResponse.json(
-      { error: 'Failed to fetch audit logs' },
-      { status: 500 }
-    );
+    logger.error({ error }, 'Failed to fetch audit logs');
+    return NextResponse.json({ error: 'Failed to fetch audit logs' }, { status: 500 });
   }
 }

--- a/src/app/api/governance/versions/route.ts
+++ b/src/app/api/governance/versions/route.ts
@@ -1,13 +1,17 @@
 /**
  * Governance API - Entity Versions
- * 
- * READ-ONLY endpoints for viewing entity version history.
+ *
+ * Endpoints for viewing entity version history and rolling back to previous versions.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { verifySession } from '@/lib/jwt';
 import { versionService } from '@/lib/services/governance';
+import { auditService } from '@/lib/services/governance';
+import { logger } from '@/lib/logger';
+import prisma from '@/lib/db';
+import { z } from 'zod';
 
 export async function GET(req: NextRequest) {
   try {
@@ -52,7 +56,7 @@ export async function GET(req: NextRequest) {
         entityId,
         parseInt(versionNumber)
       );
-      
+
       // Compare with another version if requested
       if (compareWith && version) {
         const diff = await versionService.compareVersions(
@@ -63,7 +67,7 @@ export async function GET(req: NextRequest) {
         );
         return NextResponse.json({ version, diff });
       }
-      
+
       return NextResponse.json({ version });
     }
 
@@ -71,10 +75,105 @@ export async function GET(req: NextRequest) {
     const history = await versionService.getHistory(entityType, entityId, { limit, offset });
     return NextResponse.json(history);
   } catch (error) {
-    console.error('[Governance API] Versions error:', error);
-    return NextResponse.json(
-      { error: 'Failed to fetch versions' },
-      { status: 500 }
-    );
+    logger.error({ error }, 'Failed to fetch entity versions');
+    return NextResponse.json({ error: 'Failed to fetch versions' }, { status: 500 });
+  }
+}
+
+const rollbackSchema = z.object({
+  entityType: z.enum(['Project', 'Building', 'QCInspection', 'WPS', 'ITP']),
+  entityId: z.string().uuid(),
+  versionNumber: z.number().int().positive(),
+  reason: z.string().min(1).max(500),
+});
+
+// Fields that should never be overwritten during a rollback
+const IMMUTABLE_FIELDS = new Set([
+  'id',
+  'createdAt',
+  'updatedAt',
+  'deletedAt',
+  'deletedById',
+  'deleteReason',
+]);
+
+const PRISMA_MODEL_MAP: Record<string, keyof typeof prisma> = {
+  Project: 'project',
+  Building: 'building',
+  QCInspection: 'qCInspection',
+  WPS: 'wPS',
+  ITP: 'iTP',
+};
+
+export async function POST(req: NextRequest) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    if (!['Admin', 'Manager'].includes(session.role)) {
+      return NextResponse.json({ error: 'Insufficient permissions' }, { status: 403 });
+    }
+
+    const body = await req.json();
+    const parsed = rollbackSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Invalid input', details: parsed.error.flatten() },
+        { status: 400 }
+      );
+    }
+
+    const { entityType, entityId, versionNumber, reason } = parsed.data;
+
+    const version = await versionService.getVersion(entityType, entityId, versionNumber);
+    if (!version) {
+      return NextResponse.json({ error: 'Version not found' }, { status: 404 });
+    }
+
+    const snapshot = version.snapshot as Record<string, unknown>;
+
+    // Build the update payload — exclude system-managed fields
+    const updateData: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(snapshot)) {
+      if (!IMMUTABLE_FIELDS.has(key)) {
+        updateData[key] = value;
+      }
+    }
+
+    const modelKey = PRISMA_MODEL_MAP[entityType];
+    if (!modelKey) {
+      return NextResponse.json({ error: 'Unsupported entity type' }, { status: 400 });
+    }
+
+    // Apply rollback via dynamic Prisma model access
+    const model = (prisma as unknown as Record<string, { update: (args: unknown) => Promise<unknown> }>)[modelKey as string];
+    await model.update({
+      where: { id: entityId },
+      data: updateData,
+    });
+
+    // Audit log the rollback
+    await auditService.log({
+      entityType,
+      entityId,
+      action: 'RESTORE',
+      reason: `Rolled back to version ${versionNumber}: ${reason}`,
+      userId: session.sub,
+    });
+
+    logger.info({ entityType, entityId, versionNumber, userId: session.sub }, 'Version rollback applied');
+
+    return NextResponse.json({
+      success: true,
+      message: `Successfully rolled back ${entityType} to version ${versionNumber}`,
+    });
+  } catch (error) {
+    logger.error({ error }, 'Failed to apply version rollback');
+    return NextResponse.json({ error: 'Failed to apply rollback' }, { status: 500 });
   }
 }

--- a/src/app/governance/_page-client.tsx
+++ b/src/app/governance/_page-client.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
 import {
   Select,
   SelectContent,
@@ -26,8 +28,11 @@ import {
   DialogDescription,
   DialogHeader,
   DialogTitle,
+  DialogFooter,
 } from '@/components/ui/dialog';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { ConfirmationDialog } from '@/components/ui/confirmation-dialog';
+import { useToast } from '@/hooks/use-toast';
 import {
   Shield,
   History,
@@ -44,8 +49,22 @@ import {
   ChevronLeft,
   ChevronRight,
   AlertCircle,
+  Bot,
+  MonitorCheck,
+  GitBranch,
+  ArrowLeftRight,
+  Undo2,
+  Database,
+  Filter,
+  CalendarRange,
+  SlidersHorizontal,
+  Info,
+  CheckCircle2,
+  XCircle,
 } from 'lucide-react';
 import { formatDistanceToNow, format } from 'date-fns';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
 
 interface AuditLog {
   id: string;
@@ -85,6 +104,28 @@ interface GovernanceStats {
   recentActivity: AuditLog[];
 }
 
+interface EntityVersion {
+  versionNumber: number;
+  createdAt: string;
+  createdBy: { id: string; name: string };
+  changeReason: string | null;
+}
+
+interface VersionDetail {
+  snapshot: Record<string, unknown>;
+  createdAt: string;
+  createdBy: { id: string; name: string };
+  changeReason: string | null;
+}
+
+interface VersionDiff {
+  added: string[];
+  removed: string[];
+  changed: Record<string, { old: unknown; new: unknown }>;
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
 const ACTION_COLORS: Record<string, string> = {
   CREATE: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300',
   UPDATE: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300',
@@ -95,100 +136,194 @@ const ACTION_COLORS: Record<string, string> = {
   SYNC: 'bg-cyan-100 text-cyan-800 dark:bg-cyan-900 dark:text-cyan-300',
 };
 
+const SYSTEM_SOURCES = new Set(['SYNC', 'AI', 'SYSTEM', 'CRON']);
+
 const ENTITY_TYPES = [
-  'Project',
-  'Building',
-  'AssemblyPart',
-  'ProductionLog',
-  'QCInspection',
-  'WPS',
-  'ITP',
-  'Document',
-  'RFIRequest',
-  'NCRReport',
+  'Project', 'Building', 'AssemblyPart', 'ProductionLog',
+  'QCInspection', 'WPS', 'ITP', 'Document', 'RFIRequest', 'NCRReport',
+  'Task', 'WorkOrder', 'User',
 ];
 
+const VERSIONED_ENTITIES = ['Project', 'Building', 'QCInspection', 'WPS', 'ITP'];
+
+const SOFT_DELETE_ENTITIES = ['Project', 'Building', 'AssemblyPart'];
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function isSystemEvent(sourceModule: string | null): boolean {
+  return sourceModule !== null && SYSTEM_SOURCES.has(sourceModule);
+}
+
+function getSourceLabel(sourceModule: string | null): string {
+  if (!sourceModule || sourceModule === 'UI') return 'User';
+  if (sourceModule === 'API') return 'API';
+  if (sourceModule === 'SYNC') return 'Sync';
+  if (sourceModule === 'AI') return 'AI';
+  if (sourceModule === 'CRON') return 'Scheduled';
+  if (sourceModule === 'SYSTEM') return 'System';
+  return sourceModule;
+}
+
+function formatSnapshotValue(value: unknown): string {
+  if (value === null || value === undefined) return '—';
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No';
+  if (typeof value === 'object') return JSON.stringify(value, null, 2);
+  return String(value);
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function SourceBadge({ sourceModule }: { sourceModule: string | null }) {
+  const isSystem = isSystemEvent(sourceModule);
+  return (
+    <span
+      className={`inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded font-medium ${
+        isSystem
+          ? 'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400'
+          : 'bg-violet-50 text-violet-700 dark:bg-violet-950 dark:text-violet-300'
+      }`}
+    >
+      {isSystem ? <Bot className="size-3" /> : <MonitorCheck className="size-3" />}
+      {getSourceLabel(sourceModule)}
+    </span>
+  );
+}
+
+function ActionBadge({ action }: { action: string }) {
+  return (
+    <Badge className={`text-xs font-semibold ${ACTION_COLORS[action] || 'bg-gray-100 text-gray-700'}`}>
+      {action}
+    </Badge>
+  );
+}
+
+// ─── Main Component ───────────────────────────────────────────────────────────
+
 export default function GovernancePage() {
+  const { toast } = useToast();
   const [activeTab, setActiveTab] = useState('overview');
   const [stats, setStats] = useState<GovernanceStats | null>(null);
-  const [auditLogs, setAuditLogs] = useState<AuditLog[]>([]);
-  const [deletedItems, setDeletedItems] = useState<DeletedItem[]>([]);
   const [loading, setLoading] = useState(true);
+
+  // Audit Trail state
+  const [auditLogs, setAuditLogs] = useState<AuditLog[]>([]);
+  const [auditTotal, setAuditTotal] = useState(0);
   const [loadingLogs, setLoadingLogs] = useState(false);
-  const [loadingDeleted, setLoadingDeleted] = useState(false);
-  
-  // Filters
-  const [entityTypeFilter, setEntityTypeFilter] = useState<string>('all');
-  const [actionFilter, setActionFilter] = useState<string>('all');
+  const [entityTypeFilter, setEntityTypeFilter] = useState('all');
+  const [actionFilter, setActionFilter] = useState('all');
+  const [sourceTypeFilter, setSourceTypeFilter] = useState('all');
+  const [dateFrom, setDateFrom] = useState('');
+  const [dateTo, setDateTo] = useState('');
   const [searchQuery, setSearchQuery] = useState('');
-  const [deletedEntityType, setDeletedEntityType] = useState<string>('Project');
-  
-  // Pagination
-  const [page, setPage] = useState(0);
-  const [totalLogs, setTotalLogs] = useState(0);
-  const pageSize = 20;
-  
-  // Detail dialog
+  const [auditPage, setAuditPage] = useState(0);
   const [selectedLog, setSelectedLog] = useState<AuditLog | null>(null);
-  const [showDetailDialog, setShowDetailDialog] = useState(false);
+  const [showFilters, setShowFilters] = useState(false);
+  const pageSize = 20;
 
-  // Fetch stats on mount
-  useEffect(() => {
-    fetchStats();
-  }, []);
+  // Version History state
+  const [versionEntityType, setVersionEntityType] = useState('Project');
+  const [versionEntityId, setVersionEntityId] = useState('');
+  const [versions, setVersions] = useState<EntityVersion[]>([]);
+  const [versionTotal, setVersionTotal] = useState(0);
+  const [loadingVersions, setLoadingVersions] = useState(false);
+  const [selectedVersionA, setSelectedVersionA] = useState<number | null>(null);
+  const [selectedVersionB, setSelectedVersionB] = useState<number | null>(null);
+  const [versionDetail, setVersionDetail] = useState<VersionDetail | null>(null);
+  const [versionDiff, setVersionDiff] = useState<VersionDiff | null>(null);
+  const [showVersionDialog, setShowVersionDialog] = useState(false);
+  const [showRollbackDialog, setShowRollbackDialog] = useState(false);
+  const [rollbackReason, setRollbackReason] = useState('');
+  const [rollingBack, setRollingBack] = useState(false);
+  const [rollbackTargetVersion, setRollbackTargetVersion] = useState<number | null>(null);
 
-  // Fetch audit logs when tab changes or filters change
-  useEffect(() => {
-    if (activeTab === 'audit') {
-      fetchAuditLogs();
-    }
-  }, [activeTab, entityTypeFilter, actionFilter, page]);
+  // Deleted Items state
+  const [deletedItems, setDeletedItems] = useState<DeletedItem[]>([]);
+  const [loadingDeleted, setLoadingDeleted] = useState(false);
+  const [deletedEntityType, setDeletedEntityType] = useState('Project');
+  const [restoreTarget, setRestoreTarget] = useState<DeletedItem | null>(null);
+  const [showRestoreDialog, setShowRestoreDialog] = useState(false);
+  const [restoring, setRestoring] = useState(false);
 
-  // Fetch deleted items when tab changes
-  useEffect(() => {
-    if (activeTab === 'deleted') {
-      fetchDeletedItems();
-    }
-  }, [activeTab, deletedEntityType]);
+  // ── Fetch functions ────────────────────────────────────────────────────────
 
-  const fetchStats = async () => {
+  const fetchStats = useCallback(async () => {
     try {
       const res = await fetch('/api/governance/stats');
       if (res.ok) {
         const data = await res.json();
         setStats(data);
       }
-    } catch (error) {
-      console.error('Failed to fetch stats:', error);
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
-  const fetchAuditLogs = async () => {
+  const fetchAuditLogs = useCallback(async () => {
     setLoadingLogs(true);
     try {
       const params = new URLSearchParams({
         limit: pageSize.toString(),
-        offset: (page * pageSize).toString(),
+        offset: (auditPage * pageSize).toString(),
       });
       if (entityTypeFilter !== 'all') params.set('entityType', entityTypeFilter);
       if (actionFilter !== 'all') params.set('action', actionFilter);
+      if (sourceTypeFilter !== 'all') params.set('sourceType', sourceTypeFilter);
+      if (dateFrom) params.set('dateFrom', dateFrom);
+      if (dateTo) params.set('dateTo', dateTo);
 
       const res = await fetch(`/api/governance/audit?${params}`);
       if (res.ok) {
         const data = await res.json();
         setAuditLogs(data.logs || []);
-        setTotalLogs(data.total || data.logs?.length || 0);
+        setAuditTotal(data.total || 0);
       }
-    } catch (error) {
-      console.error('Failed to fetch audit logs:', error);
     } finally {
       setLoadingLogs(false);
     }
+  }, [auditPage, entityTypeFilter, actionFilter, sourceTypeFilter, dateFrom, dateTo]);
+
+  const fetchVersions = useCallback(async () => {
+    if (!versionEntityId.trim()) return;
+    setLoadingVersions(true);
+    setVersions([]);
+    setVersionTotal(0);
+    try {
+      const res = await fetch(
+        `/api/governance/versions?entityType=${versionEntityType}&entityId=${versionEntityId.trim()}`
+      );
+      if (res.ok) {
+        const data = await res.json();
+        setVersions(data.versions || []);
+        setVersionTotal(data.total || 0);
+      } else {
+        toast({ title: 'Entity not found', description: 'No versions found for this ID.', variant: 'destructive' });
+      }
+    } finally {
+      setLoadingVersions(false);
+    }
+  }, [versionEntityType, versionEntityId, toast]);
+
+  const fetchVersionDetail = async (versionNum: number) => {
+    setVersionDetail(null);
+    setVersionDiff(null);
+    const params = new URLSearchParams({
+      entityType: versionEntityType,
+      entityId: versionEntityId,
+      version: String(versionNum),
+    });
+    if (selectedVersionB && selectedVersionB !== versionNum) {
+      params.set('compareWith', String(selectedVersionB));
+    }
+    const res = await fetch(`/api/governance/versions?${params}`);
+    if (res.ok) {
+      const data = await res.json();
+      setVersionDetail(data.version);
+      if (data.diff) setVersionDiff(data.diff);
+    }
+    setShowVersionDialog(true);
   };
 
-  const fetchDeletedItems = async () => {
+  const fetchDeletedItems = useCallback(async () => {
     setLoadingDeleted(true);
     try {
       const res = await fetch(`/api/governance/deleted?entityType=${deletedEntityType}`);
@@ -196,39 +331,92 @@ export default function GovernancePage() {
         const data = await res.json();
         setDeletedItems(data.items || []);
       }
-    } catch (error) {
-      console.error('Failed to fetch deleted items:', error);
     } finally {
       setLoadingDeleted(false);
     }
-  };
+  }, [deletedEntityType]);
 
-  const handleRestore = async (entityType: string, entityId: string) => {
+  // ── Effects ────────────────────────────────────────────────────────────────
+
+  useEffect(() => { fetchStats(); }, [fetchStats]);
+  useEffect(() => { if (activeTab === 'audit') fetchAuditLogs(); }, [activeTab, fetchAuditLogs]);
+  useEffect(() => { if (activeTab === 'deleted') fetchDeletedItems(); }, [activeTab, fetchDeletedItems]);
+
+  // ── Actions ────────────────────────────────────────────────────────────────
+
+  const handleRestore = async () => {
+    if (!restoreTarget) return;
+    setRestoring(true);
     try {
       const res = await fetch('/api/governance/deleted', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ entityType, entityId }),
+        body: JSON.stringify({ entityType: deletedEntityType, entityId: restoreTarget.id }),
       });
       if (res.ok) {
+        toast({ title: 'Restored', description: `${restoreTarget.name} has been restored successfully.` });
         fetchDeletedItems();
         fetchStats();
+      } else {
+        const err = await res.json();
+        toast({ title: 'Restore failed', description: err.error || 'Unknown error', variant: 'destructive' });
       }
-    } catch (error) {
-      console.error('Failed to restore item:', error);
+    } finally {
+      setRestoring(false);
+      setRestoreTarget(null);
+      setShowRestoreDialog(false);
     }
   };
 
-  const filteredLogs = auditLogs.filter(log => {
-    if (!searchQuery) return true;
-    const query = searchQuery.toLowerCase();
-    return (
-      log.entityType.toLowerCase().includes(query) ||
-      log.entityId.toLowerCase().includes(query) ||
-      log.performedBy.name.toLowerCase().includes(query) ||
-      log.reason?.toLowerCase().includes(query)
-    );
-  });
+  const handleRollback = async () => {
+    if (!rollbackTargetVersion || !versionEntityId || !rollbackReason.trim()) return;
+    setRollingBack(true);
+    try {
+      const res = await fetch('/api/governance/versions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          entityType: versionEntityType,
+          entityId: versionEntityId,
+          versionNumber: rollbackTargetVersion,
+          reason: rollbackReason,
+        }),
+      });
+      if (res.ok) {
+        toast({
+          title: 'Rollback applied',
+          description: `${versionEntityType} rolled back to version ${rollbackTargetVersion}.`,
+        });
+        setShowRollbackDialog(false);
+        setRollbackReason('');
+        fetchVersions();
+      } else {
+        const err = await res.json();
+        toast({ title: 'Rollback failed', description: err.error || 'Unknown error', variant: 'destructive' });
+      }
+    } finally {
+      setRollingBack(false);
+    }
+  };
+
+  // ── Derived data ───────────────────────────────────────────────────────────
+
+  const filteredLogs = searchQuery
+    ? auditLogs.filter((log) => {
+        const q = searchQuery.toLowerCase();
+        return (
+          log.entityType.toLowerCase().includes(q) ||
+          log.entityId.toLowerCase().includes(q) ||
+          log.performedBy.name.toLowerCase().includes(q) ||
+          log.reason?.toLowerCase().includes(q) ||
+          log.sourceModule?.toLowerCase().includes(q)
+        );
+      })
+    : auditLogs;
+
+  const userEventCount = stats?.auditLogs.byAction
+    ? Object.values(stats.auditLogs.byAction).reduce((a: number, b: number) => a + b, 0)
+    : 0;
 
   if (loading) {
     return (
@@ -238,94 +426,96 @@ export default function GovernancePage() {
     );
   }
 
+  // ── Render ─────────────────────────────────────────────────────────────────
+
   return (
     <div className="container mx-auto py-6 space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between flex-wrap gap-3">
         <div>
           <h1 className="text-3xl font-bold flex items-center gap-2">
             <Shield className="size-8 text-primary" />
             Governance Center
           </h1>
           <p className="text-muted-foreground mt-1">
-            Enterprise audit trail, version history, and data recovery
+            Audit trail, version history, data recovery, and compliance controls
           </p>
         </div>
-        <div className="flex gap-2">
-          <Button 
-            variant="outline" 
-            onClick={() => window.open('/docs/GOVERNANCE_QUICK_GUIDE.md', '_blank')}
-          >
-            <FileText className="size-4 mr-2" />
-            Quick Guide
-          </Button>
-          <Button variant="outline" onClick={() => { fetchStats(); if (activeTab === 'audit') fetchAuditLogs(); }}>
-            <RefreshCw className="size-4 mr-2" />
-            Refresh
-          </Button>
-        </div>
+        <Button
+          variant="outline"
+          onClick={() => {
+            fetchStats();
+            if (activeTab === 'audit') fetchAuditLogs();
+            if (activeTab === 'deleted') fetchDeletedItems();
+          }}
+        >
+          <RefreshCw className="size-4 mr-2" />
+          Refresh
+        </Button>
       </div>
 
       {/* Tabs */}
       <Tabs value={activeTab} onValueChange={setActiveTab}>
-        <TabsList className="grid w-full grid-cols-3 max-w-md">
-          <TabsTrigger value="overview" className="flex items-center gap-2">
-            <Activity className="size-4" />
+        <TabsList className="grid w-full grid-cols-4 max-w-2xl">
+          <TabsTrigger value="overview" className="flex items-center gap-1.5 text-xs sm:text-sm">
+            <Activity className="size-3.5" />
             Overview
           </TabsTrigger>
-          <TabsTrigger value="audit" className="flex items-center gap-2">
-            <FileText className="size-4" />
+          <TabsTrigger value="audit" className="flex items-center gap-1.5 text-xs sm:text-sm">
+            <FileText className="size-3.5" />
             Audit Trail
           </TabsTrigger>
-          <TabsTrigger value="deleted" className="flex items-center gap-2">
-            <Trash2 className="size-4" />
+          <TabsTrigger value="versions" className="flex items-center gap-1.5 text-xs sm:text-sm">
+            <GitBranch className="size-3.5" />
+            Versions
+          </TabsTrigger>
+          <TabsTrigger value="deleted" className="flex items-center gap-1.5 text-xs sm:text-sm">
+            <Trash2 className="size-3.5" />
             Deleted
           </TabsTrigger>
         </TabsList>
 
-        {/* Overview Tab */}
+        {/* ── Overview Tab ───────────────────────────────────────────────── */}
         <TabsContent value="overview" className="space-y-6">
-          {/* Stats Cards */}
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+          {/* Stats */}
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
             <Card>
               <CardHeader className="pb-2">
-                <CardTitle className="text-sm font-medium text-muted-foreground">
-                  Total Audit Logs
+                <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-1.5">
+                  <FileText className="size-4" /> Audit Logs
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                <div className="text-2xl font-bold">{stats?.auditLogs.total || 0}</div>
-                <p className="text-xs text-muted-foreground">
-                  {stats?.auditLogs.today || 0} today
-                </p>
+                <div className="text-2xl font-bold">{stats?.auditLogs.total.toLocaleString() || 0}</div>
+                <p className="text-xs text-muted-foreground">{stats?.auditLogs.today || 0} today</p>
               </CardContent>
             </Card>
             <Card>
               <CardHeader className="pb-2">
-                <CardTitle className="text-sm font-medium text-muted-foreground">
-                  Entity Versions
+                <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-1.5">
+                  <Database className="size-4" /> Versions
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                <div className="text-2xl font-bold">{stats?.versions.total || 0}</div>
+                <div className="text-2xl font-bold">{stats?.versions.total.toLocaleString() || 0}</div>
                 <p className="text-xs text-muted-foreground">snapshots stored</p>
               </CardContent>
             </Card>
             <Card>
               <CardHeader className="pb-2">
-                <CardTitle className="text-sm font-medium text-muted-foreground">
-                  Deleted Items
+                <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-1.5">
+                  <Trash2 className="size-4" /> Deleted
                 </CardTitle>
               </CardHeader>
               <CardContent>
                 <div className="text-2xl font-bold">{stats?.deleted.total || 0}</div>
-                <p className="text-xs text-muted-foreground">recoverable</p>
+                <p className="text-xs text-muted-foreground">recoverable items</p>
               </CardContent>
             </Card>
             <Card>
               <CardHeader className="pb-2">
-                <CardTitle className="text-sm font-medium text-muted-foreground">
-                  Actions (30d)
+                <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-1.5">
+                  <Activity className="size-4" /> Actions (30d)
                 </CardTitle>
               </CardHeader>
               <CardContent>
@@ -335,10 +525,52 @@ export default function GovernancePage() {
                       {action}: {count}
                     </Badge>
                   ))}
-                  {(!stats?.auditLogs.byAction || Object.keys(stats.auditLogs.byAction).length === 0) && (
+                  {userEventCount === 0 && (
                     <span className="text-muted-foreground text-sm">No activity</span>
                   )}
                 </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* Event Source Breakdown */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <Card className="border-violet-200 dark:border-violet-800">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-medium flex items-center gap-2 text-violet-700 dark:text-violet-300">
+                  <MonitorCheck className="size-4" />
+                  User-Initiated Actions
+                </CardTitle>
+                <CardDescription>Changes made directly by team members via the UI or API</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="w-full"
+                  onClick={() => { setSourceTypeFilter('user'); setActiveTab('audit'); }}
+                >
+                  View User Actions
+                </Button>
+              </CardContent>
+            </Card>
+            <Card className="border-slate-200 dark:border-slate-700">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-medium flex items-center gap-2 text-slate-600 dark:text-slate-400">
+                  <Bot className="size-4" />
+                  System-Generated Events
+                </CardTitle>
+                <CardDescription>Automated changes from sync, AI, scheduled jobs, and integrations</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="w-full"
+                  onClick={() => { setSourceTypeFilter('system'); setActiveTab('audit'); }}
+                >
+                  View System Events
+                </Button>
               </CardContent>
             </Card>
           </div>
@@ -350,31 +582,33 @@ export default function GovernancePage() {
                 <Clock className="size-5" />
                 Recent Activity
               </CardTitle>
-              <CardDescription>Latest changes across the system</CardDescription>
+              <CardDescription>Latest changes across all entities — hover a row for details</CardDescription>
             </CardHeader>
             <CardContent>
               {stats?.recentActivity && stats.recentActivity.length > 0 ? (
-                <div className="space-y-3">
+                <div className="space-y-2">
                   {stats.recentActivity.map((log) => (
-                    <div key={log.id} className="flex items-center justify-between p-3 rounded-lg bg-muted/50">
-                      <div className="flex items-center gap-3">
-                        <Badge className={ACTION_COLORS[log.action] || 'bg-gray-100'}>
-                          {log.action}
-                        </Badge>
-                        <div>
+                    <div
+                      key={log.id}
+                      className="flex items-center justify-between p-3 rounded-lg bg-muted/50 hover:bg-muted transition-colors"
+                    >
+                      <div className="flex items-center gap-3 min-w-0">
+                        <ActionBadge action={log.action} />
+                        <SourceBadge sourceModule={log.sourceModule ?? null} />
+                        <div className="min-w-0">
                           <span className="font-medium">{log.entityType}</span>
-                          <span className="text-muted-foreground mx-1">•</span>
+                          <span className="text-muted-foreground mx-1">·</span>
                           <span className="text-sm text-muted-foreground font-mono">
-                            {log.entityId.slice(0, 8)}...
+                            {log.entityId.slice(0, 8)}…
                           </span>
                         </div>
                       </div>
-                      <div className="flex items-center gap-4 text-sm text-muted-foreground">
-                        <span className="flex items-center gap-1">
+                      <div className="flex items-center gap-4 text-sm text-muted-foreground shrink-0 ml-2">
+                        <span className="flex items-center gap-1 hidden sm:flex">
                           <User className="size-3" />
                           {log.performedBy.name}
                         </span>
-                        <span>{formatDistanceToNow(new Date(log.performedAt), { addSuffix: true })}</span>
+                        <span className="text-xs">{formatDistanceToNow(new Date(log.performedAt), { addSuffix: true })}</span>
                       </div>
                     </div>
                   ))}
@@ -389,7 +623,7 @@ export default function GovernancePage() {
             </CardContent>
           </Card>
 
-          {/* Deleted Items Summary */}
+          {/* Recoverable Items */}
           {stats?.deleted && stats.deleted.total > 0 && (
             <Card className="border-orange-200 dark:border-orange-800">
               <CardHeader>
@@ -397,28 +631,22 @@ export default function GovernancePage() {
                   <Trash2 className="size-5" />
                   Recoverable Items
                 </CardTitle>
-                <CardDescription>Items that can be restored</CardDescription>
+                <CardDescription>These items have been soft-deleted and can be fully restored</CardDescription>
               </CardHeader>
               <CardContent>
-                <div className="grid grid-cols-3 gap-4">
-                  <div className="text-center p-4 rounded-lg bg-muted/50">
-                    <div className="text-2xl font-bold">{stats.deleted.projects}</div>
-                    <div className="text-sm text-muted-foreground">Projects</div>
-                  </div>
-                  <div className="text-center p-4 rounded-lg bg-muted/50">
-                    <div className="text-2xl font-bold">{stats.deleted.buildings}</div>
-                    <div className="text-sm text-muted-foreground">Buildings</div>
-                  </div>
-                  <div className="text-center p-4 rounded-lg bg-muted/50">
-                    <div className="text-2xl font-bold">{stats.deleted.assemblyParts}</div>
-                    <div className="text-sm text-muted-foreground">Assembly Parts</div>
-                  </div>
+                <div className="grid grid-cols-3 gap-4 mb-4">
+                  {[
+                    { label: 'Projects', count: stats.deleted.projects },
+                    { label: 'Buildings', count: stats.deleted.buildings },
+                    { label: 'Assembly Parts', count: stats.deleted.assemblyParts },
+                  ].map(({ label, count }) => (
+                    <div key={label} className="text-center p-4 rounded-lg bg-muted/50">
+                      <div className="text-2xl font-bold">{count}</div>
+                      <div className="text-sm text-muted-foreground">{label}</div>
+                    </div>
+                  ))}
                 </div>
-                <Button 
-                  variant="outline" 
-                  className="w-full mt-4"
-                  onClick={() => setActiveTab('deleted')}
-                >
+                <Button variant="outline" className="w-full" onClick={() => setActiveTab('deleted')}>
                   View & Restore Deleted Items
                 </Button>
               </CardContent>
@@ -426,54 +654,117 @@ export default function GovernancePage() {
           )}
         </TabsContent>
 
-        {/* Audit Trail Tab */}
+        {/* ── Audit Trail Tab ────────────────────────────────────────────── */}
         <TabsContent value="audit" className="space-y-4">
+          {/* Source Legend */}
+          <div className="flex items-center gap-4 px-1 text-xs text-muted-foreground flex-wrap">
+            <span className="flex items-center gap-1.5">
+              <MonitorCheck className="size-3.5 text-violet-600" />
+              <span className="text-violet-700 font-medium">User action</span>
+              — change made by a team member
+            </span>
+            <span className="flex items-center gap-1.5">
+              <Bot className="size-3.5 text-slate-500" />
+              <span className="text-slate-600 font-medium">System event</span>
+              — automated by sync, AI, or scheduler
+            </span>
+          </div>
+
           {/* Filters */}
           <Card>
-            <CardContent className="pt-4">
-              <div className="flex flex-wrap gap-4">
+            <CardContent className="pt-4 space-y-3">
+              <div className="flex flex-wrap gap-3">
                 <div className="flex-1 min-w-[200px]">
                   <div className="relative">
                     <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
                     <Input
-                      placeholder="Search logs..."
+                      placeholder="Search by entity, user, or reason…"
                       value={searchQuery}
                       onChange={(e) => setSearchQuery(e.target.value)}
                       className="pl-9"
                     />
                   </div>
                 </div>
-                <Select value={entityTypeFilter} onValueChange={(v) => { setEntityTypeFilter(v); setPage(0); }}>
-                  <SelectTrigger className="w-[180px]">
-                    <SelectValue placeholder="Entity Type" />
+                <Select value={entityTypeFilter} onValueChange={(v) => { setEntityTypeFilter(v); setAuditPage(0); }}>
+                  <SelectTrigger className="w-[160px]">
+                    <SelectValue placeholder="Entity" />
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="all">All Entities</SelectItem>
-                    {ENTITY_TYPES.map(type => (
-                      <SelectItem key={type} value={type}>{type}</SelectItem>
+                    {ENTITY_TYPES.map((t) => (
+                      <SelectItem key={t} value={t}>{t}</SelectItem>
                     ))}
                   </SelectContent>
                 </Select>
-                <Select value={actionFilter} onValueChange={(v) => { setActionFilter(v); setPage(0); }}>
-                  <SelectTrigger className="w-[150px]">
+                <Select value={actionFilter} onValueChange={(v) => { setActionFilter(v); setAuditPage(0); }}>
+                  <SelectTrigger className="w-[140px]">
                     <SelectValue placeholder="Action" />
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="all">All Actions</SelectItem>
-                    <SelectItem value="CREATE">Create</SelectItem>
-                    <SelectItem value="UPDATE">Update</SelectItem>
-                    <SelectItem value="DELETE">Delete</SelectItem>
-                    <SelectItem value="RESTORE">Restore</SelectItem>
-                    <SelectItem value="APPROVE">Approve</SelectItem>
-                    <SelectItem value="REJECT">Reject</SelectItem>
-                    <SelectItem value="SYNC">Sync</SelectItem>
+                    {['CREATE', 'UPDATE', 'DELETE', 'RESTORE', 'APPROVE', 'REJECT', 'SYNC'].map((a) => (
+                      <SelectItem key={a} value={a}>{a}</SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
+                <Select value={sourceTypeFilter} onValueChange={(v) => { setSourceTypeFilter(v); setAuditPage(0); }}>
+                  <SelectTrigger className="w-[150px]">
+                    <SelectValue placeholder="Source" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All Sources</SelectItem>
+                    <SelectItem value="user">User Actions</SelectItem>
+                    <SelectItem value="system">System Events</SelectItem>
+                  </SelectContent>
+                </Select>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setShowFilters(!showFilters)}
+                  className={showFilters ? 'border-primary' : ''}
+                >
+                  <CalendarRange className="size-4 mr-1.5" />
+                  Date Range
+                  {(dateFrom || dateTo) && <span className="ml-1 w-1.5 h-1.5 rounded-full bg-primary inline-block" />}
+                </Button>
               </div>
+
+              {showFilters && (
+                <div className="flex flex-wrap gap-3 pt-1 border-t">
+                  <div className="flex items-center gap-2">
+                    <Label className="text-xs shrink-0">From</Label>
+                    <Input
+                      type="datetime-local"
+                      value={dateFrom}
+                      onChange={(e) => { setDateFrom(e.target.value); setAuditPage(0); }}
+                      className="w-auto text-sm h-8"
+                    />
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Label className="text-xs shrink-0">To</Label>
+                    <Input
+                      type="datetime-local"
+                      value={dateTo}
+                      onChange={(e) => { setDateTo(e.target.value); setAuditPage(0); }}
+                      className="w-auto text-sm h-8"
+                    />
+                  </div>
+                  {(dateFrom || dateTo) && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => { setDateFrom(''); setDateTo(''); }}
+                      className="h-8 text-xs text-muted-foreground"
+                    >
+                      Clear dates
+                    </Button>
+                  )}
+                </div>
+              )}
             </CardContent>
           </Card>
 
-          {/* Audit Logs Table */}
+          {/* Table */}
           <Card>
             <CardContent className="p-0">
               {loadingLogs ? (
@@ -486,74 +777,80 @@ export default function GovernancePage() {
                     <TableHeader>
                       <TableRow>
                         <TableHead>Action</TableHead>
+                        <TableHead>Source</TableHead>
                         <TableHead>Entity</TableHead>
                         <TableHead>User</TableHead>
                         <TableHead>Time</TableHead>
                         <TableHead>Reason</TableHead>
-                        <TableHead className="w-[80px]"></TableHead>
+                        <TableHead className="w-[50px]" />
                       </TableRow>
                     </TableHeader>
                     <TableBody>
-                      {filteredLogs.map((log) => (
-                        <TableRow key={log.id}>
-                          <TableCell>
-                            <Badge className={ACTION_COLORS[log.action] || 'bg-gray-100'}>
-                              {log.action}
-                            </Badge>
-                          </TableCell>
-                          <TableCell>
-                            <div>
-                              <span className="font-medium">{log.entityType}</span>
-                              <div className="text-xs text-muted-foreground font-mono">
-                                {log.entityId.slice(0, 12)}...
+                      {filteredLogs.map((log) => {
+                        const system = isSystemEvent(log.sourceModule);
+                        return (
+                          <TableRow
+                            key={log.id}
+                            className={system ? 'opacity-75 bg-slate-50/50 dark:bg-slate-900/20' : ''}
+                          >
+                            <TableCell>
+                              <ActionBadge action={log.action} />
+                            </TableCell>
+                            <TableCell>
+                              <SourceBadge sourceModule={log.sourceModule ?? null} />
+                            </TableCell>
+                            <TableCell>
+                              <div>
+                                <span className="font-medium text-sm">{log.entityType}</span>
+                                <div className="text-xs text-muted-foreground font-mono">
+                                  {log.entityId === 'BATCH' ? 'BATCH' : `${log.entityId.slice(0, 10)}…`}
+                                </div>
                               </div>
-                            </div>
-                          </TableCell>
-                          <TableCell>{log.performedBy.name}</TableCell>
-                          <TableCell>
-                            <div className="text-sm">
-                              {format(new Date(log.performedAt), 'MMM d, HH:mm')}
-                            </div>
-                            <div className="text-xs text-muted-foreground">
-                              {formatDistanceToNow(new Date(log.performedAt), { addSuffix: true })}
-                            </div>
-                          </TableCell>
-                          <TableCell className="max-w-[200px] truncate">
-                            {log.reason || '-'}
-                          </TableCell>
-                          <TableCell>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={() => { setSelectedLog(log); setShowDetailDialog(true); }}
-                            >
-                              <Eye className="size-4" />
-                            </Button>
-                          </TableCell>
-                        </TableRow>
-                      ))}
+                            </TableCell>
+                            <TableCell className="text-sm">{log.performedBy.name}</TableCell>
+                            <TableCell>
+                              <div className="text-sm">{format(new Date(log.performedAt), 'MMM d, HH:mm')}</div>
+                              <div className="text-xs text-muted-foreground">
+                                {formatDistanceToNow(new Date(log.performedAt), { addSuffix: true })}
+                              </div>
+                            </TableCell>
+                            <TableCell className="max-w-[180px] truncate text-sm">
+                              {log.reason || '—'}
+                            </TableCell>
+                            <TableCell>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => setSelectedLog(log)}
+                              >
+                                <Eye className="size-4" />
+                              </Button>
+                            </TableCell>
+                          </TableRow>
+                        );
+                      })}
                     </TableBody>
                   </Table>
-                  
+
                   {/* Pagination */}
                   <div className="flex items-center justify-between px-4 py-3 border-t">
                     <div className="text-sm text-muted-foreground">
-                      Showing {page * pageSize + 1} - {Math.min((page + 1) * pageSize, totalLogs)} of {totalLogs}
+                      {auditPage * pageSize + 1}–{Math.min((auditPage + 1) * pageSize, auditTotal)} of {auditTotal.toLocaleString()}
                     </div>
                     <div className="flex gap-2">
                       <Button
                         variant="outline"
                         size="sm"
-                        onClick={() => setPage(p => Math.max(0, p - 1))}
-                        disabled={page === 0}
+                        onClick={() => setAuditPage((p) => Math.max(0, p - 1))}
+                        disabled={auditPage === 0}
                       >
                         <ChevronLeft className="size-4" />
                       </Button>
                       <Button
                         variant="outline"
                         size="sm"
-                        onClick={() => setPage(p => p + 1)}
-                        disabled={(page + 1) * pageSize >= totalLogs}
+                        onClick={() => setAuditPage((p) => p + 1)}
+                        disabled={(auditPage + 1) * pageSize >= auditTotal}
                       >
                         <ChevronRight className="size-4" />
                       </Button>
@@ -563,33 +860,190 @@ export default function GovernancePage() {
               ) : (
                 <div className="text-center py-12 text-muted-foreground">
                   <History className="size-12 mx-auto mb-2 opacity-50" />
-                  <p>No audit logs found</p>
-                  <p className="text-sm">Changes will be recorded as they happen</p>
+                  <p>No audit logs match the current filters</p>
+                  <p className="text-sm">Try adjusting your filters or date range</p>
                 </div>
               )}
             </CardContent>
           </Card>
         </TabsContent>
 
-        {/* Deleted Items Tab */}
-        <TabsContent value="deleted" className="space-y-4">
-          {/* Entity Type Selector */}
+        {/* ── Version History Tab ────────────────────────────────────────── */}
+        <TabsContent value="versions" className="space-y-4">
           <Card>
-            <CardContent className="pt-4">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <GitBranch className="size-5" />
+                Version History
+              </CardTitle>
+              <CardDescription>
+                Browse full snapshots of versioned entities (Projects, Buildings, QC Inspections, WPS, ITP).
+                Compare any two versions or roll back to a previous state.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex flex-wrap gap-3">
+                <Select value={versionEntityType} onValueChange={setVersionEntityType}>
+                  <SelectTrigger className="w-[180px]">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {VERSIONED_ENTITIES.map((e) => (
+                      <SelectItem key={e} value={e}>{e}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <div className="flex-1 min-w-[240px] flex gap-2">
+                  <Input
+                    placeholder={`Enter ${versionEntityType} ID (UUID)…`}
+                    value={versionEntityId}
+                    onChange={(e) => setVersionEntityId(e.target.value)}
+                    onKeyDown={(e) => e.key === 'Enter' && fetchVersions()}
+                  />
+                  <Button onClick={fetchVersions} disabled={!versionEntityId.trim() || loadingVersions}>
+                    {loadingVersions ? <Loader2 className="size-4 animate-spin" /> : <Search className="size-4" />}
+                  </Button>
+                </div>
+              </div>
+
+              {/* Compare mode hint */}
+              {versions.length > 0 && (
+                <div className="flex items-center gap-2 text-xs text-muted-foreground bg-muted/50 rounded-lg p-2.5">
+                  <Info className="size-3.5 shrink-0" />
+                  <span>
+                    Click <strong>View</strong> to inspect a version's snapshot. To compare two versions, select a
+                    base version from the <em>Compare with</em> dropdown and then click <strong>View</strong> on another.
+                  </span>
+                </div>
+              )}
+
+              {versions.length > 0 ? (
+                <>
+                  <div className="flex items-center justify-between">
+                    <p className="text-sm text-muted-foreground">{versionTotal} versions for this entity</p>
+                    {selectedVersionB && (
+                      <Badge variant="outline" className="text-xs">
+                        Comparing with v{selectedVersionB}
+                        <button className="ml-1.5 opacity-60 hover:opacity-100" onClick={() => setSelectedVersionB(null)}>×</button>
+                      </Badge>
+                    )}
+                  </div>
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Version</TableHead>
+                        <TableHead>Date</TableHead>
+                        <TableHead>Author</TableHead>
+                        <TableHead>Reason</TableHead>
+                        <TableHead>Compare with</TableHead>
+                        <TableHead className="w-[160px]">Actions</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {versions.map((v) => (
+                        <TableRow key={v.versionNumber}>
+                          <TableCell>
+                            <Badge variant="outline" className="font-mono">v{v.versionNumber}</Badge>
+                          </TableCell>
+                          <TableCell>
+                            <div className="text-sm">{format(new Date(v.createdAt), 'MMM d, yyyy HH:mm')}</div>
+                            <div className="text-xs text-muted-foreground">
+                              {formatDistanceToNow(new Date(v.createdAt), { addSuffix: true })}
+                            </div>
+                          </TableCell>
+                          <TableCell className="text-sm">{v.createdBy.name}</TableCell>
+                          <TableCell className="max-w-[180px] truncate text-sm">
+                            {v.changeReason || '—'}
+                          </TableCell>
+                          <TableCell>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className={selectedVersionB === v.versionNumber ? 'border border-primary' : ''}
+                              onClick={() =>
+                                setSelectedVersionB(
+                                  selectedVersionB === v.versionNumber ? null : v.versionNumber
+                                )
+                              }
+                            >
+                              <ArrowLeftRight className="size-3.5 mr-1" />
+                              {selectedVersionB === v.versionNumber ? 'Selected' : 'Select'}
+                            </Button>
+                          </TableCell>
+                          <TableCell>
+                            <div className="flex gap-1.5">
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={() => {
+                                  setSelectedVersionA(v.versionNumber);
+                                  fetchVersionDetail(v.versionNumber);
+                                }}
+                              >
+                                <Eye className="size-3.5 mr-1" />
+                                View
+                              </Button>
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                className="text-amber-600 border-amber-300 hover:bg-amber-50"
+                                onClick={() => {
+                                  setRollbackTargetVersion(v.versionNumber);
+                                  setShowRollbackDialog(true);
+                                }}
+                              >
+                                <Undo2 className="size-3.5 mr-1" />
+                                Restore
+                              </Button>
+                            </div>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </>
+              ) : versionEntityId && !loadingVersions ? (
+                <div className="text-center py-8 text-muted-foreground border rounded-lg">
+                  <Database className="size-10 mx-auto mb-2 opacity-40" />
+                  <p>No versions found for this entity</p>
+                  <p className="text-sm">Only certain entity types are versioned, and only after changes are made</p>
+                </div>
+              ) : !versionEntityId ? (
+                <div className="text-center py-8 text-muted-foreground border rounded-lg border-dashed">
+                  <GitBranch className="size-10 mx-auto mb-2 opacity-40" />
+                  <p>Enter an entity ID above to browse its version history</p>
+                </div>
+              ) : null}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        {/* ── Deleted Items Tab ──────────────────────────────────────────── */}
+        <TabsContent value="deleted" className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <RotateCcw className="size-5" />
+                Data Recovery
+              </CardTitle>
+              <CardDescription>
+                Soft-deleted items are retained and can be fully restored. Select an entity type to browse.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
               <Select value={deletedEntityType} onValueChange={setDeletedEntityType}>
                 <SelectTrigger className="w-[200px]">
-                  <SelectValue placeholder="Entity Type" />
+                  <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="Project">Projects</SelectItem>
-                  <SelectItem value="Building">Buildings</SelectItem>
-                  <SelectItem value="AssemblyPart">Assembly Parts</SelectItem>
+                  {SOFT_DELETE_ENTITIES.map((e) => (
+                    <SelectItem key={e} value={e}>{e === 'AssemblyPart' ? 'Assembly Parts' : `${e}s`}</SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
             </CardContent>
           </Card>
 
-          {/* Deleted Items Table */}
           <Card>
             <CardContent className="p-0">
               {loadingDeleted ? (
@@ -604,32 +1058,34 @@ export default function GovernancePage() {
                       <TableHead>Deleted By</TableHead>
                       <TableHead>Deleted At</TableHead>
                       <TableHead>Reason</TableHead>
-                      <TableHead className="w-[100px]"></TableHead>
+                      <TableHead className="w-[110px]" />
                     </TableRow>
                   </TableHeader>
                   <TableBody>
                     {deletedItems.map((item) => (
                       <TableRow key={item.id}>
                         <TableCell className="font-medium">{item.name}</TableCell>
-                        <TableCell>{item.deletedBy?.name || 'Unknown'}</TableCell>
+                        <TableCell className="text-sm">{item.deletedBy?.name || 'Unknown'}</TableCell>
                         <TableCell>
-                          <div className="text-sm">
-                            {format(new Date(item.deletedAt), 'MMM d, yyyy HH:mm')}
-                          </div>
+                          <div className="text-sm">{format(new Date(item.deletedAt), 'MMM d, yyyy HH:mm')}</div>
                           <div className="text-xs text-muted-foreground">
                             {formatDistanceToNow(new Date(item.deletedAt), { addSuffix: true })}
                           </div>
                         </TableCell>
-                        <TableCell className="max-w-[200px] truncate">
-                          {item.deleteReason || '-'}
+                        <TableCell className="max-w-[200px] truncate text-sm">
+                          {item.deleteReason || '—'}
                         </TableCell>
                         <TableCell>
                           <Button
                             variant="outline"
                             size="sm"
-                            onClick={() => handleRestore(deletedEntityType, item.id)}
+                            className="text-green-700 border-green-300 hover:bg-green-50"
+                            onClick={() => {
+                              setRestoreTarget(item);
+                              setShowRestoreDialog(true);
+                            }}
                           >
-                            <RotateCcw className="size-4 mr-1" />
+                            <RotateCcw className="size-3.5 mr-1" />
                             Restore
                           </Button>
                         </TableCell>
@@ -639,9 +1095,9 @@ export default function GovernancePage() {
                 </Table>
               ) : (
                 <div className="text-center py-12 text-muted-foreground">
-                  <Trash2 className="size-12 mx-auto mb-2 opacity-50" />
+                  <CheckCircle2 className="size-12 mx-auto mb-2 opacity-40 text-green-500" />
                   <p>No deleted {deletedEntityType.toLowerCase()}s</p>
-                  <p className="text-sm">Deleted items will appear here for recovery</p>
+                  <p className="text-sm">All items are active — nothing to recover here</p>
                 </div>
               )}
             </CardContent>
@@ -649,79 +1105,82 @@ export default function GovernancePage() {
         </TabsContent>
       </Tabs>
 
-      {/* Detail Dialog */}
-      <Dialog open={showDetailDialog} onOpenChange={setShowDetailDialog}>
-        <DialogContent className="max-w-2xl">
+      {/* ── Audit Detail Dialog ─────────────────────────────────────────── */}
+      <Dialog open={!!selectedLog} onOpenChange={(o) => !o && setSelectedLog(null)}>
+        <DialogContent className="max-w-2xl max-h-[85vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
               <FileText className="size-5" />
               Audit Log Details
             </DialogTitle>
-            <DialogDescription>
-              Full details of this audit entry
-            </DialogDescription>
+            <DialogDescription>Full context for this audit entry</DialogDescription>
           </DialogHeader>
           {selectedLog && (
             <div className="space-y-4">
               <div className="grid grid-cols-2 gap-4">
                 <div>
-                  <label className="text-sm font-medium text-muted-foreground">Action</label>
-                  <div className="mt-1">
-                    <Badge className={ACTION_COLORS[selectedLog.action] || 'bg-gray-100'}>
-                      {selectedLog.action}
-                    </Badge>
+                  <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Action</label>
+                  <div className="mt-1 flex items-center gap-2">
+                    <ActionBadge action={selectedLog.action} />
                   </div>
                 </div>
                 <div>
-                  <label className="text-sm font-medium text-muted-foreground">Entity Type</label>
+                  <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Source</label>
+                  <div className="mt-1">
+                    <SourceBadge sourceModule={selectedLog.sourceModule ?? null} />
+                  </div>
+                </div>
+                <div>
+                  <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Entity Type</label>
                   <div className="mt-1 font-medium">{selectedLog.entityType}</div>
                 </div>
                 <div>
-                  <label className="text-sm font-medium text-muted-foreground">Entity ID</label>
-                  <div className="mt-1 font-mono text-sm">{selectedLog.entityId}</div>
+                  <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Entity ID</label>
+                  <div className="mt-1 font-mono text-sm break-all">{selectedLog.entityId}</div>
                 </div>
                 <div>
-                  <label className="text-sm font-medium text-muted-foreground">Performed By</label>
-                  <div className="mt-1">{selectedLog.performedBy.name}</div>
+                  <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Performed By</label>
+                  <div className="mt-1 flex items-center gap-1.5">
+                    <User className="size-3.5" />
+                    {selectedLog.performedBy.name}
+                  </div>
                 </div>
                 <div>
-                  <label className="text-sm font-medium text-muted-foreground">Time</label>
-                  <div className="mt-1">{format(new Date(selectedLog.performedAt), 'PPpp')}</div>
-                </div>
-                <div>
-                  <label className="text-sm font-medium text-muted-foreground">Source</label>
-                  <div className="mt-1">{selectedLog.sourceModule || 'Unknown'}</div>
+                  <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Time</label>
+                  <div className="mt-1 text-sm">{format(new Date(selectedLog.performedAt), 'PPpp')}</div>
                 </div>
               </div>
-              
+
               {selectedLog.reason && (
                 <div>
-                  <label className="text-sm font-medium text-muted-foreground">Reason</label>
-                  <div className="mt-1 p-3 rounded-lg bg-muted">{selectedLog.reason}</div>
+                  <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Reason</label>
+                  <div className="mt-1 p-3 rounded-lg bg-muted text-sm">{selectedLog.reason}</div>
                 </div>
               )}
-              
+
               {selectedLog.changes && Object.keys(selectedLog.changes).length > 0 && (
                 <div>
-                  <label className="text-sm font-medium text-muted-foreground">Changes</label>
-                  <div className="mt-1 p-3 rounded-lg bg-muted overflow-auto max-h-[300px]">
+                  <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                    Field Changes ({Object.keys(selectedLog.changes).length})
+                  </label>
+                  <div className="mt-1 rounded-lg border overflow-auto max-h-[320px]">
                     <table className="w-full text-sm">
-                      <thead>
-                        <tr className="border-b">
-                          <th className="text-left py-2 pr-4">Field</th>
-                          <th className="text-left py-2 pr-4">Old Value</th>
-                          <th className="text-left py-2">New Value</th>
+                      <thead className="sticky top-0 bg-muted">
+                        <tr>
+                          <th className="text-left px-3 py-2 font-medium text-xs">Field</th>
+                          <th className="text-left px-3 py-2 font-medium text-xs text-red-600">Before</th>
+                          <th className="text-left px-3 py-2 font-medium text-xs text-green-600">After</th>
                         </tr>
                       </thead>
-                      <tbody>
+                      <tbody className="divide-y">
                         {Object.entries(selectedLog.changes).map(([field, change]) => (
-                          <tr key={field} className="border-b last:border-0">
-                            <td className="py-2 pr-4 font-medium">{field}</td>
-                            <td className="py-2 pr-4 text-red-600 dark:text-red-400">
-                              {JSON.stringify(change.old) || 'null'}
+                          <tr key={field} className="hover:bg-muted/30">
+                            <td className="px-3 py-2 font-medium font-mono text-xs">{field}</td>
+                            <td className="px-3 py-2 text-red-600 dark:text-red-400 font-mono text-xs max-w-[200px] truncate">
+                              {formatSnapshotValue(change.old)}
                             </td>
-                            <td className="py-2 text-green-600 dark:text-green-400">
-                              {JSON.stringify(change.new) || 'null'}
+                            <td className="px-3 py-2 text-green-600 dark:text-green-400 font-mono text-xs max-w-[200px] truncate">
+                              {formatSnapshotValue(change.new)}
                             </td>
                           </tr>
                         ))}
@@ -732,6 +1191,192 @@ export default function GovernancePage() {
               )}
             </div>
           )}
+        </DialogContent>
+      </Dialog>
+
+      {/* ── Version Detail / Diff Dialog ───────────────────────────────── */}
+      <Dialog open={showVersionDialog} onOpenChange={setShowVersionDialog}>
+        <DialogContent className="max-w-3xl max-h-[85vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <GitBranch className="size-5" />
+              {versionDiff ? `Version Comparison — v${selectedVersionA} vs v${selectedVersionB}` : `Version ${selectedVersionA} Snapshot`}
+            </DialogTitle>
+            {versionDetail && (
+              <DialogDescription>
+                {format(new Date(versionDetail.createdAt), 'PPpp')} · by {versionDetail.createdBy.name}
+                {versionDetail.changeReason && ` · ${versionDetail.changeReason}`}
+              </DialogDescription>
+            )}
+          </DialogHeader>
+
+          {versionDetail && (
+            <div className="space-y-4">
+              {/* Diff view */}
+              {versionDiff && (
+                <div className="space-y-3">
+                  {versionDiff.added.length > 0 && (
+                    <div>
+                      <p className="text-xs font-medium text-green-600 mb-1">Added Fields</p>
+                      <div className="flex flex-wrap gap-1">
+                        {versionDiff.added.map((f) => (
+                          <Badge key={f} className="bg-green-100 text-green-800 text-xs font-mono">{f}</Badge>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                  {versionDiff.removed.length > 0 && (
+                    <div>
+                      <p className="text-xs font-medium text-red-600 mb-1">Removed Fields</p>
+                      <div className="flex flex-wrap gap-1">
+                        {versionDiff.removed.map((f) => (
+                          <Badge key={f} className="bg-red-100 text-red-800 text-xs font-mono">{f}</Badge>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                  {Object.keys(versionDiff.changed).length > 0 && (
+                    <div>
+                      <p className="text-xs font-medium text-blue-600 mb-1">Changed Fields ({Object.keys(versionDiff.changed).length})</p>
+                      <div className="rounded-lg border overflow-auto max-h-[300px]">
+                        <table className="w-full text-xs">
+                          <thead className="sticky top-0 bg-muted">
+                            <tr>
+                              <th className="text-left px-3 py-2">Field</th>
+                              <th className="text-left px-3 py-2 text-red-600">v{selectedVersionA}</th>
+                              <th className="text-left px-3 py-2 text-green-600">v{selectedVersionB}</th>
+                            </tr>
+                          </thead>
+                          <tbody className="divide-y">
+                            {Object.entries(versionDiff.changed).map(([field, change]) => (
+                              <tr key={field} className="hover:bg-muted/30">
+                                <td className="px-3 py-2 font-mono font-medium">{field}</td>
+                                <td className="px-3 py-2 text-red-600 font-mono max-w-[200px] truncate">
+                                  {formatSnapshotValue(change.old)}
+                                </td>
+                                <td className="px-3 py-2 text-green-600 font-mono max-w-[200px] truncate">
+                                  {formatSnapshotValue(change.new)}
+                                </td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {/* Full snapshot */}
+              {!versionDiff && (
+                <div>
+                  <p className="text-xs font-medium text-muted-foreground mb-2">Full Snapshot</p>
+                  <div className="rounded-lg border overflow-auto max-h-[400px]">
+                    <table className="w-full text-xs">
+                      <thead className="sticky top-0 bg-muted">
+                        <tr>
+                          <th className="text-left px-3 py-2 font-medium">Field</th>
+                          <th className="text-left px-3 py-2 font-medium">Value</th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y">
+                        {Object.entries(versionDetail.snapshot).map(([field, value]) => (
+                          <tr key={field} className="hover:bg-muted/30">
+                            <td className="px-3 py-2 font-mono font-medium text-muted-foreground">{field}</td>
+                            <td className="px-3 py-2 font-mono max-w-[300px]">
+                              <span className="block truncate">{formatSnapshotValue(value)}</span>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              className="text-amber-600 border-amber-300 hover:bg-amber-50"
+              onClick={() => {
+                setShowVersionDialog(false);
+                if (selectedVersionA) {
+                  setRollbackTargetVersion(selectedVersionA);
+                  setShowRollbackDialog(true);
+                }
+              }}
+            >
+              <Undo2 className="size-4 mr-1.5" />
+              Restore to this version
+            </Button>
+            <Button variant="outline" onClick={() => setShowVersionDialog(false)}>
+              Close
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* ── Restore Confirmation Dialog ─────────────────────────────────── */}
+      <ConfirmationDialog
+        open={showRestoreDialog}
+        onOpenChange={setShowRestoreDialog}
+        type="warning"
+        title={`Restore ${restoreTarget?.name}?`}
+        description={`This will restore the ${deletedEntityType.toLowerCase()} and make it active again. All associated data will be re-linked. This action is reversible.`}
+        confirmText={restoring ? 'Restoring…' : 'Restore'}
+        cancelText="Cancel"
+        onConfirm={handleRestore}
+        onCancel={() => setRestoreTarget(null)}
+      />
+
+      {/* ── Version Rollback Dialog ─────────────────────────────────────── */}
+      <Dialog open={showRollbackDialog} onOpenChange={setShowRollbackDialog}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2 text-amber-700">
+              <Undo2 className="size-5" />
+              Restore to Version {rollbackTargetVersion}
+            </DialogTitle>
+            <DialogDescription>
+              This will overwrite the current {versionEntityType} data with the state from version {rollbackTargetVersion}.
+              The current state will be preserved in a new version. This action cannot be undone without another rollback.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div className="p-3 rounded-lg bg-amber-50 dark:bg-amber-950 border border-amber-200 dark:border-amber-800 text-sm text-amber-800 dark:text-amber-300 flex items-start gap-2">
+              <AlertCircle className="size-4 shrink-0 mt-0.5" />
+              <span>Only Admins and Managers can perform rollbacks. This action is logged in the audit trail.</span>
+            </div>
+            <div>
+              <Label htmlFor="rollback-reason">Reason for rollback <span className="text-destructive">*</span></Label>
+              <Textarea
+                id="rollback-reason"
+                placeholder="Explain why you are rolling back to this version…"
+                value={rollbackReason}
+                onChange={(e) => setRollbackReason(e.target.value)}
+                className="mt-1.5"
+                rows={3}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => { setShowRollbackDialog(false); setRollbackReason(''); }}
+            >
+              Cancel
+            </Button>
+            <Button
+              className="bg-amber-600 hover:bg-amber-700 text-white"
+              disabled={!rollbackReason.trim() || rollingBack}
+              onClick={handleRollback}
+            >
+              {rollingBack ? <Loader2 className="size-4 mr-1.5 animate-spin" /> : <Undo2 className="size-4 mr-1.5" />}
+              {rollingBack ? 'Applying rollback…' : `Restore to v${rollbackTargetVersion}`}
+            </Button>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
     </div>


### PR DESCRIPTION
Transforms the Governance Centre from a passive viewer into a fully interactive
control panel with actionable tools.

## Audit Trail
- Returns total count on all queries for accurate pagination
- New filters: date range (from/to), source type (user vs system)
- Source type filter: USER (UI/API) vs SYSTEM (SYNC/AI/CRON/SYSTEM)
- Visual differentiation: system events displayed with muted styling and bot
  icon, user actions with violet badge and monitor icon
- Source legend at top of tab explains the distinction clearly

## Version History (new tab)
- Browse full snapshots for versioned entities (Project, Building, QCInspection,
  WPS, ITP) by entering their UUID
- Timeline of versions with author, date, and change reason
- View any version's complete field snapshot in a readable table
- Compare two versions side-by-side with added/removed/changed field diff
- Rollback to any version via new POST /api/governance/versions endpoint
  - Applies snapshot data atomically, preserving system fields
  - Requires reason text and Admin/Manager role
  - Automatically creates an audit log entry for the rollback

## Deleted Items
- Restore now shows a confirmation dialog before acting (prevents accidental
  restores)
- Clearer empty state when no items need recovery

## API
- audit/route.ts: full Prisma-typed where clause, returns { logs, total }
  for all queries, supports dateFrom, dateTo, userId, sourceType params
- versions/route.ts: new POST handler with Zod validation, permission check,
  dynamic Prisma model update, and audit logging

https://claude.ai/code/session_01HR2PXJvZjht4yAQzvUzNvd