### PR TITLE
feat: v16.2.0 — Cost Classification Mapping (Product Categories & Supplier Classification)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [16.2.0] - 2026-03-24
+
+### 🏷️ Cost Classification Mapping — Product Categories & Supplier Classification
+
+**Minor Release:** Introduces a complete 3-table cost classification system so every supplier invoice line is accurately categorised in all financial reports. The old single-fallback approach (account mapping only, then "Other/Unclassified") is replaced by a 4-level hierarchy.
+
+#### Added
+
+**Product Categories** (`fin_product_categories`)
+- New table that stores named categories with a cost classification (e.g. Raw Materials) and an optional Chart-of-Accounts account code
+- Bilingual support (English name + optional Arabic name)
+- `GET /api/financial/product-categories` — list all categories with mapped product count and COA account name
+- `POST /api/financial/product-categories` — create a category
+- `PUT /api/financial/product-categories/[id]` — update name, classification, COA code, or active flag
+- `DELETE /api/financial/product-categories/[id]` — delete (blocked if product mappings exist)
+- New page `/financial/product-categories` — tabbed UI: manage categories + assign product refs to categories
+
+**Product Category Mapping** (`fin_product_category_mapping`)
+- New table that maps a Dolibarr `product_ref` to a `fin_product_categories` row
+- `GET /api/financial/product-category-mapping` — existing mappings + list of unmapped product refs (sorted by spend)
+- `POST /api/financial/product-category-mapping` — create mapping
+- `PUT /api/financial/product-category-mapping/[id]` — change category
+- `DELETE /api/financial/product-category-mapping/[id]` — remove mapping
+- Unmapped products tab shows all invoice product refs without a mapping so nothing is missed
+
+**Supplier Classification** (`fin_supplier_classification`)
+- New table that assigns a default cost category (and optional COA code) to a Dolibarr supplier
+- Serves as the third-level fallback after account mapping and product category mapping
+- `GET /api/financial/supplier-classification` — classified suppliers + unclassified suppliers sorted by total spend
+- `POST /api/financial/supplier-classification` — classify a supplier
+- `PUT /api/financial/supplier-classification/[id]` — update category or COA code
+- `DELETE /api/financial/supplier-classification/[id]` — remove classification
+- New page `/financial/supplier-classification` — inline explanation of priority order, unclassified suppliers with one-click assign, classified table with edit/delete
+
+**DB Migration**
+- `prisma/migrations/add_cost_classification_mapping.sql` — creates all 3 tables with proper indexes, FK constraints, and audit columns (`created_by`, `updated_by`)
+
+#### Changed
+
+**4-Level Classification Hierarchy in All Financial Reports**
+- SQL queries in `getProjectCostStructure()` and `getExpensesAnalysis()` now use:
+  ```
+  COALESCE(
+    account_mapping.ots_cost_category,      -- 1. Dolibarr account code mapping
+    product_category.cost_classification,    -- 2. Product ref → category mapping
+    supplier_classification.cost_category,   -- 3. Supplier default category
+    'Other / Unclassified'                   -- 4. Fallback
+  )
+  ```
+- Monthly trend query replaced: removed the old keyword pattern-matching CASE (`LIKE '%raw%'`, `LIKE '%transport%'`, etc.) with the same 4-level COALESCE using the new tables
+- All affected queries now LEFT JOIN `fin_product_category_mapping`, `fin_product_categories`, and `fin_supplier_classification`
+
+**Sidebar Navigation (Financial)**
+- Added **Product Categories** → `/financial/product-categories`
+- Added **Supplier Classification** → `/financial/supplier-classification`
+
+---
+
 ## [16.1.2] - 2026-03-23
 
 ### 🐛 PTS Source Fix & Production Logs Project Filter

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Project Overview
 Enterprise ERP for steel fabrication projects. Next.js 15 App Router + TypeScript + Prisma + MySQL.
 Deployed at `hexasteel.sa/ots` with optional `NEXT_PUBLIC_BASE_PATH` subpath.
-**Current version:** `16.1.2` — PTS Source Fix & Production Logs Project Filter (Patch Release)
+**Current version:** `16.2.0` — Cost Classification Mapping: Product Categories & Supplier Classification (Minor Release)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,11 @@ A comprehensive Enterprise Resource Planning (ERP) system specifically designed 
 - **Bank Account Management**: Multi-account tracking and reconciliation
 - **Financial Reports**: Balance Sheet, Income Statement, Cash Flow Statement
 - **Invoice Management**: Client invoicing and payment tracking
-- **Account Mapping**: Automated account classification
+- **Account Mapping**: Map Dolibarr accounting account codes to OTS cost categories
+- **Product Categories**: Define named product categories that carry a cost classification and an optional Chart-of-Accounts account code (bilingual EN/AR support)
+- **Product Category Mapping**: Map each Dolibarr `product_ref` to a category so every invoice line is classified accurately; unmapped products surfaced for quick resolution
+- **Supplier Classification**: Assign a default cost category to each supplier — used as a fallback when no account or product mapping exists
+- **4-Level Classification Hierarchy**: Account Mapping → Product Category → Supplier Classification → Other/Unclassified, applied across all cost structure and expenses reports
 
 ### Procurement
 - **Purchase Orders**: Complete PO lifecycle management
@@ -61,7 +65,7 @@ A comprehensive Enterprise Resource Planning (ERP) system specifically designed 
 - **Dolibarr ERP Integration**: Bi-directional sync with Dolibarr (products, POs, reference data)
 - **Procurement Timeline**: Integration with operations timeline
 
-### Supply Chain Management (v16.1.2)
+### Supply Chain Management (v16.2.0)
 - **LCR (Least Cost Routing)**: Automated procurement tracking with Google Sheets integration
 - **Google Sheets Sync**: Real-time sync with MD5 hash change detection and intelligent upserts
 - **Alias Resolution**: Auto-resolve project/building/supplier names from informal sheet text; fetches all Dolibarr suppliers via auto-pagination
@@ -471,6 +475,6 @@ Proprietary software — All rights reserved by Hexa Steel®.
 
 ---
 
-**Version**: 16.1.2
+**Version**: 16.2.0
 **Last Updated**: March 2026
 **Repository**: https://github.com/refedo/OTS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexa-steel-ots",
