### PR TITLE
Fix aging report print layout and sidebar mobile overflow

### DIFF
--- a/src/app/financial/reports/aging/_page-client.tsx
+++ b/src/app/financial/reports/aging/_page-client.tsx
@@ -24,6 +24,14 @@ export default function AgingReportPage() {
   const [expanded, setExpanded] = useState<Set<number>>(new Set());
   const [search, setSearch] = useState('');
   const [bucketFilter, setBucketFilter] = useState<string | null>(null);
+  const [companyLogo, setCompanyLogo] = useState<string | null>(null);
+
+  React.useEffect(() => {
+    fetch('/api/settings')
+      .then(r => r.ok ? r.json() : null)
+      .then(data => { if (data?.companyLogo) setCompanyLogo(data.companyLogo); })
+      .catch(() => {});
+  }, []);
 
   const BUCKETS = [
     { key: 'current',  label: 'Current',    color: 'text-green-600',  ring: 'ring-green-400',  field: 'current' },
@@ -62,8 +70,34 @@ export default function AgingReportPage() {
 
   return (
     <div className="space-y-6">
+      {/* ── Print Header (visible only when printing) ─────────────────────────── */}
+      <div className="hidden print:flex items-center justify-between border-b pb-4 mb-4">
+        <div className="flex items-center gap-3">
+          {companyLogo ? (
+            <img
+              src={companyLogo}
+              alt="Company Logo"
+              className="h-10 max-w-[140px] object-contain"
+            />
+          ) : (
+            <div className="flex items-center gap-2">
+              <div className="size-10 rounded-lg bg-primary flex items-center justify-center">
+                <span className="text-primary-foreground font-bold text-base">HS</span>
+              </div>
+              <span className="font-semibold text-lg">Hexa Steel</span>
+            </div>
+          )}
+        </div>
+        <div className="text-right">
+          <h1 className="text-xl font-bold">Aging Report</h1>
+          <p className="text-sm text-muted-foreground">
+            {type === 'ar' ? 'Accounts Receivable' : 'Accounts Payable'} &middot; As of {asOfDate}
+          </p>
+        </div>
+      </div>
+
       {/* ── Header ────────────────────────────────────────────────────────────── */}
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between print:hidden">
         <div className="flex items-center gap-4">
           <Link href="/financial">
             <Button variant="ghost" size="sm"><ArrowLeft className="h-4 w-4 mr-1" /> Back</Button>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -129,3 +129,14 @@
     box-shadow: 0 1px 0 0 rgb(30 41 59 / 1);
   }
 }
+
+@media print {
+  * {
+    -webkit-print-color-adjust: exact !important;
+    print-color-adjust: exact !important;
+  }
+  @page {
+    size: A4 landscape;
+    margin: 15mm;
+  }
+}

--- a/src/components/ResponsiveLayout.tsx
+++ b/src/components/ResponsiveLayout.tsx
@@ -14,7 +14,7 @@ function LayoutContent({ children }: { children: React.ReactNode }) {
     <div className="flex min-h-screen">
       <AppSidebar />
       <TopBar />
-      <main className={`flex-1 transition-all duration-300 ${collapsed ? 'lg:ml-16' : 'lg:ml-64'} pt-14`}>
+      <main className={`flex-1 transition-all duration-300 ${collapsed ? 'lg:ml-16' : 'lg:ml-64'} pt-14 print:!ml-0 print:!pt-0`}>
         <RouteGuard>{children}</RouteGuard>
       </main>
     </div>

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -39,7 +39,7 @@ export default function TopBar() {
   };
 
   return (
-    <div className="fixed top-0 right-0 z-50 flex items-center gap-1 p-2 lg:p-3">
+    <div className="fixed top-0 right-0 z-50 flex items-center gap-1 p-2 lg:p-3 print:hidden">
       <GlobalSearch />
       <RecentLinksPanel />
       <NotificationBell />

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -453,7 +453,7 @@ export function AppSidebar() {
   return (
     <>
       {/* Mobile menu button */}
-      <div className="lg:hidden fixed top-4 left-4 z-50">
+      <div className="lg:hidden fixed top-4 left-4 z-50 print:hidden">
         <Button
           variant="outline"
           size="icon"
@@ -466,8 +466,8 @@ export function AppSidebar() {
       {/* Sidebar */}
       <aside
         className={cn(
-          'fixed left-0 top-0 z-40 h-screen bg-card border-r transition-all duration-300',
-          collapsed ? 'w-0 lg:w-16' : 'w-64',
+          'fixed left-0 top-0 z-40 h-screen bg-card border-r transition-all duration-300 print:hidden',
+          collapsed ? 'w-0 overflow-hidden lg:w-16 lg:overflow-visible' : 'w-64',
           'max-lg:shadow-lg'
         )}
       >


### PR DESCRIPTION
- Hide sidebar, topbar, and mobile menu button when printing (print:hidden)
- Remove main content margin/padding in print mode so report uses full page
- Add overflow-hidden to collapsed sidebar on mobile to prevent icon bleed
- Add print-only header with company logo and report title
- Add global print styles (color-adjust, A4 landscape, margins)

https://claude.ai/code/session_01YNdExgDdUURHAQA3Zubmck