### PR TITLE
Preserve product/supplier COA mappings after COA upload

### DIFF
--- a/src/app/api/financial/product-coa-mapping/route.ts
+++ b/src/app/api/financial/product-coa-mapping/route.ts
@@ -55,6 +55,7 @@ export async function GET(req: NextRequest) {
         coa.account_name_ar AS coa_account_name_ar,
         coa.account_category AS coa_account_category,
         CASE WHEN pm.id IS NOT NULL THEN 1 ELSE 0 END AS is_mapped,
+        CASE WHEN pm.id IS NOT NULL AND coa.account_code IS NOT NULL THEN 1 ELSE 0 END AS coa_exists,
         p.line_count AS invoice_line_count,
         p.total_ht AS total_spend_ht
       FROM (
@@ -81,6 +82,7 @@ export async function GET(req: NextRequest) {
       dolibarr_id: Number(row.dolibarr_id),
       mapping_id: row.mapping_id ? Number(row.mapping_id) : null,
       is_mapped: Number(row.is_mapped),
+      coa_exists: Number(row.coa_exists),
       invoice_line_count: Number(row.invoice_line_count),
       total_spend_ht: Number(row.total_spend_ht),
     }));

--- a/src/app/api/financial/supplier-coa-default/route.ts
+++ b/src/app/api/financial/supplier-coa-default/route.ts
@@ -54,6 +54,7 @@ export async function GET(req: NextRequest) {
         coa.account_name_ar AS coa_account_name_ar,
         coa.account_category AS coa_account_category,
         CASE WHEN sd.id IS NOT NULL THEN 1 ELSE 0 END AS is_mapped,
+        CASE WHEN sd.id IS NOT NULL AND coa.account_code IS NOT NULL THEN 1 ELSE 0 END AS coa_exists,
         s.invoice_count,
         s.total_ht AS total_spend_ht,
         COALESCE(unmapped.cnt, 0) AS unmapped_product_count
@@ -84,6 +85,7 @@ export async function GET(req: NextRequest) {
       dolibarr_id: Number(row.dolibarr_id),
       mapping_id: row.mapping_id ? Number(row.mapping_id) : null,
       is_mapped: Number(row.is_mapped),
+      coa_exists: Number(row.coa_exists),
       invoice_count: Number(row.invoice_count),
       total_spend_ht: Number(row.total_spend_ht),
       unmapped_product_count: Number(row.unmapped_product_count),

--- a/src/app/financial/product-coa-mapping/_page-client.tsx
+++ b/src/app/financial/product-coa-mapping/_page-client.tsx
@@ -100,6 +100,11 @@ function CoaCombobox({ accounts, grouped, value, onChange, placeholder = 'Select
             <span className="font-mono text-xs text-muted-foreground mr-1">{selected.account_code}</span>
             {selected.account_name}
           </span>
+        ) : value ? (
+          <span className="truncate text-amber-600 dark:text-amber-400">
+            <span className="font-mono text-xs mr-1">{value}</span>
+            <span className="text-xs">(not in COA)</span>
+          </span>
         ) : (
           <span className="text-muted-foreground">{placeholder}</span>
         )}
@@ -191,6 +196,7 @@ interface ProductRow {
   coa_account_name_ar: string | null;
   coa_account_category: string | null;
   is_mapped: number;
+  coa_exists: number;
   invoice_line_count: number;
   total_spend_ht: number;
 }
@@ -205,6 +211,7 @@ interface SupplierRow {
   coa_account_name_ar: string | null;
   coa_account_category: string | null;
   is_mapped: number;
+  coa_exists: number;
   invoice_count: number;
   total_spend_ht: number;
   unmapped_product_count: number;
@@ -804,8 +811,11 @@ export default function ProductCoaMappingPage() {
                               {isDeleting ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Trash2 className="h-3.5 w-3.5" />}
                             </Button>
                           )}
-                          {p.is_mapped === 1 && !isDirty && (
+                          {p.is_mapped === 1 && p.coa_exists === 1 && !isDirty && (
                             <CheckCircle2 className="h-4 w-4 text-green-500" />
+                          )}
+                          {p.is_mapped === 1 && p.coa_exists === 0 && !isDirty && (
+                            <AlertCircle className="h-4 w-4 text-amber-500" title="Mapped account no longer exists in COA — please re-select" />
                           )}
                           {p.is_mapped === 0 && !isDirty && (
                             <AlertCircle className="h-4 w-4 text-muted-foreground opacity-40" />
@@ -1004,8 +1014,11 @@ export default function ProductCoaMappingPage() {
                               {isDeleting ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Trash2 className="h-3.5 w-3.5" />}
                             </Button>
                           )}
-                          {s.is_mapped === 1 && !isDirty && (
+                          {s.is_mapped === 1 && s.coa_exists === 1 && !isDirty && (
                             <CheckCircle2 className="h-4 w-4 text-green-500" />
+                          )}
+                          {s.is_mapped === 1 && s.coa_exists === 0 && !isDirty && (
+                            <AlertCircle className="h-4 w-4 text-amber-500" title="Mapped account no longer exists in COA — please re-select" />
                           )}
                           {s.is_mapped === 0 && !isDirty && (
                             <AlertCircle className="h-4 w-4 text-muted-foreground opacity-40" />


### PR DESCRIPTION
When the Chart of Accounts is re-uploaded (force replace), existing
product and supplier mappings survive in the database but could appear
visually "lost" if account codes changed and the combobox found no match.

- Add coa_exists field to product-coa-mapping and supplier-coa-default
  GET responses (1 if the mapped account still exists in COA, 0 if orphaned)
- Update CoaCombobox to display the stored account code with an amber
  "(not in COA)" warning instead of the empty placeholder when the code
  is no longer in the current COA
- Show amber AlertCircle icon for orphaned mappings so users know to
  re-select; green CheckCircle2 only when the mapping is valid

https://claude.ai/code/session_01X4Qo5DzUoDQcSPNwY2t8wm