### PR TITLE
feat: add restore-from-backup capability in backups settings page

### DIFF
--- a/src/app/api/backups/[filename]/restore/route.ts
+++ b/src/app/api/backups/[filename]/restore/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withApiContext } from '@/lib/api-utils';
+import { checkPermission } from '@/lib/permission-checker';
+import { logger } from '@/lib/logger';
+import fs from 'fs';
+import path from 'path';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+const BACKUP_DIR = process.env.BACKUP_DIR || '/root/backups';
+
+function isValidIdentifier(name: string): boolean {
+  if (name.includes('..') || name.includes('/')) return false;
+  if (/^\d{8}([_-]\d{6})?$/.test(name)) return true;
+  if (/\.(sql|sql\.gz)$/.test(name)) return true;
+  return false;
+}
+
+export const POST = withApiContext(async (req: NextRequest, session, context) => {
+  const hasAccess = await checkPermission('backups.restore');
+  if (!hasAccess) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const filename = context?.params?.filename ?? '';
+
+  if (!isValidIdentifier(filename)) {
+    return NextResponse.json({ error: 'Invalid backup identifier' }, { status: 400 });
+  }
+
+  const targetPath = path.join(BACKUP_DIR, filename);
+
+  if (!path.resolve(targetPath).startsWith(path.resolve(BACKUP_DIR))) {
+    return NextResponse.json({ error: 'Invalid path' }, { status: 400 });
+  }
+
+  if (!fs.existsSync(targetPath)) {
+    return NextResponse.json({ error: 'Backup not found' }, { status: 404 });
+  }
+
+  try {
+    const stat = fs.statSync(targetPath);
+    let sqlFilePath: string;
+
+    if (stat.isDirectory()) {
+      const sqlFiles = fs.readdirSync(targetPath).filter(f => f.endsWith('.sql') || f.endsWith('.sql.gz'));
+      if (sqlFiles.length === 0) {
+        return NextResponse.json({ error: 'No SQL file found in backup directory' }, { status: 404 });
+      }
+      let best = sqlFiles[0];
+      let bestSize = 0;
+      for (const sf of sqlFiles) {
+        const sfSize = fs.statSync(path.join(targetPath, sf)).size;
+        if (sfSize > bestSize) { bestSize = sfSize; best = sf; }
+      }
+      sqlFilePath = path.join(targetPath, best);
+    } else {
+      sqlFilePath = targetPath;
+    }
+
+    const dbUrl = process.env.DATABASE_URL || '';
+    const urlMatch = dbUrl.match(/mysql:\/\/([^:]+):([^@]+)@([^:]+):(\d+)\/([^?]+)/);
+    if (!urlMatch) {
+      return NextResponse.json({ error: 'Invalid database configuration' }, { status: 500 });
+    }
+
+    const [, parsedUser, parsedPass, dbHost, dbPort, dbName] = urlMatch;
+    const dbUser = process.env.BACKUP_DB_USER ?? parsedUser;
+    const dbPass = process.env.BACKUP_DB_PASSWORD ?? parsedPass;
+    const passArg = dbPass ? `-p"${dbPass}"` : '';
+
+    let cmd: string;
+    if (sqlFilePath.endsWith('.sql.gz')) {
+      cmd = `gunzip -c "${sqlFilePath}" | mysql -h "${dbHost}" -P "${dbPort}" -u "${dbUser}" ${passArg} "${dbName}"`;
+    } else {
+      cmd = `mysql -h "${dbHost}" -P "${dbPort}" -u "${dbUser}" ${passArg} "${dbName}" < "${sqlFilePath}"`;
+    }
+
+    await execAsync(cmd);
+
+    logger.info({ filename, sqlFilePath, userId: session!.userId }, 'Database restored from backup');
+
+    return NextResponse.json({ message: 'Database restored successfully' });
+  } catch (error) {
+    logger.error({ error, filename, userId: session!.userId }, 'Failed to restore database from backup');
+    return NextResponse.json({ error: 'Failed to restore database from backup' }, { status: 500 });
+  }
+});

