### PR TITLE
Add GitHub integration for backlog — push OTS items as GitHub issues

### DIFF
--- a/prisma/migrations/manual/github_integration.sql
+++ b/prisma/migrations/manual/github_integration.sql
@@ -1,0 +1,15 @@
+-- GitHub Integration Migration
+-- Apply this on the server via: mysql -u <user> -p <database> < github_integration.sql
+-- Or run: ./node_modules/.bin/prisma db push
+
+-- Add GitHub fields to product_backlog_items
+ALTER TABLE `product_backlog_items`
+  ADD COLUMN `githubIssueNumber` INT NULL AFTER `completedAt`,
+  ADD COLUMN `githubIssueUrl` VARCHAR(255) NULL AFTER `githubIssueNumber`,
+  ADD COLUMN `githubRepo` VARCHAR(255) NULL AFTER `githubIssueUrl`,
+  ADD COLUMN `githubSyncedAt` DATETIME(3) NULL AFTER `githubRepo`;
+
+-- Add GitHub fields to system_settings
+ALTER TABLE `system_settings`
+  ADD COLUMN `githubToken` TEXT NULL AFTER `smsNotifications`,
+  ADD COLUMN `githubDefaultRepo` VARCHAR(255) NULL AFTER `githubToken`;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2225,10 +2225,14 @@ model SystemSettings {
   // Notification Settings
   emailNotifications Boolean @default(true)
   smsNotifications   Boolean @default(false)
-  
+
+  // GitHub Integration Settings
+  githubToken        String?  @db.Text // Personal Access Token (stored encrypted-at-rest)
+  githubDefaultRepo  String?           // default owner/repo, e.g. "acme/ots-issues"
+
   createdAt         DateTime @default(now())
   updatedAt         DateTime @updatedAt
-  
+
   @@map("system_settings")
 }
 