-  "version": "16.1.2",
+  "version": "16.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/prisma/migrations/add_cost_classification_mapping.sql
+++ b/prisma/migrations/add_cost_classification_mapping.sql
@@ -1,0 +1,70 @@
+-- Migration: Add cost classification mapping tables
+-- Implements 3 new tables:
+--   1. fin_product_categories      - Category definitions (name + classification + COA account)
+--   2. fin_product_category_mapping - Maps Dolibarr product_ref to a category
+--   3. fin_supplier_classification  - Maps supplier (Dolibarr socid) to a default cost category
+--
+-- Classification priority in reports:
+--   1. fin_dolibarr_account_mapping (existing - highest priority)
+--   2. fin_product_category_mapping (by product_ref)
+--   3. fin_supplier_classification  (by supplier_id)
+--   4. 'Other / Unclassified'       (default)
+
+-- -----------------------------------------------------------------------
+-- 1. Product Categories
+--    A reusable category that carries a cost classification AND an optional
+--    link to a Chart-of-Accounts account code.
+-- -----------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS fin_product_categories (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(100) NOT NULL COMMENT 'Category name in English',
+  name_ar VARCHAR(100) NULL COMMENT 'Category name in Arabic (optional)',
+  cost_classification VARCHAR(100) NOT NULL COMMENT 'OTS cost classification (e.g. Raw Materials)',
+  coa_account_code VARCHAR(20) NULL COMMENT 'Maps to fin_chart_of_accounts.account_code',
+  description TEXT NULL,
+  color VARCHAR(20) NULL COMMENT 'Hex color for UI display',
+  is_active TINYINT(1) NOT NULL DEFAULT 1,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  created_by INT NULL,
+  updated_by INT NULL,
+  UNIQUE KEY uk_product_category_name (name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- -----------------------------------------------------------------------
+-- 2. Product Category Mapping
+--    Links a Dolibarr product_ref (or a product_label pattern) to a
+--    fin_product_categories row.
+-- -----------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS fin_product_category_mapping (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  product_ref VARCHAR(100) NOT NULL COMMENT 'Dolibarr product reference (fin_supplier_invoice_lines.product_ref)',
+  product_label_hint VARCHAR(255) NULL COMMENT 'Optional label hint shown in UI',
+  category_id INT NOT NULL COMMENT 'FK -> fin_product_categories.id',
+  notes TEXT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  created_by INT NULL,
+  updated_by INT NULL,
+  UNIQUE KEY uk_product_ref (product_ref),
+  CONSTRAINT fk_pcm_category FOREIGN KEY (category_id) REFERENCES fin_product_categories (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- -----------------------------------------------------------------------
+-- 3. Supplier Classification
+--    Default cost classification for a supplier.  Used when no account
+--    mapping or product category mapping exists for an invoice line.
+-- -----------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS fin_supplier_classification (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  supplier_id INT NOT NULL COMMENT 'Dolibarr thirdparty rowid (fin_supplier_invoices.socid)',
+  supplier_name VARCHAR(255) NULL COMMENT 'Cached supplier name for quick display',
+  cost_category VARCHAR(100) NOT NULL COMMENT 'OTS cost category applied to all lines from this supplier',
+  coa_account_code VARCHAR(20) NULL COMMENT 'Optional default COA account code for this supplier',
+  notes TEXT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  created_by INT NULL,
+  updated_by INT NULL,
+  UNIQUE KEY uk_supplier_id (supplier_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/app/api/financial/product-categories/[id]/route.ts
+++ b/src/app/api/financial/product-categories/[id]/route.ts
@@ -1,0 +1,89 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import prisma from '@/lib/db';
+import { requireFinancialPermission } from '@/lib/financial/require-financial-permission';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+const updateSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  name_ar: z.string().max(100).optional().nullable(),
+  cost_classification: z.string().min(1).max(100).optional(),
+  coa_account_code: z.string().max(20).optional().nullable(),
+  description: z.string().optional().nullable(),
+  color: z.string().max(20).optional().nullable(),
+  is_active: z.boolean().optional(),
+});
+
+export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await requireFinancialPermission('financial.manage');
+  if ('error' in auth) return auth.error;
+
+  const { id } = await params;
+  const numId = parseInt(id, 10);
+  if (isNaN(numId)) return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
+
+  const body = await req.json();
+  const parsed = updateSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input', details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const { name, name_ar, cost_classification, coa_account_code, description, color, is_active } = parsed.data;
+
+  try {
+    await prisma.$executeRawUnsafe(
+      `UPDATE fin_product_categories SET
+        name = COALESCE(?, name),
+        name_ar = ?,
+        cost_classification = COALESCE(?, cost_classification),
+        coa_account_code = ?,
+        description = ?,
+        color = ?,
+        is_active = COALESCE(?, is_active),
+        updated_by = ?,
+        updated_at = NOW()
+       WHERE id = ?`,
+      name ?? null, name_ar ?? null, cost_classification ?? null,
+      coa_account_code ?? null, description ?? null, color ?? null,
+      is_active !== undefined ? (is_active ? 1 : 0) : null,
+      auth.userId ?? null, numId,
+    );
+
+    logger.info({ id: numId }, 'Product category updated');
+    return NextResponse.json({ success: true });
+  } catch (error: unknown) {
+    logger.error({ error }, 'Failed to update product category');
+    return NextResponse.json({ error: 'Failed to update product category' }, { status: 500 });
+  }
+}
+
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await requireFinancialPermission('financial.manage');
+  if ('error' in auth) return auth.error;
+
+  const { id } = await params;
+  const numId = parseInt(id, 10);
+  if (isNaN(numId)) return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
+
+  try {
+    const mappings: unknown[] = await prisma.$queryRawUnsafe(
+      `SELECT COUNT(*) as cnt FROM fin_product_category_mapping WHERE category_id = ?`, numId,
+    );
+    const cnt = Number((mappings as Record<string, unknown>[])[0]?.cnt ?? 0);
+    if (cnt > 0) {
+      return NextResponse.json(
+        { error: `Cannot delete: ${cnt} product mapping(s) use this category. Remove them first.` },
+        { status: 409 },
+      );
+    }
+
+    await prisma.$executeRawUnsafe(`DELETE FROM fin_product_categories WHERE id = ?`, numId);
+    logger.info({ id: numId }, 'Product category deleted');
+    return NextResponse.json({ success: true });
+  } catch (error: unknown) {
+    logger.error({ error }, 'Failed to delete product category');
+    return NextResponse.json({ error: 'Failed to delete product category' }, { status: 500 });
+  }
+}

--- a/src/app/api/financial/product-categories/route.ts
+++ b/src/app/api/financial/product-categories/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import prisma from '@/lib/db';
+import { requireFinancialPermission } from '@/lib/financial/require-financial-permission';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+const createSchema = z.object({
+  name: z.string().min(1).max(100),
+  name_ar: z.string().max(100).optional().nullable(),
+  cost_classification: z.string().min(1).max(100),
+  coa_account_code: z.string().max(20).optional().nullable(),
+  description: z.string().optional().nullable(),
+  color: z.string().max(20).optional().nullable(),
+});
+
+export async function GET() {
+  const auth = await requireFinancialPermission('financial.view');
+  if ('error' in auth) return auth.error;
+
+  try {
+    const categories: unknown[] = await prisma.$queryRawUnsafe(`
+      SELECT
+        pc.*,
+        coa.account_name as coa_account_name,
+        (SELECT COUNT(*) FROM fin_product_category_mapping pcm WHERE pcm.category_id = pc.id) as mapped_products
+      FROM fin_product_categories pc
+      LEFT JOIN fin_chart_of_accounts coa ON coa.account_code = pc.coa_account_code
+      ORDER BY pc.name ASC
+    `);
+
+    return NextResponse.json({ categories });
+  } catch (error: unknown) {
+    logger.error({ error }, 'Failed to fetch product categories');
+    return NextResponse.json({ error: 'Failed to fetch product categories' }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await requireFinancialPermission('financial.manage');
+  if ('error' in auth) return auth.error;
+
+  const body = await req.json();
+  const parsed = createSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input', details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const { name, name_ar, cost_classification, coa_account_code, description, color } = parsed.data;
+
+  try {
+    await prisma.$executeRawUnsafe(
+      `INSERT INTO fin_product_categories (name, name_ar, cost_classification, coa_account_code, description, color, created_by)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      name, name_ar ?? null, cost_classification, coa_account_code ?? null,
+      description ?? null, color ?? null, auth.userId ?? null,
+    );
+
+    const rows: unknown[] = await prisma.$queryRawUnsafe(
+      `SELECT * FROM fin_product_categories WHERE name = ? LIMIT 1`, name,
+    );
+
+    logger.info({ name, cost_classification }, 'Product category created');
+    return NextResponse.json({ category: (rows as Record<string, unknown>[])[0] }, { status: 201 });
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : 'Unknown error';
+    if (msg.includes('Duplicate') || msg.includes('uk_product_category_name')) {
+      return NextResponse.json({ error: `Category "${name}" already exists` }, { status: 409 });
+    }
+    logger.error({ error }, 'Failed to create product category');
+    return NextResponse.json({ error: 'Failed to create product category' }, { status: 500 });
+  }
+}

--- a/src/app/api/financial/product-category-mapping/[id]/route.ts
+++ b/src/app/api/financial/product-category-mapping/[id]/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import prisma from '@/lib/db';
+import { requireFinancialPermission } from '@/lib/financial/require-financial-permission';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+const updateSchema = z.object({
+  category_id: z.number().int().positive().optional(),
+  product_label_hint: z.string().max(255).optional().nullable(),
+  notes: z.string().optional().nullable(),
+});
+
+export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await requireFinancialPermission('financial.manage');
+  if ('error' in auth) return auth.error;
+
+  const { id } = await params;
+  const numId = parseInt(id, 10);
+  if (isNaN(numId)) return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
+
+  const body = await req.json();
+  const parsed = updateSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input', details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const { category_id, product_label_hint, notes } = parsed.data;
+
+  try {
+    await prisma.$executeRawUnsafe(
+      `UPDATE fin_product_category_mapping SET
+        category_id = COALESCE(?, category_id),
+        product_label_hint = ?,
+        notes = ?,
+        updated_by = ?,
+        updated_at = NOW()
+       WHERE id = ?`,
+      category_id ?? null, product_label_hint ?? null, notes ?? null, auth.userId ?? null, numId,
+    );
+
+    logger.info({ id: numId }, 'Product category mapping updated');
+    return NextResponse.json({ success: true });
+  } catch (error: unknown) {
+    logger.error({ error }, 'Failed to update product category mapping');
+    return NextResponse.json({ error: 'Failed to update product category mapping' }, { status: 500 });
+  }
+}
+
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await requireFinancialPermission('financial.manage');
+  if ('error' in auth) return auth.error;
+
+  const { id } = await params;
+  const numId = parseInt(id, 10);
+  if (isNaN(numId)) return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
+
+  try {
+    await prisma.$executeRawUnsafe(`DELETE FROM fin_product_category_mapping WHERE id = ?`, numId);
+    logger.info({ id: numId }, 'Product category mapping deleted');
+    return NextResponse.json({ success: true });
+  } catch (error: unknown) {
+    logger.error({ error }, 'Failed to delete product category mapping');
+    return NextResponse.json({ error: 'Failed to delete product category mapping' }, { status: 500 });
+  }
+}

--- a/src/app/api/financial/product-category-mapping/route.ts
+++ b/src/app/api/financial/product-category-mapping/route.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import prisma from '@/lib/db';
+import { requireFinancialPermission } from '@/lib/financial/require-financial-permission';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+const createSchema = z.object({
+  product_ref: z.string().min(1).max(100),
+  product_label_hint: z.string().max(255).optional().nullable(),
+  category_id: z.number().int().positive(),
+  notes: z.string().optional().nullable(),
+});
+
+export async function GET() {
+  const auth = await requireFinancialPermission('financial.view');
+  if ('error' in auth) return auth.error;
+
+  try {
+    const mappings: unknown[] = await prisma.$queryRawUnsafe(`
+      SELECT
+        pcm.*,
+        pc.name as category_name,
+        pc.name_ar as category_name_ar,
+        pc.cost_classification,
+        pc.coa_account_code,
+        pc.color as category_color,
+        (
+          SELECT COUNT(*) FROM fin_supplier_invoice_lines sil
+          WHERE sil.product_ref = pcm.product_ref
+        ) as line_count,
+        (
+          SELECT ROUND(SUM(sil.total_ht), 2)
+          FROM fin_supplier_invoice_lines sil
+          JOIN fin_supplier_invoices si ON si.dolibarr_id = sil.invoice_dolibarr_id
+          WHERE sil.product_ref = pcm.product_ref AND si.is_active = 1
+        ) as total_ht
+      FROM fin_product_category_mapping pcm
+      JOIN fin_product_categories pc ON pc.id = pcm.category_id
+      ORDER BY pcm.product_ref ASC
+    `);
+
+    // Also return list of unmapped product refs that appear in invoices
+    const unmapped: unknown[] = await prisma.$queryRawUnsafe(`
+      SELECT
+        sil.product_ref,
+        MIN(sil.product_label) as product_label,
+        COUNT(*) as line_count,
+        ROUND(SUM(sil.total_ht), 2) as total_ht
+      FROM fin_supplier_invoice_lines sil
+      JOIN fin_supplier_invoices si ON si.dolibarr_id = sil.invoice_dolibarr_id
+      WHERE si.is_active = 1
+        AND sil.product_ref IS NOT NULL
+        AND sil.product_ref != ''
+        AND sil.product_ref NOT IN (
+          SELECT product_ref FROM fin_product_category_mapping
+        )
+      GROUP BY sil.product_ref
+      ORDER BY total_ht DESC
+      LIMIT 200
+    `);
+
+    return NextResponse.json({ mappings, unmapped });
+  } catch (error: unknown) {
+    logger.error({ error }, 'Failed to fetch product category mappings');
+    return NextResponse.json({ error: 'Failed to fetch product category mappings' }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await requireFinancialPermission('financial.manage');
+  if ('error' in auth) return auth.error;
+
+  const body = await req.json();
+  const parsed = createSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input', details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const { product_ref, product_label_hint, category_id, notes } = parsed.data;
+
+  try {
+    await prisma.$executeRawUnsafe(
+      `INSERT INTO fin_product_category_mapping (product_ref, product_label_hint, category_id, notes, created_by)
+       VALUES (?, ?, ?, ?, ?)`,
+      product_ref, product_label_hint ?? null, category_id, notes ?? null, auth.userId ?? null,
+    );
+
+    logger.info({ product_ref, category_id }, 'Product category mapping created');
+    return NextResponse.json({ success: true }, { status: 201 });
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : 'Unknown error';
+    if (msg.includes('Duplicate') || msg.includes('uk_product_ref')) {
+      return NextResponse.json({ error: `Product ref "${product_ref}" is already mapped` }, { status: 409 });
+    }
+    logger.error({ error }, 'Failed to create product category mapping');
+    return NextResponse.json({ error: 'Failed to create product category mapping' }, { status: 500 });
+  }
+}

--- a/src/app/api/financial/supplier-classification/[id]/route.ts
+++ b/src/app/api/financial/supplier-classification/[id]/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import prisma from '@/lib/db';
+import { requireFinancialPermission } from '@/lib/financial/require-financial-permission';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+const updateSchema = z.object({
+  cost_category: z.string().min(1).max(100).optional(),
+  coa_account_code: z.string().max(20).optional().nullable(),
+  notes: z.string().optional().nullable(),
+});
+
+export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await requireFinancialPermission('financial.manage');
+  if ('error' in auth) return auth.error;
+
+  const { id } = await params;
+  const numId = parseInt(id, 10);
+  if (isNaN(numId)) return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
+
+  const body = await req.json();
+  const parsed = updateSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input', details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const { cost_category, coa_account_code, notes } = parsed.data;
+
+  try {
+    await prisma.$executeRawUnsafe(
+      `UPDATE fin_supplier_classification SET
+        cost_category = COALESCE(?, cost_category),
+        coa_account_code = ?,
+        notes = ?,
+        updated_by = ?,
+        updated_at = NOW()
+       WHERE id = ?`,
+      cost_category ?? null, coa_account_code ?? null, notes ?? null, auth.userId ?? null, numId,
+    );
+
+    logger.info({ id: numId }, 'Supplier classification updated');
+    return NextResponse.json({ success: true });
+  } catch (error: unknown) {
+    logger.error({ error }, 'Failed to update supplier classification');
+    return NextResponse.json({ error: 'Failed to update supplier classification' }, { status: 500 });
+  }
+}
+
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await requireFinancialPermission('financial.manage');
+  if ('error' in auth) return auth.error;
+
+  const { id } = await params;
+  const numId = parseInt(id, 10);
+  if (isNaN(numId)) return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
+
+  try {
+    await prisma.$executeRawUnsafe(`DELETE FROM fin_supplier_classification WHERE id = ?`, numId);
+    logger.info({ id: numId }, 'Supplier classification deleted');
+    return NextResponse.json({ success: true });
+  } catch (error: unknown) {
+    logger.error({ error }, 'Failed to delete supplier classification');
+    return NextResponse.json({ error: 'Failed to delete supplier classification' }, { status: 500 });
+  }
+}

--- a/src/app/api/financial/supplier-classification/route.ts
+++ b/src/app/api/financial/supplier-classification/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import prisma from '@/lib/db';
+import { requireFinancialPermission } from '@/lib/financial/require-financial-permission';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+const createSchema = z.object({
+  supplier_id: z.number().int().positive(),
+  supplier_name: z.string().max(255).optional().nullable(),
+  cost_category: z.string().min(1).max(100),
+  coa_account_code: z.string().max(20).optional().nullable(),
+  notes: z.string().optional().nullable(),
+});
+
+export async function GET() {
+  const auth = await requireFinancialPermission('financial.view');
+  if ('error' in auth) return auth.error;
+
+  try {
+    const classifications: unknown[] = await prisma.$queryRawUnsafe(`
+      SELECT
+        sc.*,
+        coa.account_name as coa_account_name,
+        (
+          SELECT COUNT(DISTINCT si.dolibarr_id)
+          FROM fin_supplier_invoices si
+          WHERE si.socid = sc.supplier_id AND si.is_active = 1
+        ) as invoice_count,
+        (
+          SELECT ROUND(SUM(si.total_ht), 2)
+          FROM fin_supplier_invoices si
+          WHERE si.socid = sc.supplier_id AND si.is_active = 1
+        ) as total_ht
+      FROM fin_supplier_classification sc
+      LEFT JOIN fin_chart_of_accounts coa ON coa.account_code = sc.coa_account_code
+      ORDER BY sc.supplier_name ASC
+    `);
+
+    // Suppliers that appear in invoices but are not yet classified
+    const unclassified: unknown[] = await prisma.$queryRawUnsafe(`
+      SELECT
+        si.socid as supplier_id,
+        dt.name as supplier_name,
+        COUNT(DISTINCT si.dolibarr_id) as invoice_count,
+        ROUND(SUM(si.total_ht), 2) as total_ht
+      FROM fin_supplier_invoices si
+      LEFT JOIN dolibarr_thirdparties dt ON dt.dolibarr_id = si.socid
+      WHERE si.is_active = 1
+        AND si.socid NOT IN (SELECT supplier_id FROM fin_supplier_classification)
+      GROUP BY si.socid, dt.name
+      ORDER BY total_ht DESC
+      LIMIT 200
+    `);
+
+    return NextResponse.json({ classifications, unclassified });
+  } catch (error: unknown) {
+    logger.error({ error }, 'Failed to fetch supplier classifications');
+    return NextResponse.json({ error: 'Failed to fetch supplier classifications' }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await requireFinancialPermission('financial.manage');
+  if ('error' in auth) return auth.error;
+
+  const body = await req.json();
+  const parsed = createSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input', details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const { supplier_id, supplier_name, cost_category, coa_account_code, notes } = parsed.data;
+
+  try {
+    await prisma.$executeRawUnsafe(
+      `INSERT INTO fin_supplier_classification (supplier_id, supplier_name, cost_category, coa_account_code, notes, created_by)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      supplier_id, supplier_name ?? null, cost_category, coa_account_code ?? null, notes ?? null, auth.userId ?? null,
+    );
+
+    logger.info({ supplier_id, cost_category }, 'Supplier classification created');
+    return NextResponse.json({ success: true }, { status: 201 });
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : 'Unknown error';
+    if (msg.includes('Duplicate') || msg.includes('uk_supplier_id')) {
+      return NextResponse.json({ error: `Supplier ${supplier_id} is already classified` }, { status: 409 });
+    }
+    logger.error({ error }, 'Failed to create supplier classification');
+    return NextResponse.json({ error: 'Failed to create supplier classification' }, { status: 500 });
+  }
+}

--- a/src/app/api/system/latest-version/route.ts
+++ b/src/app/api/system/latest-version/route.ts
@@ -7,55 +7,75 @@ import { APP_VERSION } from '@/lib/version';
 // This should match the latest version in changelog
 const CURRENT_VERSION = {
   ...APP_VERSION,
-  mainTitle: '🔧 Supply Chain UX Improvements & Dolibarr Integrations',
+  mainTitle: '🏷️ Cost Classification Mapping — Product Categories & Supplier Classification',
   highlights: [
-    'New Purchase Orders page at /supply-chain/purchase-orders shows Dolibarr POs with status, supplier, project, and totals',
-    'Supply Chain sidebar now links to Purchase Orders, AP Aging Report (pre-selected), and Statement of Account',
-    'LCR filter bar redesigned into a single row — project and status dropdowns no longer overlap',
-    'Alias management now fetches ALL Dolibarr suppliers via auto-pagination (was capped at 200)',
-    'Aging Report reads ?type=payable URL param to pre-select Accounts Payable automatically',
+    'New Product Categories system: define named categories that carry a cost classification and an optional Chart-of-Accounts account code',
+    'Product Category Mapping: map each Dolibarr product reference to a category so every invoice line is classified accurately',
+    'Supplier Classification: assign a default cost category to each supplier, used as a fallback when no account or product mapping exists',
+    '4-level classification hierarchy in all financial reports: Account Mapping → Product Category → Supplier Classification → Other/Unclassified',
+    'New sidebar entries: Product Categories and Supplier Classification under Financial',
   ],
   changes: {
     added: [
       {
-        title: 'Purchase Orders Page',
+        title: 'Product Categories',
         items: [
-          'New page /supply-chain/purchase-orders — lists Dolibarr purchase orders in OTS',
-          'Status badges (Draft / Validated / Approved / Ordered / Partially Received / Received / Canceled / Refused) with colour coding',
-          'Supplier name, supplier ref, project ref, order date, delivery date, billing status, HT and TTC totals per row',
-          'Client-side status filter + full-text search (ref, supplier, project); configurable page size with prev/next pagination',
-          'Open in Dolibarr button linking to the Dolibarr supplier orders module',
+          'New table fin_product_categories — stores named categories (English + Arabic) with cost_classification and optional coa_account_code',
+          'GET /api/financial/product-categories — list all categories with mapped product count and COA account name',
+          'POST /api/financial/product-categories — create a new category',
+          'PUT /api/financial/product-categories/[id] — update name, classification, COA code, or active status',
+          'DELETE /api/financial/product-categories/[id] — delete a category (blocked if product mappings exist)',
+          'New page /financial/product-categories — manage categories and map product refs on a single tabbed page',
         ],
       },
       {
-        title: 'Supply Chain Sidebar',
+        title: 'Product Category Mapping',
         items: [
-          'Purchase Orders → /supply-chain/purchase-orders',
-          'AP Aging Report → /financial/reports/aging?type=payable (deep-links to Accounts Payable)',
-          'Statement of Account → /financial/reports/soa',
-          'Navigation permission registered for /supply-chain/purchase-orders (supply_chain.view)',
+          'New table fin_product_category_mapping — maps Dolibarr product_ref to a fin_product_categories row',
+          'GET /api/financial/product-category-mapping — returns existing mappings + list of unmapped product refs from invoices',
+          'POST /api/financial/product-category-mapping — create a new product→category mapping',
+          'PUT /api/financial/product-category-mapping/[id] — change the category for an existing mapping',
+          'DELETE /api/financial/product-category-mapping/[id] — remove a mapping',
+          'Unmapped products tab shows all product refs appearing in invoices with no mapping, sorted by spend',
         ],
       },
-      'Aging Report: reads ?type=payable query param on load and auto-initialises type to Accounts Payable',
+      {
+        title: 'Supplier Classification',
+        items: [
+          'New table fin_supplier_classification — maps supplier (Dolibarr socid) to a default cost category and optional COA code',
+          'GET /api/financial/supplier-classification — returns classified suppliers + unclassified suppliers sorted by spend',
+          'POST /api/financial/supplier-classification — classify a supplier',
+          'PUT /api/financial/supplier-classification/[id] — update category or COA code',
+          'DELETE /api/financial/supplier-classification/[id] — remove classification',
+          'New page /financial/supplier-classification — shows classification priority explanation, unclassified suppliers, and classified table',
+        ],
+      },
+      {
+        title: 'DB Migration',
+        items: [
+          'prisma/migrations/add_cost_classification_mapping.sql — creates all 3 new tables with proper indexes, FK constraints, and audit columns',
+        ],
+      },
     ],
-    fixed: [
+    changed: [
       {
-        title: 'LCR Page Layout',
+        title: '4-Level Classification Hierarchy in Reports',
         items: [
-          'Merged page title and all filter controls into a single flex-wrap row — eliminates project/status overlap',
-          'Project dropdown widened from w-56 to w-64; Status from w-44 to w-52 with "All Statuses" placeholder',
-          'Sync Now / Reports buttons and row/sync stats moved to far right of the same header row',
+          'Cost Structure report (getProjectCostStructure): COALESCE now checks account mapping → product category → supplier classification → Other/Unclassified',
+          'Monthly trend query updated from keyword pattern matching to the same 4-level hierarchy',
+          'Expenses Analysis report (getExpensesAnalysis): supplier expenses breakdown uses the same 4-level COALESCE',
+          'All SQL queries now LEFT JOIN fin_product_category_mapping, fin_product_categories, and fin_supplier_classification',
         ],
       },
       {
-        title: 'Alias Management — complete supplier list',
+        title: 'Sidebar Navigation',
         items: [
-          'Alias page was capped at 200 Dolibarr suppliers due to API hard limit',
-          'Now reads pagination.total and fetches remaining pages in parallel so all suppliers appear in the combobox',
+          'Added "Product Categories" → /financial/product-categories under Financial',
+          'Added "Supplier Classification" → /financial/supplier-classification under Financial',
         ],
       },
     ],
-    changed: [],
+    fixed: [],
   },
 };
 

--- a/src/app/changelog/_page-client.tsx
+++ b/src/app/changelog/_page-client.tsx
@@ -23,10 +23,76 @@ type ChangelogVersion = {
 // Version order: Major versions first, then their minor versions
 const hardcodedVersions: ChangelogVersion[] = [
   {
+    version: '16.2.0',
+    date: 'March 24, 2026',
+    type: 'minor',
+    status: 'current',
+    mainTitle: '🏷️ Cost Classification Mapping — Product Categories & Supplier Classification',
+    highlights: [
+      'New Product Categories system: define named categories that carry a cost classification and an optional Chart-of-Accounts account code',
+      'Product Category Mapping: map each Dolibarr product reference to a category so every invoice line is classified accurately',
+      'Supplier Classification: assign a default cost category to each supplier as a fallback when no account or product mapping exists',
+      '4-level classification hierarchy in all financial reports: Account Mapping → Product Category → Supplier Classification → Other/Unclassified',
+      'Monthly trend query now uses the structured mapping tables instead of keyword pattern matching',
+    ],
+    changes: {
+      added: [
+        {
+          title: 'Product Categories (fin_product_categories)',
+          items: [
+            'New table storing named categories with cost_classification and optional coa_account_code',
+            'Bilingual support: English name + optional Arabic name',
+            'GET /api/financial/product-categories — list all with mapped product count and COA name',
+            'POST /api/financial/product-categories — create category',
+            'PUT /api/financial/product-categories/[id] — update name, classification, COA code, active flag',
+            'DELETE /api/financial/product-categories/[id] — delete (blocked if product mappings exist)',
+            'New page /financial/product-categories — tabbed UI: manage categories + assign product refs',
+          ],
+        },
+        {
+          title: 'Product Category Mapping (fin_product_category_mapping)',
+          items: [
+            'New table mapping Dolibarr product_ref to a fin_product_categories row',
+            'GET /api/financial/product-category-mapping — existing mappings + unmapped product refs sorted by spend',
+            'POST /api/financial/product-category-mapping — create mapping',
+            'PUT /api/financial/product-category-mapping/[id] — change category',
+            'DELETE /api/financial/product-category-mapping/[id] — remove mapping',
+            'Unmapped products tab shows all invoice product refs without a mapping',
+          ],
+        },
+        {
+          title: 'Supplier Classification (fin_supplier_classification)',
+          items: [
+            'New table assigning a default cost category (and optional COA code) to a Dolibarr supplier',
+            'GET /api/financial/supplier-classification — classified + unclassified suppliers sorted by spend',
+            'POST /api/financial/supplier-classification — classify a supplier',
+            'PUT /api/financial/supplier-classification/[id] — update category or COA code',
+            'DELETE /api/financial/supplier-classification/[id] — remove classification',
+            'New page /financial/supplier-classification — inline priority explanation, one-click classify, edit/delete table',
+          ],
+        },
+        'DB migration: prisma/migrations/add_cost_classification_mapping.sql creates all 3 tables with indexes, FK constraints, and audit columns',
+      ],
+      changed: [
+        {
+          title: '4-Level Classification Hierarchy in Financial Reports',
+          items: [
+            'Cost Structure report: COALESCE now checks account mapping → product category → supplier classification → Other/Unclassified',
+            'Monthly trend query replaced keyword LIKE pattern-matching with the same 4-level COALESCE using the new tables',
+            'Expenses Analysis report: supplier expenses breakdown uses the 4-level hierarchy',
+            'All affected queries LEFT JOIN fin_product_category_mapping, fin_product_categories, fin_supplier_classification',
+          ],
+        },
+        'Sidebar: Added "Product Categories" and "Supplier Classification" entries under Financial',
+      ],
+      fixed: [],
+    },
+  },
+  {
     version: '16.1.2',
     date: 'March 23, 2026',
     type: 'patch',
-    status: 'current',
+    status: 'previous',
     mainTitle: '🐛 PTS Source Fix & Production Logs Project Filter',
     highlights: [
       'PTS-synced logs that showed source "OTS" are now corrected to "PTS" via the Fix Process Labels migration button',

--- a/src/app/financial/product-categories/_page-client.tsx
+++ b/src/app/financial/product-categories/_page-client.tsx
@@ -1,0 +1,737 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from '@/components/ui/tabs';
+import {
+  Loader2, ArrowLeft, Plus, Pencil, Trash2, Package,
+  Link2, AlertCircle, CheckCircle2, RefreshCw,
+} from 'lucide-react';
+import Link from 'next/link';
+import { useToast } from '@/hooks/use-toast';
+
+function formatSAR(amount: number): string {
+  return new Intl.NumberFormat('en-SA', {
+    style: 'currency', currency: 'SAR', minimumFractionDigits: 0, maximumFractionDigits: 0,
+  }).format(amount);
+}
+
+const COST_CLASSIFICATIONS = [
+  'Raw Materials',
+  'Subcontractors',
+  'Transportation',
+  'Labor',
+  'Equipment',
+  'Rent & Facilities',
+  'Operating Expenses',
+  'Administrative',
+  'Financial Expenses',
+  'Other / Unclassified',
+];
+
+const CLASSIFICATION_COLORS: Record<string, string> = {
+  'Raw Materials': 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400',
+  'Subcontractors': 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+  'Transportation': 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
+  'Labor': 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
+  'Equipment': 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-400',
+  'Rent & Facilities': 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
+  'Operating Expenses': 'bg-pink-100 text-pink-700 dark:bg-pink-900/30 dark:text-pink-400',
+  'Administrative': 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400',
+  'Financial Expenses': 'bg-slate-100 text-slate-700 dark:bg-slate-900/30 dark:text-slate-400',
+  'Other / Unclassified': 'bg-gray-100 text-gray-600 dark:bg-gray-900/30 dark:text-gray-400',
+};
+
+interface ProductCategory {
+  id: number;
+  name: string;
+  name_ar: string | null;
+  cost_classification: string;
+  coa_account_code: string | null;
+  coa_account_name: string | null;
+  description: string | null;
+  color: string | null;
+  is_active: number;
+  mapped_products: number;
+}
+
+interface ProductMapping {
+  id: number;
+  product_ref: string;
+  product_label_hint: string | null;
+  category_id: number;
+  category_name: string;
+  cost_classification: string;
+  coa_account_code: string | null;
+  category_color: string | null;
+  line_count: number;
+  total_ht: number | null;
+  notes: string | null;
+}
+
+interface UnmappedProduct {
+  product_ref: string;
+  product_label: string | null;
+  line_count: number;
+  total_ht: number | null;
+}
+
+export default function ProductCategoriesPage() {
+  const { toast } = useToast();
+  const [activeTab, setActiveTab] = useState('categories');
+
+  // Categories state
+  const [categories, setCategories] = useState<ProductCategory[]>([]);
+  const [loadingCategories, setLoadingCategories] = useState(true);
+  const [showCategoryDialog, setShowCategoryDialog] = useState(false);
+  const [editingCategory, setEditingCategory] = useState<ProductCategory | null>(null);
+  const [categoryForm, setCategoryForm] = useState({
+    name: '',
+    name_ar: '',
+    cost_classification: '',
+    coa_account_code: '',
+    description: '',
+  });
+  const [savingCategory, setSavingCategory] = useState(false);
+
+  // Mappings state
+  const [mappings, setMappings] = useState<ProductMapping[]>([]);
+  const [unmapped, setUnmapped] = useState<UnmappedProduct[]>([]);
+  const [loadingMappings, setLoadingMappings] = useState(false);
+  const [mappingSearch, setMappingSearch] = useState('');
+  const [editingMapping, setEditingMapping] = useState<ProductMapping | null>(null);
+  const [editMappingCategoryId, setEditMappingCategoryId] = useState<string>('');
+  const [savingMapping, setSavingMapping] = useState<number | string | null>(null);
+  const [assigningRef, setAssigningRef] = useState<string | null>(null);
+  const [assignCategoryId, setAssignCategoryId] = useState<string>('');
+
+  useEffect(() => {
+    loadCategories();
+  }, []);
+
+  useEffect(() => {
+    if (activeTab === 'mapping') loadMappings();
+  }, [activeTab]);
+
+  const loadCategories = async () => {
+    setLoadingCategories(true);
+    try {
+      const res = await fetch('/api/financial/product-categories');
+      if (res.ok) {
+        const data = await res.json();
+        setCategories(data.categories || []);
+      }
+    } catch {
+      toast({ title: 'Error', description: 'Failed to load categories', variant: 'destructive' });
+    } finally {
+      setLoadingCategories(false);
+    }
+  };
+
+  const loadMappings = async () => {
+    setLoadingMappings(true);
+    try {
+      const res = await fetch('/api/financial/product-category-mapping');
+      if (res.ok) {
+        const data = await res.json();
+        setMappings(data.mappings || []);
+        setUnmapped(data.unmapped || []);
+      }
+    } catch {
+      toast({ title: 'Error', description: 'Failed to load product mappings', variant: 'destructive' });
+    } finally {
+      setLoadingMappings(false);
+    }
+  };
+
+  const openCreateCategory = () => {
+    setEditingCategory(null);
+    setCategoryForm({ name: '', name_ar: '', cost_classification: '', coa_account_code: '', description: '' });
+    setShowCategoryDialog(true);
+  };
+
+  const openEditCategory = (cat: ProductCategory) => {
+    setEditingCategory(cat);
+    setCategoryForm({
+      name: cat.name,
+      name_ar: cat.name_ar || '',
+      cost_classification: cat.cost_classification,
+      coa_account_code: cat.coa_account_code || '',
+      description: cat.description || '',
+    });
+    setShowCategoryDialog(true);
+  };
+
+  const saveCategory = async () => {
+    if (!categoryForm.name || !categoryForm.cost_classification) {
+      toast({ title: 'Validation', description: 'Name and classification are required', variant: 'destructive' });
+      return;
+    }
+    setSavingCategory(true);
+    try {
+      const method = editingCategory ? 'PUT' : 'POST';
+      const url = editingCategory
+        ? `/api/financial/product-categories/${editingCategory.id}`
+        : '/api/financial/product-categories';
+
+      const res = await fetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: categoryForm.name,
+          name_ar: categoryForm.name_ar || null,
+          cost_classification: categoryForm.cost_classification,
+          coa_account_code: categoryForm.coa_account_code || null,
+          description: categoryForm.description || null,
+        }),
+      });
+
+      if (res.ok) {
+        toast({ title: 'Success', description: editingCategory ? 'Category updated' : 'Category created' });
+        setShowCategoryDialog(false);
+        loadCategories();
+      } else {
+        const err = await res.json();
+        toast({ title: 'Error', description: err.error || 'Failed to save', variant: 'destructive' });
+      }
+    } finally {
+      setSavingCategory(false);
+    }
+  };
+
+  const deleteCategory = async (cat: ProductCategory) => {
+    if (!confirm(`Delete category "${cat.name}"? This cannot be undone.`)) return;
+    try {
+      const res = await fetch(`/api/financial/product-categories/${cat.id}`, { method: 'DELETE' });
+      if (res.ok) {
+        toast({ title: 'Deleted', description: `Category "${cat.name}" removed` });
+        loadCategories();
+      } else {
+        const err = await res.json();
+        toast({ title: 'Error', description: err.error || 'Failed to delete', variant: 'destructive' });
+      }
+    } catch {
+      toast({ title: 'Error', description: 'Failed to delete', variant: 'destructive' });
+    }
+  };
+
+  const assignProduct = async (product_ref: string, product_label: string | null) => {
+    if (!assignCategoryId || assigningRef !== product_ref) return;
+    setSavingMapping(product_ref);
+    try {
+      const res = await fetch('/api/financial/product-category-mapping', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          product_ref,
+          product_label_hint: product_label,
+          category_id: parseInt(assignCategoryId, 10),
+        }),
+      });
+      if (res.ok) {
+        toast({ title: 'Mapped', description: `"${product_ref}" mapped successfully` });
+        setAssigningRef(null);
+        setAssignCategoryId('');
+        loadMappings();
+      } else {
+        const err = await res.json();
+        toast({ title: 'Error', description: err.error || 'Failed to map', variant: 'destructive' });
+      }
+    } finally {
+      setSavingMapping(null);
+    }
+  };
+
+  const updateMapping = async (mapping: ProductMapping) => {
+    if (!editMappingCategoryId) return;
+    setSavingMapping(mapping.id);
+    try {
+      const res = await fetch(`/api/financial/product-category-mapping/${mapping.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ category_id: parseInt(editMappingCategoryId, 10) }),
+      });
+      if (res.ok) {
+        toast({ title: 'Updated', description: 'Mapping updated' });
+        setEditingMapping(null);
+        setEditMappingCategoryId('');
+        loadMappings();
+      } else {
+        const err = await res.json();
+        toast({ title: 'Error', description: err.error || 'Failed to update', variant: 'destructive' });
+      }
+    } finally {
+      setSavingMapping(null);
+    }
+  };
+
+  const deleteMapping = async (mapping: ProductMapping) => {
+    if (!confirm(`Remove mapping for "${mapping.product_ref}"?`)) return;
+    try {
+      const res = await fetch(`/api/financial/product-category-mapping/${mapping.id}`, { method: 'DELETE' });
+      if (res.ok) {
+        toast({ title: 'Removed', description: 'Mapping removed' });
+        loadMappings();
+      } else {
+        const err = await res.json();
+        toast({ title: 'Error', description: err.error || 'Failed to remove', variant: 'destructive' });
+      }
+    } catch {
+      toast({ title: 'Error', description: 'Failed to remove', variant: 'destructive' });
+    }
+  };
+
+  const filteredMappings = mappings.filter(m =>
+    !mappingSearch ||
+    m.product_ref.toLowerCase().includes(mappingSearch.toLowerCase()) ||
+    (m.product_label_hint || '').toLowerCase().includes(mappingSearch.toLowerCase()) ||
+    m.category_name.toLowerCase().includes(mappingSearch.toLowerCase()),
+  );
+
+  const filteredUnmapped = unmapped.filter(u =>
+    !mappingSearch ||
+    u.product_ref.toLowerCase().includes(mappingSearch.toLowerCase()) ||
+    (u.product_label || '').toLowerCase().includes(mappingSearch.toLowerCase()),
+  );
+
+  return (
+    <div className="p-4 space-y-4 max-w-7xl mx-auto">
+      <div className="flex items-center gap-3">
+        <Link href="/financial">
+          <Button variant="ghost" size="icon"><ArrowLeft className="h-4 w-4" /></Button>
+        </Link>
+        <div>
+          <h1 className="text-xl font-bold">Product Categories & Mapping</h1>
+          <p className="text-sm text-muted-foreground">
+            Define cost categories and map invoice products to them for accurate classification
+          </p>
+        </div>
+      </div>
+
+      <Tabs value={activeTab} onValueChange={setActiveTab}>
+        <TabsList>
+          <TabsTrigger value="categories">
+            <Package className="h-4 w-4 mr-2" />
+            Categories
+            {categories.length > 0 && (
+              <Badge variant="secondary" className="ml-2">{categories.length}</Badge>
+            )}
+          </TabsTrigger>
+          <TabsTrigger value="mapping">
+            <Link2 className="h-4 w-4 mr-2" />
+            Product Mapping
+            {unmapped.length > 0 && (
+              <Badge variant="destructive" className="ml-2">{unmapped.length} unmapped</Badge>
+            )}
+          </TabsTrigger>
+        </TabsList>
+
+        {/* ── CATEGORIES TAB ── */}
+        <TabsContent value="categories" className="space-y-4">
+          <div className="flex justify-between items-center">
+            <p className="text-sm text-muted-foreground">
+              Categories group products by type. Each category maps to a cost classification and optionally a Chart of Accounts code.
+            </p>
+            <Button onClick={openCreateCategory} size="sm">
+              <Plus className="h-4 w-4 mr-2" />New Category
+            </Button>
+          </div>
+
+          {loadingCategories ? (
+            <div className="flex items-center justify-center py-10">
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            </div>
+          ) : categories.length === 0 ? (
+            <Card>
+              <CardContent className="py-10 text-center text-muted-foreground">
+                <Package className="h-10 w-10 mx-auto mb-3 opacity-40" />
+                <p className="font-medium">No categories defined yet</p>
+                <p className="text-sm mt-1">Create categories to classify your invoice products</p>
+                <Button className="mt-4" onClick={openCreateCategory}>
+                  <Plus className="h-4 w-4 mr-2" />Create First Category
+                </Button>
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+              {categories.map(cat => (
+                <Card key={cat.id} className={cat.is_active ? '' : 'opacity-50'}>
+                  <CardHeader className="pb-2">
+                    <div className="flex items-start justify-between gap-2">
+                      <div>
+                        <CardTitle className="text-base">{cat.name}</CardTitle>
+                        {cat.name_ar && (
+                          <p className="text-xs text-muted-foreground mt-0.5" dir="rtl">{cat.name_ar}</p>
+                        )}
+                      </div>
+                      <div className="flex gap-1 shrink-0">
+                        <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => openEditCategory(cat)}>
+                          <Pencil className="h-3.5 w-3.5" />
+                        </Button>
+                        <Button
+                          variant="ghost" size="icon" className="h-7 w-7 text-destructive"
+                          onClick={() => deleteCategory(cat)}
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </Button>
+                      </div>
+                    </div>
+                  </CardHeader>
+                  <CardContent className="space-y-2">
+                    <Badge className={CLASSIFICATION_COLORS[cat.cost_classification] || CLASSIFICATION_COLORS['Other / Unclassified']}>
+                      {cat.cost_classification}
+                    </Badge>
+                    {cat.coa_account_code && (
+                      <div className="text-xs text-muted-foreground">
+                        Account: <span className="font-mono font-medium">{cat.coa_account_code}</span>
+                        {cat.coa_account_name && ` — ${cat.coa_account_name}`}
+                      </div>
+                    )}
+                    {cat.description && (
+                      <p className="text-xs text-muted-foreground line-clamp-2">{cat.description}</p>
+                    )}
+                    <div className="text-xs text-muted-foreground">
+                      {Number(cat.mapped_products)} product{Number(cat.mapped_products) !== 1 ? 's' : ''} mapped
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+        </TabsContent>
+
+        {/* ── PRODUCT MAPPING TAB ── */}
+        <TabsContent value="mapping" className="space-y-4">
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex-1">
+              <Input
+                placeholder="Search product ref or label..."
+                value={mappingSearch}
+                onChange={e => setMappingSearch(e.target.value)}
+                className="max-w-sm"
+              />
+            </div>
+            <Button variant="outline" size="sm" onClick={loadMappings} disabled={loadingMappings}>
+              <RefreshCw className={`h-4 w-4 mr-2 ${loadingMappings ? 'animate-spin' : ''}`} />
+              Refresh
+            </Button>
+          </div>
+
+          {loadingMappings ? (
+            <div className="flex items-center justify-center py-10">
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            </div>
+          ) : (
+            <div className="space-y-6">
+              {/* Unmapped products */}
+              {filteredUnmapped.length > 0 && (
+                <Card>
+                  <CardHeader className="pb-2">
+                    <CardTitle className="text-base flex items-center gap-2">
+                      <AlertCircle className="h-4 w-4 text-amber-500" />
+                      Unmapped Products ({filteredUnmapped.length})
+                      <span className="text-sm font-normal text-muted-foreground">
+                        — assign a category to classify these costs
+                      </span>
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="p-0">
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead>Product Ref</TableHead>
+                          <TableHead>Label</TableHead>
+                          <TableHead className="text-right">Lines</TableHead>
+                          <TableHead className="text-right">Total (HT)</TableHead>
+                          <TableHead>Assign Category</TableHead>
+                          <TableHead></TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {filteredUnmapped.map(u => (
+                          <TableRow key={u.product_ref}>
+                            <TableCell className="font-mono text-sm">{u.product_ref}</TableCell>
+                            <TableCell className="text-sm text-muted-foreground max-w-[200px] truncate">
+                              {u.product_label || '—'}
+                            </TableCell>
+                            <TableCell className="text-right text-sm">{Number(u.line_count).toLocaleString()}</TableCell>
+                            <TableCell className="text-right text-sm font-medium">
+                              {u.total_ht ? formatSAR(Number(u.total_ht)) : '—'}
+                            </TableCell>
+                            <TableCell>
+                              {assigningRef === u.product_ref ? (
+                                <Select value={assignCategoryId} onValueChange={setAssignCategoryId}>
+                                  <SelectTrigger className="w-52 h-8">
+                                    <SelectValue placeholder="Select category..." />
+                                  </SelectTrigger>
+                                  <SelectContent>
+                                    {categories.filter(c => c.is_active).map(c => (
+                                      <SelectItem key={c.id} value={String(c.id)}>
+                                        {c.name} — {c.cost_classification}
+                                      </SelectItem>
+                                    ))}
+                                  </SelectContent>
+                                </Select>
+                              ) : (
+                                <Button
+                                  variant="outline" size="sm"
+                                  onClick={() => { setAssigningRef(u.product_ref); setAssignCategoryId(''); }}
+                                >
+                                  <Link2 className="h-3.5 w-3.5 mr-1.5" />Assign
+                                </Button>
+                              )}
+                            </TableCell>
+                            <TableCell>
+                              {assigningRef === u.product_ref && (
+                                <div className="flex gap-1">
+                                  <Button
+                                    size="sm"
+                                    disabled={!assignCategoryId || savingMapping === u.product_ref}
+                                    onClick={() => assignProduct(u.product_ref, u.product_label)}
+                                  >
+                                    {savingMapping === u.product_ref
+                                      ? <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                      : <CheckCircle2 className="h-3.5 w-3.5" />
+                                    }
+                                  </Button>
+                                  <Button
+                                    size="sm" variant="ghost"
+                                    onClick={() => { setAssigningRef(null); setAssignCategoryId(''); }}
+                                  >
+                                    ✕
+                                  </Button>
+                                </div>
+                              )}
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </CardContent>
+                </Card>
+              )}
+
+              {/* Mapped products */}
+              <Card>
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base flex items-center gap-2">
+                    <CheckCircle2 className="h-4 w-4 text-green-500" />
+                    Mapped Products ({filteredMappings.length})
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="p-0">
+                  {filteredMappings.length === 0 ? (
+                    <div className="py-8 text-center text-muted-foreground text-sm">
+                      No mappings yet. Assign categories to unmapped products above.
+                    </div>
+                  ) : (
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead>Product Ref</TableHead>
+                          <TableHead>Label</TableHead>
+                          <TableHead>Category</TableHead>
+                          <TableHead>Classification</TableHead>
+                          <TableHead>Account</TableHead>
+                          <TableHead className="text-right">Lines</TableHead>
+                          <TableHead className="text-right">Total (HT)</TableHead>
+                          <TableHead></TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {filteredMappings.map(m => (
+                          <TableRow key={m.id}>
+                            <TableCell className="font-mono text-sm">{m.product_ref}</TableCell>
+                            <TableCell className="text-sm text-muted-foreground max-w-[160px] truncate">
+                              {m.product_label_hint || '—'}
+                            </TableCell>
+                            <TableCell>
+                              {editingMapping?.id === m.id ? (
+                                <Select value={editMappingCategoryId} onValueChange={setEditMappingCategoryId}>
+                                  <SelectTrigger className="w-48 h-8">
+                                    <SelectValue placeholder="Category..." />
+                                  </SelectTrigger>
+                                  <SelectContent>
+                                    {categories.filter(c => c.is_active).map(c => (
+                                      <SelectItem key={c.id} value={String(c.id)}>
+                                        {c.name}
+                                      </SelectItem>
+                                    ))}
+                                  </SelectContent>
+                                </Select>
+                              ) : (
+                                <span className="text-sm font-medium">{m.category_name}</span>
+                              )}
+                            </TableCell>
+                            <TableCell>
+                              <Badge className={`text-xs ${CLASSIFICATION_COLORS[m.cost_classification] || ''}`}>
+                                {m.cost_classification}
+                              </Badge>
+                            </TableCell>
+                            <TableCell className="font-mono text-sm">{m.coa_account_code || '—'}</TableCell>
+                            <TableCell className="text-right text-sm">{Number(m.line_count).toLocaleString()}</TableCell>
+                            <TableCell className="text-right text-sm font-medium">
+                              {m.total_ht ? formatSAR(Number(m.total_ht)) : '—'}
+                            </TableCell>
+                            <TableCell>
+                              <div className="flex gap-1">
+                                {editingMapping?.id === m.id ? (
+                                  <>
+                                    <Button
+                                      size="icon" className="h-7 w-7"
+                                      disabled={!editMappingCategoryId || savingMapping === m.id}
+                                      onClick={() => updateMapping(m)}
+                                    >
+                                      {savingMapping === m.id
+                                        ? <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                        : <CheckCircle2 className="h-3.5 w-3.5" />
+                                      }
+                                    </Button>
+                                    <Button
+                                      size="icon" variant="ghost" className="h-7 w-7"
+                                      onClick={() => { setEditingMapping(null); setEditMappingCategoryId(''); }}
+                                    >✕</Button>
+                                  </>
+                                ) : (
+                                  <>
+                                    <Button
+                                      size="icon" variant="ghost" className="h-7 w-7"
+                                      onClick={() => {
+                                        setEditingMapping(m);
+                                        setEditMappingCategoryId(String(m.category_id));
+                                      }}
+                                    >
+                                      <Pencil className="h-3.5 w-3.5" />
+                                    </Button>
+                                    <Button
+                                      size="icon" variant="ghost" className="h-7 w-7 text-destructive"
+                                      onClick={() => deleteMapping(m)}
+                                    >
+                                      <Trash2 className="h-3.5 w-3.5" />
+                                    </Button>
+                                  </>
+                                )}
+                              </div>
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  )}
+                </CardContent>
+              </Card>
+            </div>
+          )}
+        </TabsContent>
+      </Tabs>
+
+      {/* Category dialog */}
+      <Dialog open={showCategoryDialog} onOpenChange={setShowCategoryDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{editingCategory ? 'Edit Category' : 'New Product Category'}</DialogTitle>
+            <DialogDescription>
+              Define a category with its cost classification and optional Chart of Accounts link.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 pt-2">
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <Label>Name (English) *</Label>
+                <Input
+                  placeholder="e.g. Steel Profiles"
+                  value={categoryForm.name}
+                  onChange={e => setCategoryForm(f => ({ ...f, name: e.target.value }))}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label>Name (Arabic)</Label>
+                <Input
+                  placeholder="اختياري"
+                  dir="rtl"
+                  value={categoryForm.name_ar}
+                  onChange={e => setCategoryForm(f => ({ ...f, name_ar: e.target.value }))}
+                />
+              </div>
+            </div>
+            <div className="space-y-1.5">
+              <Label>Cost Classification *</Label>
+              <Select
+                value={categoryForm.cost_classification}
+                onValueChange={v => setCategoryForm(f => ({ ...f, cost_classification: v }))}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select classification..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {COST_CLASSIFICATIONS.map(c => (
+                    <SelectItem key={c} value={c}>{c}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1.5">
+              <Label>Chart of Accounts Code</Label>
+              <Input
+                placeholder="e.g. 6010"
+                value={categoryForm.coa_account_code}
+                onChange={e => setCategoryForm(f => ({ ...f, coa_account_code: e.target.value }))}
+              />
+              <p className="text-xs text-muted-foreground">
+                Links this category to a specific account in your Chart of Accounts
+              </p>
+            </div>
+            <div className="space-y-1.5">
+              <Label>Description</Label>
+              <Textarea
+                placeholder="Optional description..."
+                rows={2}
+                value={categoryForm.description}
+                onChange={e => setCategoryForm(f => ({ ...f, description: e.target.value }))}
+              />
+            </div>
+            <div className="flex gap-2 justify-end pt-2">
+              <Button variant="outline" onClick={() => setShowCategoryDialog(false)}>Cancel</Button>
+              <Button onClick={saveCategory} disabled={savingCategory}>
+                {savingCategory && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+                {editingCategory ? 'Save Changes' : 'Create Category'}
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/app/financial/product-categories/page.tsx
+++ b/src/app/financial/product-categories/page.tsx
@@ -1,0 +1,3 @@
+import type { Metadata } from 'next';
+export const metadata: Metadata = { title: 'Product Categories & Mapping' };
+export { default } from './_page-client';

--- a/src/app/financial/supplier-classification/_page-client.tsx
+++ b/src/app/financial/supplier-classification/_page-client.tsx
@@ -1,0 +1,456 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  Loader2, ArrowLeft, Pencil, Trash2, Building2,
+  AlertCircle, CheckCircle2, RefreshCw, Link2,
+} from 'lucide-react';
+import Link from 'next/link';
+import { useToast } from '@/hooks/use-toast';
+
+function formatSAR(amount: number): string {
+  return new Intl.NumberFormat('en-SA', {
+    style: 'currency', currency: 'SAR', minimumFractionDigits: 0, maximumFractionDigits: 0,
+  }).format(amount);
+}
+
+const COST_CATEGORIES = [
+  'Raw Materials',
+  'Subcontractors',
+  'Transportation',
+  'Labor',
+  'Equipment',
+  'Rent & Facilities',
+  'Operating Expenses',
+  'Administrative',
+  'Financial Expenses',
+  'Other / Unclassified',
+];
+
+const CATEGORY_COLORS: Record<string, string> = {
+  'Raw Materials': 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400',
+  'Subcontractors': 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+  'Transportation': 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
+  'Labor': 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
+  'Equipment': 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-400',
+  'Rent & Facilities': 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
+  'Operating Expenses': 'bg-pink-100 text-pink-700 dark:bg-pink-900/30 dark:text-pink-400',
+  'Administrative': 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400',
+  'Financial Expenses': 'bg-slate-100 text-slate-700 dark:bg-slate-900/30 dark:text-slate-400',
+  'Other / Unclassified': 'bg-gray-100 text-gray-600 dark:bg-gray-900/30 dark:text-gray-400',
+};
+
+interface SupplierClassification {
+  id: number;
+  supplier_id: number;
+  supplier_name: string | null;
+  cost_category: string;
+  coa_account_code: string | null;
+  coa_account_name: string | null;
+  invoice_count: number;
+  total_ht: number | null;
+  notes: string | null;
+}
+
+interface UnclassifiedSupplier {
+  supplier_id: number;
+  supplier_name: string | null;
+  invoice_count: number;
+  total_ht: number | null;
+}
+
+export default function SupplierClassificationPage() {
+  const { toast } = useToast();
+  const [classifications, setClassifications] = useState<SupplierClassification[]>([]);
+  const [unclassified, setUnclassified] = useState<UnclassifiedSupplier[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState('');
+
+  // For classifying an unclassified supplier
+  const [assigningId, setAssigningId] = useState<number | null>(null);
+  const [assignCategory, setAssignCategory] = useState('');
+  const [assignCoaCode, setAssignCoaCode] = useState('');
+  const [saving, setSaving] = useState<number | null>(null);
+
+  // For editing an existing classification
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editCategory, setEditCategory] = useState('');
+  const [editCoaCode, setEditCoaCode] = useState('');
+
+  useEffect(() => {
+    loadData();
+  }, []);
+
+  const loadData = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/financial/supplier-classification');
+      if (res.ok) {
+        const data = await res.json();
+        setClassifications(data.classifications || []);
+        setUnclassified(data.unclassified || []);
+      }
+    } catch {
+      toast({ title: 'Error', description: 'Failed to load supplier classifications', variant: 'destructive' });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const assignSupplier = async (supplier: UnclassifiedSupplier) => {
+    if (!assignCategory) return;
+    setSaving(supplier.supplier_id);
+    try {
+      const res = await fetch('/api/financial/supplier-classification', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          supplier_id: supplier.supplier_id,
+          supplier_name: supplier.supplier_name,
+          cost_category: assignCategory,
+          coa_account_code: assignCoaCode || null,
+        }),
+      });
+      if (res.ok) {
+        toast({ title: 'Classified', description: `${supplier.supplier_name || `Supplier #${supplier.supplier_id}`} classified as ${assignCategory}` });
+        setAssigningId(null);
+        setAssignCategory('');
+        setAssignCoaCode('');
+        loadData();
+      } else {
+        const err = await res.json();
+        toast({ title: 'Error', description: err.error || 'Failed to classify', variant: 'destructive' });
+      }
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  const saveEdit = async (sc: SupplierClassification) => {
+    if (!editCategory) return;
+    setSaving(sc.id);
+    try {
+      const res = await fetch(`/api/financial/supplier-classification/${sc.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          cost_category: editCategory,
+          coa_account_code: editCoaCode || null,
+        }),
+      });
+      if (res.ok) {
+        toast({ title: 'Updated', description: 'Supplier classification updated' });
+        setEditingId(null);
+        loadData();
+      } else {
+        const err = await res.json();
+        toast({ title: 'Error', description: err.error || 'Failed to update', variant: 'destructive' });
+      }
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  const deleteClassification = async (sc: SupplierClassification) => {
+    if (!confirm(`Remove classification for "${sc.supplier_name || `Supplier #${sc.supplier_id}`}"?`)) return;
+    try {
+      const res = await fetch(`/api/financial/supplier-classification/${sc.id}`, { method: 'DELETE' });
+      if (res.ok) {
+        toast({ title: 'Removed', description: 'Supplier classification removed' });
+        loadData();
+      } else {
+        const err = await res.json();
+        toast({ title: 'Error', description: err.error || 'Failed to remove', variant: 'destructive' });
+      }
+    } catch {
+      toast({ title: 'Error', description: 'Failed to remove', variant: 'destructive' });
+    }
+  };
+
+  const filteredClassifications = classifications.filter(sc =>
+    !search ||
+    (sc.supplier_name || '').toLowerCase().includes(search.toLowerCase()) ||
+    sc.cost_category.toLowerCase().includes(search.toLowerCase()),
+  );
+
+  const filteredUnclassified = unclassified.filter(u =>
+    !search || (u.supplier_name || '').toLowerCase().includes(search.toLowerCase()),
+  );
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 space-y-4 max-w-7xl mx-auto">
+      <div className="flex items-center gap-3">
+        <Link href="/financial">
+          <Button variant="ghost" size="icon"><ArrowLeft className="h-4 w-4" /></Button>
+        </Link>
+        <div>
+          <h1 className="text-xl font-bold">Supplier Classification</h1>
+          <p className="text-sm text-muted-foreground">
+            Assign a default cost category to each supplier — used when no account or product mapping exists
+          </p>
+        </div>
+      </div>
+
+      {/* Classification priority note */}
+      <Card className="border-blue-200 bg-blue-50 dark:bg-blue-950/20 dark:border-blue-800">
+        <CardContent className="py-3 px-4">
+          <p className="text-sm text-blue-800 dark:text-blue-300 font-medium">Classification Priority (highest → lowest)</p>
+          <ol className="text-xs text-blue-700 dark:text-blue-400 mt-1 space-y-0.5 list-decimal list-inside">
+            <li>Account Mapping — per Dolibarr accounting account code</li>
+            <li>Product Category Mapping — per product reference on the invoice line</li>
+            <li>Supplier Classification — per supplier (this page)</li>
+            <li>Other / Unclassified — default fallback</li>
+          </ol>
+        </CardContent>
+      </Card>
+
+      <div className="flex items-center justify-between gap-3">
+        <Input
+          placeholder="Search supplier or category..."
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          className="max-w-sm"
+        />
+        <Button variant="outline" size="sm" onClick={loadData}>
+          <RefreshCw className="h-4 w-4 mr-2" />Refresh
+        </Button>
+      </div>
+
+      <div className="space-y-6">
+        {/* Unclassified suppliers */}
+        {filteredUnclassified.length > 0 && (
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-base flex items-center gap-2">
+                <AlertCircle className="h-4 w-4 text-amber-500" />
+                Unclassified Suppliers ({filteredUnclassified.length})
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="p-0">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Supplier</TableHead>
+                    <TableHead className="text-right">Invoices</TableHead>
+                    <TableHead className="text-right">Total (HT)</TableHead>
+                    <TableHead>Cost Category</TableHead>
+                    <TableHead>COA Account</TableHead>
+                    <TableHead></TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {filteredUnclassified.map(u => (
+                    <TableRow key={u.supplier_id}>
+                      <TableCell>
+                        <div className="font-medium text-sm">{u.supplier_name || `Supplier #${u.supplier_id}`}</div>
+                        <div className="text-xs text-muted-foreground">ID: {u.supplier_id}</div>
+                      </TableCell>
+                      <TableCell className="text-right text-sm">{Number(u.invoice_count).toLocaleString()}</TableCell>
+                      <TableCell className="text-right text-sm font-medium">
+                        {u.total_ht ? formatSAR(Number(u.total_ht)) : '—'}
+                      </TableCell>
+                      <TableCell>
+                        {assigningId === u.supplier_id ? (
+                          <Select value={assignCategory} onValueChange={setAssignCategory}>
+                            <SelectTrigger className="w-52 h-8">
+                              <SelectValue placeholder="Select category..." />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {COST_CATEGORIES.map(c => (
+                                <SelectItem key={c} value={c}>{c}</SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        ) : (
+                          <Button variant="outline" size="sm" onClick={() => {
+                            setAssigningId(u.supplier_id);
+                            setAssignCategory('');
+                            setAssignCoaCode('');
+                          }}>
+                            <Link2 className="h-3.5 w-3.5 mr-1.5" />Classify
+                          </Button>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        {assigningId === u.supplier_id && (
+                          <Input
+                            placeholder="e.g. 6010"
+                            className="w-28 h-8"
+                            value={assignCoaCode}
+                            onChange={e => setAssignCoaCode(e.target.value)}
+                          />
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        {assigningId === u.supplier_id && (
+                          <div className="flex gap-1">
+                            <Button
+                              size="sm"
+                              disabled={!assignCategory || saving === u.supplier_id}
+                              onClick={() => assignSupplier(u)}
+                            >
+                              {saving === u.supplier_id
+                                ? <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                : <CheckCircle2 className="h-3.5 w-3.5" />
+                              }
+                            </Button>
+                            <Button size="sm" variant="ghost" onClick={() => setAssigningId(null)}>✕</Button>
+                          </div>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Classified suppliers */}
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base flex items-center gap-2">
+              <Building2 className="h-4 w-4 text-green-500" />
+              Classified Suppliers ({filteredClassifications.length})
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="p-0">
+            {filteredClassifications.length === 0 ? (
+              <div className="py-8 text-center text-muted-foreground text-sm">
+                {search ? 'No results for your search.' : 'No classified suppliers yet. Use the table above to assign categories.'}
+              </div>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Supplier</TableHead>
+                    <TableHead>Cost Category</TableHead>
+                    <TableHead>COA Account</TableHead>
+                    <TableHead className="text-right">Invoices</TableHead>
+                    <TableHead className="text-right">Total (HT)</TableHead>
+                    <TableHead></TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {filteredClassifications.map(sc => (
+                    <TableRow key={sc.id}>
+                      <TableCell>
+                        <div className="font-medium text-sm">{sc.supplier_name || `Supplier #${sc.supplier_id}`}</div>
+                        <div className="text-xs text-muted-foreground">ID: {sc.supplier_id}</div>
+                      </TableCell>
+                      <TableCell>
+                        {editingId === sc.id ? (
+                          <Select value={editCategory} onValueChange={setEditCategory}>
+                            <SelectTrigger className="w-52 h-8">
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {COST_CATEGORIES.map(c => (
+                                <SelectItem key={c} value={c}>{c}</SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        ) : (
+                          <Badge className={`text-xs ${CATEGORY_COLORS[sc.cost_category] || CATEGORY_COLORS['Other / Unclassified']}`}>
+                            {sc.cost_category}
+                          </Badge>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        {editingId === sc.id ? (
+                          <Input
+                            placeholder="e.g. 6010"
+                            className="w-28 h-8"
+                            value={editCoaCode}
+                            onChange={e => setEditCoaCode(e.target.value)}
+                          />
+                        ) : (
+                          <span className="font-mono text-sm">
+                            {sc.coa_account_code || '—'}
+                            {sc.coa_account_name && (
+                              <span className="text-muted-foreground font-sans"> — {sc.coa_account_name}</span>
+                            )}
+                          </span>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-right text-sm">{Number(sc.invoice_count).toLocaleString()}</TableCell>
+                      <TableCell className="text-right text-sm font-medium">
+                        {sc.total_ht ? formatSAR(Number(sc.total_ht)) : '—'}
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex gap-1 justify-end">
+                          {editingId === sc.id ? (
+                            <>
+                              <Button
+                                size="icon" className="h-7 w-7"
+                                disabled={!editCategory || saving === sc.id}
+                                onClick={() => saveEdit(sc)}
+                              >
+                                {saving === sc.id
+                                  ? <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                  : <CheckCircle2 className="h-3.5 w-3.5" />
+                                }
+                              </Button>
+                              <Button size="icon" variant="ghost" className="h-7 w-7" onClick={() => setEditingId(null)}>✕</Button>
+                            </>
+                          ) : (
+                            <>
+                              <Button
+                                size="icon" variant="ghost" className="h-7 w-7"
+                                onClick={() => {
+                                  setEditingId(sc.id);
+                                  setEditCategory(sc.cost_category);
+                                  setEditCoaCode(sc.coa_account_code || '');
+                                }}
+                              >
+                                <Pencil className="h-3.5 w-3.5" />
+                              </Button>
+                              <Button
+                                size="icon" variant="ghost" className="h-7 w-7 text-destructive"
+                                onClick={() => deleteClassification(sc)}
+                              >
+                                <Trash2 className="h-3.5 w-3.5" />
+                              </Button>
+                            </>
+                          )}
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/app/financial/supplier-classification/page.tsx
+++ b/src/app/financial/supplier-classification/page.tsx
@@ -1,0 +1,3 @@
+import type { Metadata } from 'next';
+export const metadata: Metadata = { title: 'Supplier Classification' };
+export { default } from './_page-client';

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -259,6 +259,8 @@ const navigationSections: NavigationSection[] = [
       { name: 'OTS Journal Entries', href: '/financial/reports/ots-journal-entries', icon: BookOpen, isNew: true },
       { name: 'Journal Entries', href: '/financial/journal-entries', icon: List, isNew: true },
       { name: 'Account Mapping', href: '/financial/account-mapping', icon: GitBranch, isNew: true },
+      { name: 'Product Categories', href: '/financial/product-categories', icon: Package, isNew: true },
+      { name: 'Supplier Classification', href: '/financial/supplier-classification', icon: Building2, isNew: true },
       { name: 'Settings', href: '/financial/settings', icon: Settings, isNew: true },
     ],
   },

--- a/src/lib/financial/report-service.ts
+++ b/src/lib/financial/report-service.ts
@@ -1359,6 +1359,12 @@ export class FinancialReportService {
   // ============================================
 
   async getProjectCostStructure(fromDate: string, toDate: string): Promise<any> {
+    // Classification priority (highest → lowest):
+    //   1. fin_dolibarr_account_mapping  — per Dolibarr accounting account code
+    //   2. fin_product_category_mapping  — per product_ref on the invoice line
+    //   3. fin_supplier_classification   — per supplier (socid)
+    //   4. 'Other / Unclassified'        — default
+
     // 1. Get all supplier invoice lines with their categories, grouped by supplier (project proxy)
     const linesBySupplier: any[] = await prisma.$queryRawUnsafe(`
       SELECT
@@ -1367,7 +1373,12 @@ export class FinancialReportService {
         sil.product_label,
         sil.product_ref,
         sil.accounting_code,
-        COALESCE(dam.ots_cost_category, 'Other / Unclassified') as cost_category,
+        COALESCE(
+          dam.ots_cost_category,
+          pc.cost_classification,
+          sc.cost_category,
+          'Other / Unclassified'
+        ) as cost_category,
         COALESCE(dam.dolibarr_account_label, sil.product_label, 'Unknown') as account_name,
         SUM(sil.total_ht) as total_ht,
         SUM(sil.total_tva) as total_vat,
@@ -1378,17 +1389,26 @@ export class FinancialReportService {
       JOIN fin_supplier_invoices si ON si.dolibarr_id = sil.invoice_dolibarr_id
       LEFT JOIN dolibarr_thirdparties dt ON dt.dolibarr_id = si.socid
       LEFT JOIN fin_dolibarr_account_mapping dam ON dam.dolibarr_account_id = sil.accounting_code
+      LEFT JOIN fin_product_category_mapping pcm ON pcm.product_ref = sil.product_ref
+      LEFT JOIN fin_product_categories pc ON pc.id = pcm.category_id AND pc.is_active = 1
+      LEFT JOIN fin_supplier_classification sc ON sc.supplier_id = si.socid
       WHERE si.is_active = 1 AND si.status >= 1
         AND si.date_invoice BETWEEN ? AND ?
       GROUP BY si.socid, dt.name, sil.product_label, sil.product_ref, sil.accounting_code,
-               dam.ots_cost_category, dam.dolibarr_account_label
+               dam.ots_cost_category, dam.dolibarr_account_label,
+               pc.cost_classification, sc.cost_category
       ORDER BY dt.name, total_ttc DESC
     `, fromDate, toDate);
 
     // 2. Get cost breakdown by category (aggregate)
     const costByCategory: any[] = await prisma.$queryRawUnsafe(`
       SELECT
-        COALESCE(dam.ots_cost_category, 'Other / Unclassified') as cost_category,
+        COALESCE(
+          dam.ots_cost_category,
+          pc.cost_classification,
+          sc.cost_category,
+          'Other / Unclassified'
+        ) as cost_category,
         SUM(sil.total_ht) as total_ht,
         SUM(sil.total_tva) as total_vat,
         SUM(sil.total_ttc) as total_ttc,
@@ -1397,6 +1417,9 @@ export class FinancialReportService {
       FROM fin_supplier_invoice_lines sil
       JOIN fin_supplier_invoices si ON si.dolibarr_id = sil.invoice_dolibarr_id
       LEFT JOIN fin_dolibarr_account_mapping dam ON dam.dolibarr_account_id = sil.accounting_code
+      LEFT JOIN fin_product_category_mapping pcm ON pcm.product_ref = sil.product_ref
+      LEFT JOIN fin_product_categories pc ON pc.id = pcm.category_id AND pc.is_active = 1
+      LEFT JOIN fin_supplier_classification sc ON sc.supplier_id = si.socid
       WHERE si.is_active = 1 AND si.status >= 1
         AND si.date_invoice BETWEEN ? AND ?
       GROUP BY cost_category
@@ -1420,23 +1443,24 @@ export class FinancialReportService {
       ORDER BY total_ttc DESC
     `, fromDate, toDate);
 
-    // 4. Monthly cost trend
+    // 4. Monthly cost trend (uses same 4-level classification hierarchy)
     const monthlyTrend: any[] = await prisma.$queryRawUnsafe(`
       SELECT
         DATE_FORMAT(si.date_invoice, '%Y-%m') as month,
-        COALESCE(coa.account_category,
-          CASE 
-            WHEN sil.product_label LIKE '%raw%' OR sil.product_label LIKE '%material%' OR sil.product_label LIKE '%مواد%' OR sil.product_label LIKE '%خام%' THEN 'Raw Materials'
-            WHEN sil.product_label LIKE '%sub%contract%' OR sil.product_label LIKE '%مقاول%' THEN 'Subcontractors'
-            WHEN sil.product_label LIKE '%transport%' OR sil.product_label LIKE '%shipping%' OR sil.product_label LIKE '%freight%' OR sil.product_label LIKE '%نقل%' OR sil.product_label LIKE '%شحن%' THEN 'Transportation'
-            ELSE 'Other Costs'
-          END
+        COALESCE(
+          dam.ots_cost_category,
+          pc.cost_classification,
+          sc.cost_category,
+          'Other / Unclassified'
         ) as cost_category,
         SUM(sil.total_ht) as total_ht,
         SUM(sil.total_ttc) as total_ttc
       FROM fin_supplier_invoice_lines sil
       JOIN fin_supplier_invoices si ON si.dolibarr_id = sil.invoice_dolibarr_id
-      LEFT JOIN fin_chart_of_accounts coa ON coa.account_code = sil.accounting_code
+      LEFT JOIN fin_dolibarr_account_mapping dam ON dam.dolibarr_account_id = sil.accounting_code
+      LEFT JOIN fin_product_category_mapping pcm ON pcm.product_ref = sil.product_ref
+      LEFT JOIN fin_product_categories pc ON pc.id = pcm.category_id AND pc.is_active = 1
+      LEFT JOIN fin_supplier_classification sc ON sc.supplier_id = si.socid
       WHERE si.is_active = 1 AND si.status >= 1
         AND si.date_invoice BETWEEN ? AND ?
       GROUP BY month, cost_category
@@ -1537,7 +1561,12 @@ export class FinancialReportService {
       SELECT
         si.socid as supplier_id,
         dt.name as supplier_name,
-        COALESCE(dam.ots_cost_category, 'Other / Unclassified') as expense_category,
+        COALESCE(
+          dam.ots_cost_category,
+          pc.cost_classification,
+          sc.cost_category,
+          'Other / Unclassified'
+        ) as expense_category,
         SUM(sil.total_ht) as total_ht,
         SUM(sil.total_tva) as total_vat,
         SUM(sil.total_ttc) as total_ttc,
@@ -1546,6 +1575,9 @@ export class FinancialReportService {
       JOIN fin_supplier_invoices si ON si.dolibarr_id = sil.invoice_dolibarr_id
       LEFT JOIN dolibarr_thirdparties dt ON dt.dolibarr_id = si.socid
       LEFT JOIN fin_dolibarr_account_mapping dam ON dam.dolibarr_account_id = sil.accounting_code
+      LEFT JOIN fin_product_category_mapping pcm ON pcm.product_ref = sil.product_ref
+      LEFT JOIN fin_product_categories pc ON pc.id = pcm.category_id AND pc.is_active = 1
+      LEFT JOIN fin_supplier_classification sc ON sc.supplier_id = si.socid
       WHERE si.is_active = 1 AND si.status >= 1
         AND si.date_invoice BETWEEN ? AND ?
       GROUP BY si.socid, dt.name, expense_category

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -8,8 +8,8 @@ const resolvedVersion = process.env.NEXT_PUBLIC_APP_VERSION ?? '0.0.0';
 
 export const APP_VERSION = {
   version: resolvedVersion,
-  date: 'March 23, 2026',
-  type: 'patch' as const,
+  date: 'March 24, 2026',
+  type: 'minor' as const,
   name: 'Hexa Steel Operation Tracking System',
 };
 


### PR DESCRIPTION
## What's new

### 3 new database tables
- `fin_product_categories` — named categories with cost_classification + COA account code
  (bilingual EN/AR, is_active flag, audit columns)
- `fin_product_category_mapping` — maps Dolibarr product_ref → category
- `fin_supplier_classification` — maps supplier (socid) → default cost category + COA code
- Migration: prisma/migrations/add_cost_classification_mapping.sql

### 8 new API routes (full CRUD)
- GET/POST  /api/financial/product-categories
- PUT/DELETE /api/financial/product-categories/[id]
- GET/POST  /api/financial/product-category-mapping
- PUT/DELETE /api/financial/product-category-mapping/[id]
- GET/POST  /api/financial/supplier-classification
- PUT/DELETE /api/financial/supplier-classification/[id]

### 2 new pages
- /financial/product-categories — tabbed: manage categories + map product refs
- /financial/supplier-classification — classify suppliers with priority-order explanation

### Report service: 4-level classification hierarchy
All cost queries now use COALESCE(account_mapping, product_category, supplier_classification, 'Other / Unclassified'):
- getProjectCostStructure — lines, category breakdown, monthly trend
- getExpensesAnalysis — supplier expenses breakdown
- Monthly trend query replaces old keyword LIKE pattern-matching

### Sidebar
Added "Product Categories" and "Supplier Classification" under Financial section

### Version bump: 16.1.2 → 16.2.0
- package.json, src/lib/version.ts, CLAUDE.md, README.md
- CHANGELOG.md: new [16.2.0] entry
- Hardcoded changelog page: 16.2.0 set as current, 16.1.2 demoted to previous
- latest-version route: updated highlights and changes

https://claude.ai/code/session_01TACe6mYn6VV7drpuU6R3P7