--- a/src/app/settings/backups/_page-client.tsx
+++ b/src/app/settings/backups/_page-client.tsx
@@ -37,6 +37,7 @@ import {
   AlertTriangle,
   User,
   Bot,
+  RotateCcw,
 } from 'lucide-react';
 
 type BackupEntry = {
@@ -108,7 +109,9 @@ export default function BackupsPageClient() {
   const [creating, setCreating] = useState(false);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [downloadingId, setDownloadingId] = useState<string | null>(null);
+  const [restoringId, setRestoringId] = useState<string | null>(null);
   const [confirmDelete, setConfirmDelete] = useState<BackupEntry | null>(null);
+  const [confirmRestore, setConfirmRestore] = useState<BackupEntry | null>(null);
   const [toast, setToast] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
 
   const showToast = (type: 'success' | 'error', message: string) => {
@@ -167,6 +170,24 @@ export default function BackupsPageClient() {
     } finally {
       setDeletingId(null);
       setConfirmDelete(null);
+    }
+  };
+
+  const handleRestore = async (backup: BackupEntry) => {
+    setRestoringId(backup.dirname);
+    try {
+      const res = await fetch(`/api/backups/${encodeURIComponent(backup.dirname)}/restore`, { method: 'POST' });
+      if (!res.ok) {
+        const err = await res.json();
+        showToast('error', err.error || 'Failed to restore from backup');
+        return;
+      }
+      showToast('success', `Database restored from backup ${formatDirname(backup.dirname)}`);
+    } catch {
+      showToast('error', 'Failed to restore from backup');
+    } finally {
+      setRestoringId(null);
+      setConfirmRestore(null);
     }
   };
 
@@ -400,6 +421,20 @@ export default function BackupsPageClient() {
                           <Button
                             variant="ghost"
                             size="sm"
+                            onClick={() => setConfirmRestore(backup)}
+                            disabled={restoringId === backup.dirname}
+                            className="text-amber-600 hover:text-amber-700 hover:bg-amber-50 dark:hover:bg-amber-950/30"
+                            title="Restore database from this backup"
+                          >
+                            {restoringId === backup.dirname ? (
+                              <Loader2 className="h-4 w-4 animate-spin" />
+                            ) : (
+                              <RotateCcw className="h-4 w-4" />
+                            )}
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="sm"
                             onClick={() => setConfirmDelete(backup)}
                             disabled={deletingId === backup.dirname}
                             className="text-destructive hover:text-destructive hover:bg-destructive/10"
@@ -440,6 +475,39 @@ export default function BackupsPageClient() {
               onClick={() => confirmDelete && handleDelete(confirmDelete)}
             >
               Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Restore Confirmation */}
+      <AlertDialog open={!!confirmRestore} onOpenChange={() => setConfirmRestore(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle className="flex items-center gap-2">
+              <AlertTriangle className="h-5 w-5 text-amber-500" />
+              Restore Database
+            </AlertDialogTitle>
+            <AlertDialogDescription asChild>
+              <div className="space-y-2">
+                <p>
+                  You are about to restore the database from the backup dated{' '}
+                  <span className="font-semibold">{confirmRestore ? formatDirname(confirmRestore.dirname) : ''}</span>.
+                </p>
+                <p className="font-semibold text-destructive">
+                  This will overwrite all current data with the backup snapshot. Any changes made after this backup was created will be permanently lost.
+                </p>
+                <p>Are you sure you want to proceed?</p>
+              </div>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-amber-600 text-white hover:bg-amber-700"
+              onClick={() => confirmRestore && handleRestore(confirmRestore)}
+            >
+              Yes, Restore Database
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/lib/module-restrictions.ts
+++ b/src/lib/module-restrictions.ts
@@ -262,6 +262,7 @@ export const MODULE_RESTRICTIONS: ModuleRestriction[] = [
       'backups.create',
       'backups.delete',
       'backups.download',
+      'backups.restore',
     ],
   },
 ];

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -298,6 +298,7 @@ export const PERMISSIONS: PermissionCategory[] = [
       { id: 'backups.create', name: 'Create Backups', description: 'Trigger new database backups', category: 'backups' },
       { id: 'backups.delete', name: 'Delete Backups', description: 'Delete existing backup files', category: 'backups' },
       { id: 'backups.download', name: 'Download Backups', description: 'Download backup files', category: 'backups' },
+      { id: 'backups.restore', name: 'Restore from Backup', description: 'Restore the database from a backup file', category: 'backups' },
     ],
   },
 ];


### PR DESCRIPTION
- Add new `backups.restore` permission to permissions and module restrictions
- Create POST /api/backups/[filename]/restore route that runs mysql import
  against the selected backup's SQL file (supports plain .sql and .sql.gz)
- Add restore button (amber RotateCcw icon) per backup row in the UI
- Add two-step confirmation dialog warning that all current data will be
  overwritten before proceeding

https://claude.ai/code/session_019BVTdqKnC7VHnEHUh2TWJu