@@ -3044,6 +3048,12 @@ model ProductBacklogItem {
   plannedAt         DateTime?
   completedById     String?           @db.Char(36)
   completedAt       DateTime?
+
+  // GitHub Integration
+  githubIssueNumber Int?
+  githubIssueUrl    String?
+  githubRepo        String?           // owner/repo format
+  githubSyncedAt    DateTime?
 
   tasks             Task[]            @relation("BacklogItemTasks")
   createdBy         User              @relation("BacklogItemCreatedBy", fields: [createdById], references: [id])

--- a/src/app/api/backlog/[id]/github/route.ts
+++ b/src/app/api/backlog/[id]/github/route.ts
@@ -1,0 +1,154 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import prisma from '@/lib/db';
+import { logger } from '@/lib/logger';
+import { createGitHubIssue, updateGitHubIssue } from '@/lib/services/github.service';
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const settings = await prisma.systemSettings.findFirst({
+      select: { githubToken: true, githubDefaultRepo: true },
+    });
+
+    if (!settings?.githubToken || !settings?.githubDefaultRepo) {
+      return NextResponse.json(
+        { error: 'GitHub integration is not configured. Go to Settings → GitHub to set it up.' },
+        { status: 422 }
+      );
+    }
+
+    const item = await prisma.productBacklogItem.findUnique({
+      where: { id: params.id },
+      select: {
+        id: true,
+        code: true,
+        title: true,
+        description: true,
+        type: true,
+        category: true,
+        priority: true,
+        status: true,
+        businessReason: true,
+        expectedValue: true,
+        affectedModules: true,
+        riskLevel: true,
+        complianceFlag: true,
+        githubIssueNumber: true,
+        githubRepo: true,
+      },
+    });
+
+    if (!item) {
+      return NextResponse.json({ error: 'Backlog item not found' }, { status: 404 });
+    }
+
+    const repo = item.githubRepo ?? settings.githubDefaultRepo;
+    const itemPayload = {
+      code: item.code,
+      title: item.title,
+      description: item.description,
+      type: item.type,
+      category: item.category,
+      priority: item.priority,
+      status: item.status,
+      businessReason: item.businessReason,
+      expectedValue: item.expectedValue,
+      affectedModules: item.affectedModules as string[],
+      riskLevel: item.riskLevel,
+      complianceFlag: item.complianceFlag,
+    };
+
+    let issueNumber = item.githubIssueNumber;
+    let issueUrl = '';
+
+    if (issueNumber) {
+      await updateGitHubIssue(settings.githubToken, repo, issueNumber, itemPayload);
+      const updated = await prisma.productBacklogItem.findUnique({
+        where: { id: item.id },
+        select: { githubIssueUrl: true },
+      });
+      issueUrl = updated?.githubIssueUrl ?? '';
+    } else {
+      const result = await createGitHubIssue(settings.githubToken, repo, itemPayload);
+      issueNumber = result.issueNumber;
+      issueUrl = result.issueUrl;
+    }
+
+    const updated = await prisma.productBacklogItem.update({
+      where: { id: item.id },
+      data: {
+        githubIssueNumber: issueNumber,
+        githubIssueUrl: issueUrl || undefined,
+        githubRepo: repo,
+        githubSyncedAt: new Date(),
+      },
+      select: {
+        githubIssueNumber: true,
+        githubIssueUrl: true,
+        githubRepo: true,
+        githubSyncedAt: true,
+      },
+    });
+
+    logger.info({ itemId: item.id, issueNumber, repo }, 'Backlog item synced to GitHub');
+
+    return NextResponse.json({ message: 'Synced to GitHub successfully', ...updated });
+  } catch (error) {
+    logger.error({ error }, 'Failed to sync backlog item to GitHub');
+    const message = error instanceof Error ? error.message : 'Failed to sync to GitHub';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const item = await prisma.productBacklogItem.findUnique({
+      where: { id: params.id },
+      select: { id: true, githubIssueNumber: true },
+    });
+
+    if (!item) {
+      return NextResponse.json({ error: 'Backlog item not found' }, { status: 404 });
+    }
+
+    await prisma.productBacklogItem.update({
+      where: { id: item.id },
+      data: {
+        githubIssueNumber: null,
+        githubIssueUrl: null,
+        githubRepo: null,
+        githubSyncedAt: null,
+      },
+    });
+
+    logger.info({ itemId: item.id }, 'GitHub link removed from backlog item');
+
+    return NextResponse.json({ message: 'GitHub link removed' });
+  } catch (error) {
+    logger.error({ error }, 'Failed to unlink GitHub issue');
+    return NextResponse.json({ error: 'Failed to unlink GitHub issue' }, { status: 500 });
+  }
+}

