### PR TITLE
fix(tasks): restore tasks with null mainActivity that were silently hidden

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Project Overview
 Enterprise ERP for steel fabrication projects. Next.js 15 App Router + TypeScript + Prisma + MySQL.
 Deployed at `hexasteel.sa/ots` with optional `NEXT_PUBLIC_BASE_PATH` subpath.
-**Current version:** `17.26.2` — Fix LCR column positions (groups start at col 26), fix PTS weight aggregation (sum totals, no multiplication)
+**Current version:** `17.26.3` — Critical fix: tasks with null mainActivity were excluded from all task lists due to MySQL NULL comparison behavior
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexa-steel-ots",
-  "version": "17.26.2",
+  "version": "17.26.3",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -133,12 +133,15 @@ export async function GET(req: Request) {
     }
   }
 
-  // Exclude standalone conversation containers (Discussion tasks) and soft-deleted tasks
+  // Exclude standalone conversation containers (Discussion tasks) and soft-deleted tasks.
+  // Use OR to include tasks where mainActivity IS NULL — MySQL's NOT (field = value)
+  // evaluates to NULL (not TRUE) for NULL columns, which would silently exclude them.
+  const excludeDiscussion = { OR: [{ mainActivity: null }, { NOT: { mainActivity: 'Discussion' } }] };
   if (whereClause.AND) {
-    (whereClause.AND as unknown[]).push({ NOT: { mainActivity: 'Discussion' } });
+    (whereClause.AND as unknown[]).push(excludeDiscussion);
     (whereClause.AND as unknown[]).push({ deletedAt: null });
   } else {
-    whereClause.AND = [{ NOT: { mainActivity: 'Discussion' } }, { deletedAt: null }];
+    whereClause.AND = [excludeDiscussion, { deletedAt: null }];
   }
 
   let tasks = await prisma.task.findMany({

--- a/src/app/changelog/_page-client.tsx
+++ b/src/app/changelog/_page-client.tsx
@@ -23,10 +23,29 @@ type ChangelogVersion = {
 // Version order: Most recent first
 const hardcodedVersions: ChangelogVersion[] = [
   {
-    version: '17.26.2',
+    version: '17.26.3',
     date: 'April 9, 2026',
     type: 'patch',
     status: 'current',
+    mainTitle: 'Critical Fix: Missing Tasks Across All Departments',
+    highlights: [
+      'Tasks without a mainActivity (the majority of tasks) were being silently excluded from all task list views',
+      'Root cause: MySQL NULL handling — NOT (mainActivity = \'Discussion\') evaluates to NULL for NULL rows, hiding them',
+      'Fix: filter now explicitly includes tasks where mainActivity IS NULL',
+    ],
+    changes: {
+      added: [],
+      fixed: [
+        'Tasks with no mainActivity set were missing from all task list views across every department and project',
+      ],
+      changed: [],
+    },
+  },
+  {
+    version: '17.26.2',
+    date: 'April 9, 2026',
+    type: 'patch',
+    status: 'previous',
     mainTitle: 'LCR Column Position Fix & PTS Weight Aggregation Fix',
     highlights: [
       'LCR comparison groups shifted to correct positions: LCR1 at col 26-28, LCR2 at 29-31, LCR3 at 32-34, Thickness at 35',


### PR DESCRIPTION
MySQL evaluates `NOT (mainActivity = 'Discussion')` to NULL (not TRUE)
for rows where mainActivity IS NULL, causing every task without a
mainActivity value to be excluded from all task list views across every
department and project.

Fix: replace `{ NOT: { mainActivity: 'Discussion' } }` with
`{ OR: [{ mainActivity: null }, { NOT: { mainActivity: 'Discussion' } }] }`
so NULL-mainActivity tasks are included while Discussion containers are
still correctly excluded.

Bumps version 17.26.2 → 17.26.3.

https://claude.ai/code/session_01FRihQmnKRNgQXsZMw62KAM