### PR TITLE
feat(project-tracker): track dispatched-to-customer weight per building

### DIFF
--- a/src/app/api/project-tracker/route.ts
+++ b/src/app/api/project-tracker/route.ts
@@ -36,7 +36,7 @@ const COMPLETION_ACTIVITIES = new Set(['design', 'detailing']);
 const PRODUCTION_PROCESS_TYPES: Record<string, string[]> = {
   production: ['Fit-up', 'Welding', 'Visualization'],
   coating: ['Sandblasting', 'Painting', 'Galvanization'],
-  dispatch: ['Dispatch'],
+  dispatch: ['Dispatched to Customer'],
   erection: ['Erection'],
 };
 
@@ -75,6 +75,7 @@ interface ProcurementDetail {
 
 interface ProductionDetail {
   totalWeight: number;
+  dispatchedWeight: number;
   processes: { name: string; processedWeight: number; percentage: number }[];
 }
 
@@ -479,8 +480,13 @@ async function computeProductionProgress(
   }
   const pct = Math.round(totalPct / processTypes.length);
 
+  const dispatchedWeight = processTypes.includes('Dispatched to Customer')
+    ? Math.round((weightByProcess.get('Dispatched to Customer') || 0) * 100) / 100
+    : 0;
+
   const detail: ProductionDetail = {
     totalWeight: Math.round(totalWeight * 100) / 100,
+    dispatchedWeight,
     processes,
   };
 

--- a/src/app/project-tracker/_page-client.tsx
+++ b/src/app/project-tracker/_page-client.tsx
@@ -52,6 +52,7 @@ interface ProcurementDetail {
 
 interface ProductionDetail {
   totalWeight: number;
+  dispatchedWeight: number;
   processes: { name: string; processedWeight: number; percentage: number }[];
 }
 
@@ -341,25 +342,58 @@ function DetailPopover({
       {/* Production details */}
       {activity.details.production && (
         <div className={`rounded-md p-2 border ${isDark ? 'border-slate-700 bg-slate-800/50' : 'border-slate-200 bg-slate-50'}`}>
-          <div className={`mb-1.5 ${muted}`}>
-            <Weight className="w-3 h-3 inline mr-1" />
-            Total Weight: {formatWeight(activity.details.production.totalWeight)}
-          </div>
-          <div className="space-y-1">
-            {activity.details.production.processes.map((p) => (
-              <div key={p.name} className="flex items-center justify-between">
-                <span className={muted}>{p.name}</span>
-                <div className="flex items-center gap-2">
-                  <span className={`tabular-nums ${p.percentage > 0 ? 'text-amber-400' : muted}`}>
-                    {formatWeight(p.processedWeight)}
-                  </span>
-                  <span className={`tabular-nums font-medium w-10 text-right ${p.percentage >= 100 ? 'text-emerald-400' : p.percentage > 0 ? 'text-amber-400' : muted}`}>
-                    {p.percentage}%
-                  </span>
-                </div>
+          {activity.activityType === 'dispatch' ? (
+            <div className="space-y-1.5">
+              <div className="flex items-center justify-between">
+                <span className={muted}>
+                  <Weight className="w-3 h-3 inline mr-1" />
+                  Scope Weight
+                </span>
+                <span className={`tabular-nums font-medium ${isDark ? 'text-slate-300' : 'text-slate-700'}`}>
+                  {formatWeight(activity.details.production.totalWeight)}
+                </span>
               </div>
-            ))}
-          </div>
+              <div className="flex items-center justify-between">
+                <span className={muted}>
+                  <Weight className="w-3 h-3 inline mr-1" />
+                  Dispatched to Customer
+                </span>
+                <span className={`tabular-nums font-semibold ${activity.details.production.dispatchedWeight > 0 ? 'text-emerald-400' : muted}`}>
+                  {formatWeight(activity.details.production.dispatchedWeight)}
+                </span>
+              </div>
+              {activity.details.production.totalWeight > 0 && (
+                <div className={`h-1.5 rounded-full overflow-hidden ${isDark ? 'bg-slate-700' : 'bg-slate-200'}`}>
+                  <div
+                    className="h-full rounded-full bg-emerald-500 transition-all duration-500"
+                    style={{ width: `${Math.min(Math.round((activity.details.production.dispatchedWeight / activity.details.production.totalWeight) * 100), 100)}%` }}
+                  />
+                </div>
+              )}
+            </div>
+          ) : (
+            <>
+              <div className={`mb-1.5 ${muted}`}>
+                <Weight className="w-3 h-3 inline mr-1" />
+                Total Weight: {formatWeight(activity.details.production.totalWeight)}
+              </div>
+              <div className="space-y-1">
+                {activity.details.production.processes.map((p) => (
+                  <div key={p.name} className="flex items-center justify-between">
+                    <span className={muted}>{p.name}</span>
+                    <div className="flex items-center gap-2">
+                      <span className={`tabular-nums ${p.percentage > 0 ? 'text-amber-400' : muted}`}>
+                        {formatWeight(p.processedWeight)}
+                      </span>
+                      <span className={`tabular-nums font-medium w-10 text-right ${p.percentage >= 100 ? 'text-emerald-400' : p.percentage > 0 ? 'text-amber-400' : muted}`}>
+                        {p.percentage}%
+                      </span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
- Fix dispatch column process type: was 'Dispatch' (non-existent), now
  correctly maps to 'Dispatched to Customer' production log type
- Add dispatchedWeight field to ProductionDetail so the API returns the
  actual kg dispatched alongside total scope weight
- Update dispatch popover to show Scope Weight vs Dispatched to Customer
  weight with a progress bar instead of the generic process breakdown

https://claude.ai/code/session_01KJbtLA33hHMmgt1jnbmaXA