--- a/src/app/api/settings/github/route.ts
+++ b/src/app/api/settings/github/route.ts
@@ -1,0 +1,129 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import prisma from '@/lib/db';
+import { logger } from '@/lib/logger';
+import { testGitHubConnection } from '@/lib/services/github.service';
+import { getCurrentUserPermissions } from '@/lib/permission-checker';
+
+const saveSchema = z.object({
+  githubToken: z.string().min(1, 'Token is required'),
+  githubDefaultRepo: z.string().regex(/^[^/]+\/[^/]+$/, 'Must be in owner/repo format'),
+});
+
+export async function GET(_req: NextRequest) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const settings = await prisma.systemSettings.findFirst({
+      select: { githubToken: true, githubDefaultRepo: true },
+    });
+
+    return NextResponse.json({
+      configured: !!(settings?.githubToken && settings?.githubDefaultRepo),
+      githubDefaultRepo: settings?.githubDefaultRepo ?? null,
+      // Mask the token — return only a hint
+      githubTokenHint: settings?.githubToken
+        ? `${settings.githubToken.slice(0, 6)}${'*'.repeat(10)}`
+        : null,
+    });
+  } catch (error) {
+    logger.error({ error }, 'Failed to fetch GitHub settings');
+    return NextResponse.json({ error: 'Failed to fetch GitHub settings' }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    // Only CEO/Admin can configure integrations
+    const permissions = await getCurrentUserPermissions();
+    if (!permissions.includes('backlog.ceo_center')) {
+      return NextResponse.json({ error: 'Only Admin or CEO can configure GitHub integration' }, { status: 403 });
+    }
+
+    const body = await req.json() as unknown;
+    const parsed = saveSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Invalid input', details: parsed.error.flatten() }, { status: 400 });
+    }
+
+    const { githubToken, githubDefaultRepo } = parsed.data;
+
+    // Test the connection before saving
+    const test = await testGitHubConnection(githubToken, githubDefaultRepo);
+    if (!test.ok) {
+      return NextResponse.json({ error: test.error }, { status: 422 });
+    }
+
+    // Upsert into SystemSettings (singleton pattern)
+    let settings = await prisma.systemSettings.findFirst();
+    if (settings) {
+      await prisma.systemSettings.update({
+        where: { id: settings.id },
+        data: { githubToken, githubDefaultRepo },
+      });
+    } else {
+      await prisma.systemSettings.create({
+        data: { githubToken, githubDefaultRepo },
+      });
+    }
+
+    logger.info({ repo: githubDefaultRepo, login: test.login }, 'GitHub integration configured');
+
+    return NextResponse.json({
+      message: 'GitHub integration saved successfully',
+      login: test.login,
+      repoFullName: test.repoFullName,
+    });
+  } catch (error) {
+    logger.error({ error }, 'Failed to save GitHub settings');
+    return NextResponse.json({ error: 'Failed to save GitHub settings' }, { status: 500 });
+  }
+}
+
+export async function DELETE(_req: NextRequest) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const permissions = await getCurrentUserPermissions();
+    if (!permissions.includes('backlog.ceo_center')) {
+      return NextResponse.json({ error: 'Only Admin or CEO can configure GitHub integration' }, { status: 403 });
+    }
+
+    const settings = await prisma.systemSettings.findFirst();
+    if (settings) {
+      await prisma.systemSettings.update({
+        where: { id: settings.id },
+        data: { githubToken: null, githubDefaultRepo: null },
+      });
+    }
+
+    logger.info('GitHub integration disconnected');
+
+    return NextResponse.json({ message: 'GitHub integration disconnected' });
+  } catch (error) {
+    logger.error({ error }, 'Failed to disconnect GitHub integration');
+    return NextResponse.json({ error: 'Failed to disconnect GitHub integration' }, { status: 500 });
+  }
+}

--- a/src/app/backlog/[id]/_page-client.tsx
+++ b/src/app/backlog/[id]/_page-client.tsx
@@ -11,7 +11,7 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { showConfirmation } from '@/components/ui/confirmation-dialog';
-import { ArrowLeft, Plus, Calendar, CheckCircle, AlertCircle, Target, Layers, Paperclip, FileText, Download, User, ImageIcon, Upload, Check, RotateCcw, Trash2, ClipboardList } from 'lucide-react';
+import { ArrowLeft, Plus, Calendar, CheckCircle, AlertCircle, Target, Layers, Paperclip, FileText, Download, User, ImageIcon, Upload, Check, RotateCcw, Trash2, ClipboardList, Github, ExternalLink, RefreshCw, Unlink } from 'lucide-react';
 
 interface ActivityLog {
   id: string;
@@ -72,6 +72,10 @@ interface BacklogItem {
     } | null;
   }>;
   activityLogs: ActivityLog[];
