### PR TITLE
fix(ci): grep DATABASE_URL instead of sourcing .env in SQL migration workflow

### DIFF
--- a/.github/workflows/run-sql-migration.yml
+++ b/.github/workflows/run-sql-migration.yml
@@ -49,7 +49,21 @@ jobs:
             fi
 
             echo "Running migration: $MIGRATION_FILE"
-            source "$APP_DIR/.env"
+
+            # Extract DATABASE_URL directly from .env without sourcing the whole file.
+            # Sourcing fails when .env contains JSON values (e.g. GOOGLE_SERVICE_ACCOUNT_KEY)
+            # because bash tries to interpret the colons/braces as shell syntax.
+            DATABASE_URL=$(grep -E '^DATABASE_URL=' "$APP_DIR/.env" | head -1 | cut -d '=' -f 2-)
+            # Strip surrounding single or double quotes if present
+            DATABASE_URL="${DATABASE_URL%\"}"
+            DATABASE_URL="${DATABASE_URL#\"}"
+            DATABASE_URL="${DATABASE_URL%\'}"
+            DATABASE_URL="${DATABASE_URL#\'}"
+
+            if [ -z "$DATABASE_URL" ]; then
+              echo "ERROR: DATABASE_URL not found in $APP_DIR/.env"
+              exit 1
+            fi
 
             # Extract connection details from DATABASE_URL
             # Expected format: mysql://user:password@host:port/database


### PR DESCRIPTION
## Summary

This PR carries the one commit that was left behind on the feature branch after PR #264 was merged:

- `af13426 fix(ci): grep DATABASE_URL instead of sourcing entire .env`

## Why the migration workflow keeps failing

`origin/main` still has the old `Run Manual SQL Migration` step, which does:

```bash
source "$APP_DIR/.env"
```

Our production `.env` contains `GOOGLE_SERVICE_ACCOUNT_KEY={...single-line JSON...}`. When bash `source`s that file, it tries to interpret the JSON as shell syntax and crashes with:

```
/var/www/hexasteel.sa/ots/.env: line N: service_account,project_id:: command not found
Process exited with status 127
```

That's why every manual migration run — even after merging PR #264 — fails with the same error. The `workflow_dispatch` action reads the YAML from `main`, and the fix commit was never in `main`.

## The fix

Replace `source "$APP_DIR/.env"` with a targeted `grep` that extracts only `DATABASE_URL`, so we don't try to evaluate the JSON credential:

```bash
DATABASE_URL=$(grep -E '^DATABASE_URL=' "$APP_DIR/.env" | head -1 | cut -d '=' -f 2-)
# strip surrounding quotes if any
DATABASE_URL="${DATABASE_URL%\"}"
DATABASE_URL="${DATABASE_URL#\"}"
DATABASE_URL="${DATABASE_URL%\'}"
DATABASE_URL="${DATABASE_URL#\'}"
```

Everything else in the workflow stays identical.

## Test plan

- [ ] Merge this PR.
- [ ] Re-run the `Run Manual SQL Migration` workflow against `main` with `migration_file = add_attendance_phase_2.sql`.
- [ ] Verify the job succeeds and the three Phase 2 tables (`AttendanceRecord`, `PublicHoliday`, `GoogleSheetAttendanceSyncLog`) exist in production.

https://claude.ai/code/session_011rpxCt8Kzc7q9FwxXAcoss