### PR TITLE
feat: add Sync Labels button to update product names/codes from Dolibarr

### DIFF
--- a/src/app/api/financial/product-coa-mapping/sync-labels/route.ts
+++ b/src/app/api/financial/product-coa-mapping/sync-labels/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/db';
+import { requireFinancialPermission } from '@/lib/financial/require-financial-permission';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /api/financial/product-coa-mapping/sync-labels
+ *
+ * Updates product_ref and product_label in supplier (and customer) invoice lines
+ * to match the current values in dolibarr_products, without touching any COA
+ * mappings or vendor relationships.
+ */
+export async function POST() {
+  const auth = await requireFinancialPermission('financial.manage');
+  if ('error' in auth) return auth.error;
+
+  try {
+    const supplierResult: { affectedRows?: number }[] = await prisma.$queryRawUnsafe(`
+      UPDATE fin_supplier_invoice_lines sil
+      INNER JOIN dolibarr_products dp ON dp.dolibarr_id = sil.fk_product
+      SET sil.product_ref   = dp.ref,
+          sil.product_label = dp.label
+      WHERE sil.fk_product IS NOT NULL
+        AND sil.fk_product > 0
+        AND (sil.product_ref != dp.ref OR sil.product_label != dp.label
+             OR sil.product_ref IS NULL OR sil.product_label IS NULL)
+    `);
+
+    const customerResult: { affectedRows?: number }[] = await prisma.$queryRawUnsafe(`
+      UPDATE fin_customer_invoice_lines cil
+      INNER JOIN dolibarr_products dp ON dp.dolibarr_id = cil.fk_product
+      SET cil.product_ref   = dp.ref,
+          cil.product_label = dp.label
+      WHERE cil.fk_product IS NOT NULL
+        AND cil.fk_product > 0
+        AND (cil.product_ref != dp.ref OR cil.product_label != dp.label
+             OR cil.product_ref IS NULL OR cil.product_label IS NULL)
+    `);
+
+    const supplierUpdated = Number((supplierResult as unknown as { affectedRows: number })?.affectedRows ?? 0);
+    const customerUpdated = Number((customerResult as unknown as { affectedRows: number })?.affectedRows ?? 0);
+    const total = supplierUpdated + customerUpdated;
+
+    logger.info({ supplierUpdated, customerUpdated }, 'Product labels synced in invoice lines');
+
+    return NextResponse.json({
+      success: true,
+      supplierLinesUpdated: supplierUpdated,
+      customerLinesUpdated: customerUpdated,
+      totalUpdated: total,
+    });
+  } catch (error: unknown) {
+    logger.error({ error }, 'Failed to sync product labels');
+    return NextResponse.json({ error: 'Failed to sync product labels' }, { status: 500 });
+  }
+}

--- a/src/app/financial/product-coa-mapping/_page-client.tsx
+++ b/src/app/financial/product-coa-mapping/_page-client.tsx
@@ -279,6 +279,9 @@ export default function ProductCoaMappingPage() {
   // Save all state
   const [savingAll, setSavingAll] = useState(false);
 
+  // Sync labels state
+  const [syncingLabels, setSyncingLabels] = useState(false);
+
   // Notes dialog
   const [notesDialog, setNotesDialog] = useState<{ type: 'product' | 'supplier'; id: number; code: string; notes: string } | null>(null);
   const [editNotes, setEditNotes] = useState('');
@@ -585,6 +588,27 @@ export default function ProductCoaMappingPage() {
     return code && code !== (s?.coa_account_code || '');
   }).length;
 
+  async function handleSyncLabels() {
+    setSyncingLabels(true);
+    try {
+      const res = await fetch('/api/financial/product-coa-mapping/sync-labels', { method: 'POST' });
+      const data = await res.json();
+      if (res.ok) {
+        toast({
+          title: 'Labels synced',
+          description: data.totalUpdated > 0
+            ? `Updated ${data.totalUpdated} invoice line(s) with current product names and codes.`
+            : 'All product labels were already up to date.',
+        });
+        await Promise.all([fetchProducts(productPagination.page), fetchCoverage()]);
+      } else {
+        toast({ title: 'Sync failed', description: data.error || 'Could not sync labels.', variant: 'destructive' });
+      }
+    } finally {
+      setSyncingLabels(false);
+    }
+  }
+
   // ─────────────────────────────────────────────────────────────────────────────
 
   return (
@@ -600,9 +624,15 @@ export default function ProductCoaMappingPage() {
             Map products and suppliers to Chart of Accounts expense categories for accurate cost reporting
           </p>
         </div>
-        <Button variant="outline" size="sm" onClick={() => { fetchCoverage(); fetchProducts(productPagination.page); fetchSuppliers(supplierPagination.page); }} className="ml-auto gap-2">
-          <RefreshCw className="h-3.5 w-3.5" /> Refresh
-        </Button>
+        <div className="ml-auto flex items-center gap-2">
+          <Button variant="outline" size="sm" onClick={handleSyncLabels} disabled={syncingLabels} className="gap-2">
+            {syncingLabels ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
+            Sync Labels
+          </Button>
+          <Button variant="outline" size="sm" onClick={() => { fetchCoverage(); fetchProducts(productPagination.page); fetchSuppliers(supplierPagination.page); }} className="gap-2">
+            <RefreshCw className="h-3.5 w-3.5" /> Refresh
+          </Button>
+        </div>
       </div>
 
       {/* Coverage Stats */}


### PR DESCRIPTION
When product ref or label is changed in Dolibarr, invoice lines in
fin_supplier_invoice_lines (and fin_customer_invoice_lines) retain
stale values because unchanged invoices skip re-sync.

New POST /api/financial/product-coa-mapping/sync-labels endpoint joins
invoice lines against dolibarr_products and updates product_ref and
product_label in-place. COA mappings and vendor links are untouched —
the mapping key is the numeric dolibarr_product_id, not the ref.

A "Sync Labels" button is added to the product-coa-mapping page header.
After syncing it refreshes the product list and coverage stats.

https://claude.ai/code/session_01HJ3HpdZg1EPwwGjhJ1ioeS