### PR TITLE
fix(assembly-parts): column sorting always ignored due to duplicate orderBy (v17.26.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [17.26.4] - 2026-04-11
+
+### Assembly Parts Column Sorting Fix (Patch)
+
+#### Fixed
+- **Assembly parts column sorting** — clicking column headers (Part Designation, Name, Source, Project, Building, Qty, Length, Weight, Upload Date, Status) now correctly sorts the data; previously the dynamic sort was silently overridden by a duplicate hardcoded `orderBy` clause in the Prisma query that always forced `assemblyMark / partMark` order regardless of the selected column
+
+---
+
 ## [17.26.2] - 2026-04-09
 
 ### LCR Column Position Fix & PTS Weight Aggregation Fix (Patch)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Project Overview
 Enterprise ERP for steel fabrication projects. Next.js 15 App Router + TypeScript + Prisma + MySQL.
 Deployed at `hexasteel.sa/ots` with optional `NEXT_PUBLIC_BASE_PATH` subpath.
-**Current version:** `17.26.3` — Critical fix: tasks with null mainActivity were excluded from all task lists due to MySQL NULL comparison behavior
+**Current version:** `17.26.4` — Fix: assembly parts column sorting was always overridden by hardcoded assemblyMark/partMark sort due to duplicate orderBy keys
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexa-steel-ots",
-  "version": "17.26.3",
+  "version": "17.26.4",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/api/production/assembly-parts/route.ts
+++ b/src/app/api/production/assembly-parts/route.ts
@@ -152,13 +152,23 @@ export async function GET(req: Request) {
       statusCountMap[sc.status] = sc._count._all;
     });
 
+    const sortDir = (orderBy === 'asc' || orderBy === 'desc') ? orderBy : ('asc' as const);
+    const primarySort =
+      sortBy === 'projectNumber'
+        ? { project: { projectNumber: sortDir } }
+        : sortBy === 'buildingName'
+        ? { building: { name: sortDir } }
+        : { [sortBy]: sortDir };
+
     const assemblyParts = await prisma.assemblyPart.findMany({
       where,
       skip,
       take: limit,
-      orderBy: sortBy === 'projectNumber' || sortBy === 'buildingName'
-        ? { [sortBy === 'projectNumber' ? 'project' : 'building']: { [sortBy === 'projectNumber' ? 'projectNumber' : 'name']: orderBy } }
-        : { [sortBy]: orderBy },
+      orderBy: [
+        primarySort,
+        { assemblyMark: 'asc' },
+        { partMark: 'asc' },
+      ],
       select: {
         id: true,
         partDesignation: true,
@@ -175,6 +185,7 @@ export async function GET(req: Request) {
         singlePartWeight: true,
         netWeightTotal: true,
         status: true,
+        currentProcess: true,
         source: true,
         externalRef: true,
         projectId: true,
@@ -206,10 +217,6 @@ export async function GET(req: Request) {
           select: { productionLogs: true },
         },
       },
-      orderBy: [
-        { assemblyMark: 'asc' },
-        { partMark: 'asc' },
-      ],
     });
 
     return NextResponse.json({


### PR DESCRIPTION
The Prisma findMany call had two separate `orderBy` properties in the same
object literal — the dynamic user-selected sort (lines 159-161) and a
hardcoded `[assemblyMark asc, partMark asc]` sort (lines 209-212). In JS,
duplicate object keys mean the last one wins, so the user's chosen sort
column was silently discarded on every request.

Fix: consolidate into a single orderBy array where the user-selected column
is primary and assemblyMark/partMark serve as tiebreakers.

Also adds `currentProcess` to the select (was missing from API response
despite being used by the card view).

https://claude.ai/code/session_013aoPTpQGJUYRdRMFnFWWeo