### PR TITLE
fix: preserve redirect destination after login and prevent sign-out loop

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from 'next/navigation';
 import { cookies } from 'next/headers';
+import { Suspense } from 'react';
 import { verifySession } from '@/lib/jwt';
 import { LoginForm } from '@/components/login-form';
 import type { Metadata } from 'next';
@@ -22,5 +23,9 @@ export default async function LoginPage() {
   if (session) {
     redirect('/dashboard');
   }
-  return <LoginForm />;
+  return (
+    <Suspense>
+      <LoginForm />
+    </Suspense>
+  );
 }

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -21,7 +21,7 @@ export default function TopBar() {
       localStorage.clear();
       sessionStorage.clear();
 
-      fetch('/api/auth/logout', { method: 'POST', credentials: 'include' }).catch(() => {});
+      await fetch('/api/auth/logout', { method: 'POST', credentials: 'include' }).catch(() => {});
 
       const loginUrl =
         process.env.NODE_ENV === 'production'

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -742,8 +742,7 @@ export function AppSidebar() {
                     localStorage.clear();
                     sessionStorage.clear();
                     
-                    // Fire logout API (don't wait)
-                    fetch('/api/auth/logout', { method: 'POST', credentials: 'include' }).catch(() => {});
+                    await fetch('/api/auth/logout', { method: 'POST', credentials: 'include' }).catch(() => {});
                     
                     const loginUrl = process.env.NODE_ENV === 'production' 
                       ? 'https://ots.hexasteel.sa/login?t=' + Date.now()

--- a/src/components/login-form.tsx
+++ b/src/components/login-form.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import Image from 'next/image';
 import { Label } from '@/components/ui/label';
@@ -12,6 +12,7 @@ import { CURRENT_VERSION } from '@/lib/version';
 
 export function LoginForm() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [loginLogo, setLoginLogo] = useState<string | null>(null);
@@ -94,7 +95,8 @@ export function LoginForm() {
         }
       }
 
-      router.push('/dashboard');
+      const next = searchParams.get('next');
+      router.push(next && next.startsWith('/') ? next : '/dashboard');
       router.refresh();
     } catch (err: any) {
       console.error('Login error:', err);


### PR DESCRIPTION
- login-form: read ?next= param via useSearchParams and redirect there
  after successful login instead of always going to /dashboard
- login/page: wrap LoginForm in Suspense (required for useSearchParams)
- TopBar/app-sidebar collapsed: await logout API before navigating to
  /login so the session cookie is cleared server-side before the login
  page renders, preventing the repeated dashboard redirect loop

https://claude.ai/code/session_016ySEvKmU34HAvK1JwE52jr