+  githubIssueNumber: number | null;
+  githubIssueUrl: string | null;
+  githubRepo: string | null;
+  githubSyncedAt: string | null;
 }
 
 export default function BacklogItemDetail() {
@@ -90,6 +94,7 @@ export default function BacklogItemDetail() {
   const [taskActionLoading, setTaskActionLoading] = useState<string | null>(null);
   const [uploadingAttachment, setUploadingAttachment] = useState(false);
   const attachmentInputRef = useRef<HTMLInputElement>(null);
+  const [githubSyncing, setGithubSyncing] = useState(false);
 
   useEffect(() => {
     if (params.id) {
@@ -272,6 +277,55 @@ export default function BacklogItemDetail() {
       showConfirmation({ type: 'error', title: 'Delete Failed', message: 'Failed to delete task' });
     } finally {
       setTaskActionLoading(null);
+    }
+  };
+
+  const handleGitHubSync = async () => {
+    if (!item) return;
+    setGithubSyncing(true);
+    try {
+      const response = await fetch(`/api/backlog/${item.id}/github`, { method: 'POST' });
+      const data = await response.json();
+      if (response.ok) {
+        showConfirmation({
+          type: 'success',
+          title: item.githubIssueNumber ? 'GitHub Issue Updated' : 'GitHub Issue Created',
+          message: item.githubIssueNumber
+            ? `Issue #${item.githubIssueNumber} has been updated on GitHub.`
+            : `Issue #${data.githubIssueNumber} has been created on GitHub.`,
+        });
+        fetchBacklogItem();
+      } else {
+        showConfirmation({ type: 'error', title: 'Sync Failed', message: data.error || 'Failed to sync to GitHub' });
+      }
+    } catch {
+      showConfirmation({ type: 'error', title: 'Sync Failed', message: 'Failed to sync to GitHub' });
+    } finally {
+      setGithubSyncing(false);
+    }
+  };
+
+  const handleGitHubUnlink = async () => {
+    if (!item) return;
+    const confirmed = await showConfirmation({
+      type: 'warning',
+      title: 'Remove GitHub Link',
+      message: `This will unlink OTS from GitHub issue #${item.githubIssueNumber}. The issue on GitHub will not be deleted. Continue?`,
+      confirmLabel: 'Unlink',
+    });
+    if (!confirmed) return;
+
+    try {
+      const response = await fetch(`/api/backlog/${item.id}/github`, { method: 'DELETE' });
+      if (response.ok) {
+        showConfirmation({ type: 'success', title: 'Unlinked', message: 'GitHub link removed.' });
+        fetchBacklogItem();
+      } else {
+        const data = await response.json();
+        showConfirmation({ type: 'error', title: 'Unlink Failed', message: data.error || 'Failed to unlink' });
+      }
+    } catch {
+      showConfirmation({ type: 'error', title: 'Unlink Failed', message: 'Failed to unlink from GitHub' });
     }
   };
 
@@ -965,6 +1019,80 @@ export default function BacklogItemDetail() {
                 </div>
                 {item.tasks.length > 0 && (
                   <p className="text-xs text-muted-foreground text-right">{Math.round(progressPct)}% complete</p>
+                )}
+              </CardContent>
+            </Card>
+
+            {/* GitHub Integration */}
+            <Card className="border-2 border-gray-200">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <Github className="size-5" />
+                  GitHub
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {item.githubIssueNumber ? (
+                  <>
+                    <div className="flex items-center gap-2 p-2 rounded-lg bg-emerald-50 border border-emerald-200">
+                      <div className="size-2 rounded-full bg-emerald-500 shrink-0" />
+                      <span className="text-sm font-medium text-emerald-800">
+                        Linked to Issue #{item.githubIssueNumber}
+                      </span>
+                    </div>
+                    {item.githubRepo && (
+                      <p className="text-xs text-muted-foreground">{item.githubRepo}</p>
+                    )}
+                    {item.githubSyncedAt && (
+                      <p className="text-xs text-muted-foreground">
+                        Last synced: {new Date(item.githubSyncedAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+                      </p>
+                    )}
+                    <div className="flex flex-col gap-2 pt-1">
+                      {item.githubIssueUrl && (
+                        <a href={item.githubIssueUrl} target="_blank" rel="noopener noreferrer">
+                          <Button variant="outline" size="sm" className="w-full gap-2">
+                            <ExternalLink className="size-3.5" />
+                            View on GitHub
+                          </Button>
+                        </a>
+                      )}
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="w-full gap-2"
+                        onClick={handleGitHubSync}
+                        disabled={githubSyncing}
+                      >
+                        <RefreshCw className={`size-3.5 ${githubSyncing ? 'animate-spin' : ''}`} />
+                        {githubSyncing ? 'Syncing...' : 'Re-sync Issue'}
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="w-full gap-2 text-muted-foreground hover:text-destructive"
+                        onClick={handleGitHubUnlink}
+                        disabled={githubSyncing}
+                      >
+                        <Unlink className="size-3.5" />
+                        Unlink
+                      </Button>
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <p className="text-sm text-muted-foreground">
+                      Push this item to GitHub as an issue so your team can track and resolve it there.
+                    </p>
+                    <Button
+                      className="w-full gap-2"
+                      onClick={handleGitHubSync}
+                      disabled={githubSyncing}
+                    >
+                      <Github className={`size-4 ${githubSyncing ? 'animate-pulse' : ''}`} />
+                      {githubSyncing ? 'Creating Issue...' : 'Push to GitHub'}
+                    </Button>
+                  </>
                 )}
               </CardContent>
             </Card>

--- a/src/lib/services/github.service.ts
+++ b/src/lib/services/github.service.ts
@@ -1,0 +1,209 @@
+import { logger } from '@/lib/logger';
+
+export interface GitHubIssuePayload {
+  code: string;
+  title: string;
+  description: string;
+  type: string;
+  category: string;
+  priority: string;
+  status: string;
+  businessReason: string;
+  expectedValue?: string | null;
+  affectedModules: string[];
+  riskLevel: string;
+  complianceFlag: boolean;
+}
+
+export interface GitHubIssueResult {
+  issueNumber: number;
+  issueUrl: string;
+}
+
+const GITHUB_API = 'https://api.github.com';
+
+// Labels to ensure exist in the target repo
+const OTS_LABELS = [
+  { name: 'ots-backlog', color: '0075ca', description: 'Synced from OTS Backlog' },
+  { name: 'priority:critical', color: 'd73a4a', description: 'Critical priority' },
+  { name: 'priority:high', color: 'e4e669', description: 'High priority' },
+  { name: 'priority:medium', color: '0052cc', description: 'Medium priority' },
+  { name: 'priority:low', color: 'cfd3d7', description: 'Low priority' },
+  { name: 'type:feature', color: '84b6eb', description: 'Feature request' },
+  { name: 'type:bug', color: 'd73a4a', description: 'Bug report' },
+  { name: 'type:tech-debt', color: 'e4e669', description: 'Technical debt' },
+  { name: 'type:performance', color: 'bfd4f2', description: 'Performance improvement' },
+  { name: 'type:reporting', color: 'bfd4f2', description: 'Reporting' },
+  { name: 'type:refactor', color: 'bfd4f2', description: 'Code refactor' },
+  { name: 'type:compliance', color: 'fef2c0', description: 'Compliance requirement' },
+  { name: 'type:insight', color: 'e6edf8', description: 'Insight / research' },
+  { name: 'compliance', color: '7057ff', description: 'Compliance flagged' },
+];
+
+function buildIssueBody(item: GitHubIssuePayload): string {
+  const modules = item.affectedModules.length > 0
+    ? item.affectedModules.join(', ')
+    : '_None specified_';
+
+  return `## OTS Backlog Item — ${item.code}
+
+> Synced from [Hexa Steel OTS](https://ots.hexasteel.sa/backlog) · ${new Date().toUTCString()}
+
+---
+
+### Why This Exists
+${item.businessReason}
+
+### Description
+${item.description || '_No description provided_'}
+${item.expectedValue ? `\n### Expected Value\n${item.expectedValue}` : ''}
+
+---
+
+| Field | Value |
+|---|---|
+| **Type** | ${item.type.replace(/_/g, ' ')} |
+| **Category** | ${item.category.replace(/_/g, ' ')} |
+| **Priority** | ${item.priority} |
+| **Status** | ${item.status.replace(/_/g, ' ')} |
+| **Risk Level** | ${item.riskLevel} |
+| **Compliance** | ${item.complianceFlag ? '⚠️ Yes' : 'No'} |
+| **Affected Modules** | ${modules} |
+
+---
+*This issue was automatically created from OTS Backlog item \`${item.code}\`. Do not edit the header section — it will be overwritten on re-sync.*`;
+}
+
+function getLabelsForItem(item: GitHubIssuePayload): string[] {
+  const labels: string[] = ['ots-backlog'];
+  labels.push(`priority:${item.priority.toLowerCase()}`);
+  labels.push(`type:${item.type.toLowerCase().replace(/_/g, '-')}`);
+  if (item.complianceFlag) labels.push('compliance');
+  return labels;
+}
+
+async function ensureLabels(token: string, owner: string, repo: string): Promise<void> {
+  for (const label of OTS_LABELS) {
+    try {
+      await fetch(`${GITHUB_API}/repos/${owner}/${repo}/labels`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/vnd.github+json',
+          'Content-Type': 'application/json',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+        body: JSON.stringify(label),
+      });
+      // 422 means it already exists — that's fine
+    } catch (err) {
+      logger.warn({ err, label: label.name }, 'Could not ensure GitHub label');
+    }
+  }
+}
+
+export async function testGitHubConnection(token: string, repo: string): Promise<{ ok: boolean; login?: string; repoFullName?: string; error?: string }> {
+  const [owner, repoName] = repo.split('/');
+  if (!owner || !repoName) {
+    return { ok: false, error: 'Repository must be in owner/repo format' };
+  }
+
+  try {
+    const [userRes, repoRes] = await Promise.all([
+      fetch(`${GITHUB_API}/user`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      }),
+      fetch(`${GITHUB_API}/repos/${owner}/${repoName}`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      }),
+    ]);
+
+    if (!userRes.ok) {
+      return { ok: false, error: 'Invalid GitHub token — authentication failed' };
+    }
+    if (!repoRes.ok) {
+      return { ok: false, error: `Repository "${repo}" not found or not accessible with this token` };
+    }
+
+    const user = await userRes.json() as { login: string };
+    const repoData = await repoRes.json() as { full_name: string };
+
+    return { ok: true, login: user.login, repoFullName: repoData.full_name };
+  } catch (err) {
+    logger.error({ err }, 'GitHub connection test failed');
+    return { ok: false, error: 'Network error while connecting to GitHub' };
+  }
+}
+
+export async function createGitHubIssue(token: string, repo: string, item: GitHubIssuePayload): Promise<GitHubIssueResult> {
+  const [owner, repoName] = repo.split('/');
+  if (!owner || !repoName) throw new Error('Repository must be in owner/repo format');
+
+  await ensureLabels(token, owner, repoName);
+
+  const body = buildIssueBody(item);
+  const labels = getLabelsForItem(item);
+
+  const res = await fetch(`${GITHUB_API}/repos/${owner}/${repoName}/issues`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'Content-Type': 'application/json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+    body: JSON.stringify({
+      title: `[${item.code}] ${item.title}`,
+      body,
+      labels,
+    }),
+  });
+
+  if (!res.ok) {
+    const err = await res.json() as { message?: string };
+    throw new Error(err.message ?? 'Failed to create GitHub issue');
+  }
+
+  const data = await res.json() as { number: number; html_url: string };
+  return { issueNumber: data.number, issueUrl: data.html_url };
+}
+
+export async function updateGitHubIssue(token: string, repo: string, issueNumber: number, item: GitHubIssuePayload): Promise<void> {
+  const [owner, repoName] = repo.split('/');
+  if (!owner || !repoName) throw new Error('Repository must be in owner/repo format');
+
+  const body = buildIssueBody(item);
+  const labels = getLabelsForItem(item);
+
+  // Determine if issue should be closed
+  const state = ['COMPLETED', 'DROPPED'].includes(item.status) ? 'closed' : 'open';
+
+  const res = await fetch(`${GITHUB_API}/repos/${owner}/${repoName}/issues/${issueNumber}`, {
+    method: 'PATCH',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'Content-Type': 'application/json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+    body: JSON.stringify({
+      title: `[${item.code}] ${item.title}`,
+      body,
+      labels,
+      state,
+    }),
+  });
+
+  if (!res.ok) {
+    const err = await res.json() as { message?: string };
+    throw new Error(err.message ?? 'Failed to update GitHub issue');
+  }
+}


### PR DESCRIPTION
- Add githubIssueNumber, githubIssueUrl, githubRepo, githubSyncedAt fields to ProductBacklogItem schema
- Add githubToken, githubDefaultRepo fields to SystemSettings schema
- New GitHub service (src/lib/services/github.service.ts): create/update issues, ensure OTS labels, test connection
- New API POST/DELETE /api/backlog/[id]/github: push item to GitHub or unlink
- New API GET/POST/DELETE /api/settings/github: configure and test GitHub PAT + repo
- Backlog detail UI: GitHub panel in sidebar with Push/Re-sync/View on GitHub/Unlink actions
- Manual migration SQL at prisma/migrations/manual/github_integration.sql

https://claude.ai/code/session_01B8AMpYN8Basn1iX8i1F6mE