### PR TITLE
fix(hr): correct attendance parser row/col offsets + A/P ↔ O.T swap (18.1.1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Project Overview
 Enterprise ERP for steel fabrication projects. Next.js 15 App Router + TypeScript + Prisma + MySQL.
 Deployed at `hexasteel.sa/ots` with optional `NEXT_PUBLIC_BASE_PATH` subpath.
-**Current version:** `18.1.0` — **Minor:** HR / Payroll Module Phase 2 — Attendance, Leaves & Overtime Ingestion. Adds the AttendanceRecord / PublicHoliday / GoogleSheetAttendanceSyncLog schema, one-way Google Sheets → OTS attendance sync reading the shared Overtime tab (same workbook used by PTS sync), the runAttendanceSync service with Friday 1.5× OT auto-detection and SHA-256 row-hash idempotency, monthly per-worker timesheet with colour-coded day grid, public holidays CRUD, and five new `hr.attendance.*` / `hr.holiday.*` permissions. Sheet-wins policy (no writeback, no preserve-on-edit). Orphan identifiers downgrade runs to PARTIAL without failing the job.
+**Current version:** `18.1.1` — **Patch:** Attendance sheet parser now targets the correct Overtime-tab rows and columns after the first production probe. Header row moved from 10 → 12, data-start row from 12 → 15, first worker column from E → Q. Also fixes a semantics swap between A/P (regular hours) and O.T (overtime hours) — they were previously reversed, routing regular hours into the overtime field and vice-versa. Renames internal `colIndexA` / `colIndexP` → `colIndexAP` / `colIndexOT` for clarity.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hexa-steel-ots",
-  "version": "18.1.0",
+  "version": "18.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hexa-steel-ots",
-      "version": "18.1.0",
+      "version": "18.1.1",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexa-steel-ots",
-  "version": "18.1.0",
+  "version": "18.1.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/api/hr/attendance/sync/probe/route.ts
+++ b/src/app/api/hr/attendance/sync/probe/route.ts
@@ -30,10 +30,10 @@ export async function GET() {
   if (!canProbe) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
 
   try {
-    // Rows 1..25 — everything above and just below the assumed data-start at row 12.
+    // Rows 1..25 — everything above and just below the data-start at row 15.
     const headerBlock = await readAttendanceRange(`${ATTENDANCE_TAB_NAME}!A1:ZZ25`);
-    // Totals row usually sits near the very top; sample separately for clarity.
-    const firstFiveDataRows = headerBlock.slice(11, 16);
+    // Data starts at 0-based index 14 (sheet row 15) — sample the first 5 rows.
+    const firstFiveDataRows = headerBlock.slice(14, 19);
 
     return NextResponse.json({
       spreadsheetId: ATTENDANCE_SPREADSHEET_ID,
@@ -41,12 +41,15 @@ export async function GET() {
       rowCount: headerBlock.length,
       maxCols: headerBlock.reduce((m, r) => Math.max(m, r.length), 0),
       headerBlockRows1to25: headerBlock,
-      firstFiveDataRowsAssumedFrom12: firstFiveDataRows,
+      firstFiveDataRowsAssumedFrom15: firstFiveDataRows,
       notes: [
-        'Rows 1-11 are reporting/header per Walid',
-        'Data expected to start at row 12',
-        'Employees: 2 columns each (A/P = Absence/Presence)',
-        'Manpower slots: 1 column each (no overtime)',
+        'Rows 1-11: reporting / role / category header block',
+        'Row 12: worker name row (e.g. "25-Mustafa Ibrahim", "SH-W1")',
+        'Row 13: monthly totals per worker (ignored)',
+        'Row 14: "Date / Month / Total / …" column labels (ignored)',
+        'Row 15+: daily data',
+        'Col A: date · Col B: month label · Col C-P: daily breakdowns (ignored)',
+        'Col Q+: worker cells — employees 2 cols (A/P + O.T), slots 1 col',
       ],
     });
   } catch (error) {

--- a/src/components/hr/timesheet-client.tsx
+++ b/src/components/hr/timesheet-client.tsx
@@ -222,7 +222,7 @@ export function TimesheetClient({
                 const title =
                   (holiday ? `${holiday.nameEn}\n` : '') +
                   (rec
-                    ? `${status}\nRegular: ${rec.regularHours}h\nOT: ${rec.overtimeHours}h (×${rec.otMultiplier})${rec.rawCellP ? `\nP: ${rec.rawCellP}` : ''}${rec.rawCellA ? `\nA: ${rec.rawCellA}` : ''}`
+                    ? `${status}\nRegular: ${rec.regularHours}h\nOT: ${rec.overtimeHours}h (×${rec.otMultiplier})${rec.rawCellA ? `\nA/P: ${rec.rawCellA}` : ''}${rec.rawCellP ? `\nO.T: ${rec.rawCellP}` : ''}`
                     : 'No record');
                 return (
                   <div

--- a/src/lib/services/hr/sync-attendance-from-sheet.ts
+++ b/src/lib/services/hr/sync-attendance-from-sheet.ts
@@ -5,18 +5,20 @@
  * of the Hexa attendance workbook into OTS `AttendanceRecord`. Triggered
  * manually via the sync UI; idempotent.
  *
- * Sheet layout (per Walid, 2026-04-12):
- *   - Rows 1-11: reporting / designation header block (ignored by sync)
- *   - Row 12+  : one row per date
- *   - Col A    : date (e.g. "Sat-01-11-25")
- *   - Col B    : month (e.g. "11-2025")
- *   - Col C/D  : daily totals (ignored — we re-compute)
- *   - From col E onwards:
- *       * Employees — 2 columns each, labeled A/P (Absence/Presence)
- *       * Manpower slots — 1 column each (no overtime entitlement)
- *   - Header row above each employee/slot pair contains:
- *       "<employmentId>-<Name>" for employees
- *       "<slotCode>" or "<slotCode>-<name>" for manpower slots
+ * Sheet layout (observed from the Overtime tab probe, 2026-04-12):
+ *   - Rows 1-11 : reporting / designation / role header block (ignored)
+ *   - Row 12    : worker-name header row
+ *                   "<employmentId>-<Name>" for employees (2 identical cells — A/P + O.T)
+ *                   "<slotCode>" or "<slotCode>-<name>" for manpower slots (1 cell)
+ *   - Row 13    : per-worker monthly totals (ignored — we re-compute)
+ *   - Row 14    : "Date / Month / Total / …" column labels (ignored)
+ *   - Row 15+   : one row per date
+ *   - Col A     : date (e.g. "Wed-01-1-25")
+ *   - Col B     : month label (e.g. "Wed 1/01", "8-2025")
+ *   - Col C-P   : daily totals / breakdowns (ignored)
+ *   - Col Q+    : per-worker columns
+ *       * Employees — 2 columns each (A/P + O.T)
+ *       * Manpower slots — 1 column each
  *
  * Cell semantics:
  *   - Numeric value → hours worked that slot/day
@@ -27,9 +29,9 @@
  *   - Empty / 0 on a Friday → WEEKEND
  *   - Empty / 0 on any other day → UNKNOWN (soft warning)
  *
- * For employees the two cells (A, P) are combined into a single record:
- *   - P cell holds regular hours worked
- *   - A cell holds overtime hours (OT is logged on top of regular)
+ * For employees the two cells per day are combined into a single record:
+ *   - colIndexAP (first of pair, sheet label "A/P") → regular hours worked
+ *   - colIndexOT (second of pair, sheet label "O.T") → overtime hours on top
  *   - If either cell is an absence code, the row is an absence and hours = 0
  *   - Friday with any positive hours → isFriday=true, otMultiplier=1.5
  *
@@ -52,11 +54,11 @@ import {
 // CONSTANTS
 // ============================================================================
 
-const HEADER_ID_NAME_ROW_INDEX = 9; // 0-based — "25-Mustafa Ibrahim" style row
-const DATA_START_ROW_INDEX = 11;   // 0-based — first daily row (row 12 in sheet)
-const DATE_COL_INDEX = 0;          // col A
-const MONTH_COL_INDEX = 1;         // col B
-const FIRST_WORKER_COL_INDEX = 4;  // col E
+const HEADER_ID_NAME_ROW_INDEX = 11; // 0-based — sheet row 12 ("25-Mustafa Ibrahim")
+const DATA_START_ROW_INDEX = 14;     // 0-based — sheet row 15 (first daily row)
+const DATE_COL_INDEX = 0;            // col A
+const MONTH_COL_INDEX = 1;           // col B
+const FIRST_WORKER_COL_INDEX = 16;   // col Q
 
 // Absence codes the sheet uses. Case-insensitive match on trim.
 const ABSENCE_CODES = new Map<string, AttendanceStatusLiteral>([
@@ -88,8 +90,8 @@ interface WorkerColumn {
   manpowerSlotId: string | null;   // OTS ManpowerSlot.id if resolved
   identifier: string;               // raw identifier from header ("25", "SH-W01", etc.)
   displayName: string;              // raw header text
-  colIndexA: number;                // column index of the "A" cell (or the only cell for slots)
-  colIndexP: number | null;         // column index of the "P" cell (null for manpower slots)
+  colIndexAP: number;               // "A/P" column (regular hours) — the only cell for slots
+  colIndexOT: number | null;        // "O.T" column (overtime hours) — null for manpower slots
   orphan: boolean;                  // true if identifier did not resolve
 }
 
@@ -170,8 +172,8 @@ async function parseWorkerColumns(headerRow: string[]): Promise<WorkerColumn[]> 
         manpowerSlotId: null,
         identifier: employmentId,
         displayName,
-        colIndexA: col,
-        colIndexP: col + 1,
+        colIndexAP: col,
+        colIndexOT: col + 1,
         orphan: !resolved,
       });
       col += 2;
@@ -189,8 +191,8 @@ async function parseWorkerColumns(headerRow: string[]): Promise<WorkerColumn[]> 
         manpowerSlotId: resolved?.id ?? null,
         identifier: slotCode,
         displayName: raw,
-        colIndexA: col,
-        colIndexP: null,
+        colIndexAP: col,
+        colIndexOT: null,
         orphan: !resolved,
       });
       col += 1;
@@ -322,7 +324,7 @@ export async function runAttendanceSync(
       .map((w) => ({
         identifier: w.identifier,
         displayName: w.displayName,
-        headerColumnIndex: w.colIndexA,
+        headerColumnIndex: w.colIndexAP,
       }));
 
     const slotOrphans: Orphan[] = workerColumns
@@ -330,7 +332,7 @@ export async function runAttendanceSync(
       .map((w) => ({
         identifier: w.identifier,
         displayName: w.displayName,
-        headerColumnIndex: w.colIndexA,
+        headerColumnIndex: w.colIndexAP,
       }));
 
     const resolvedColumns = workerColumns.filter((w) => !w.orphan);
@@ -369,11 +371,11 @@ export async function runAttendanceSync(
       const dayIsHoliday = holidaySet.has(isoDate);
 
       for (const worker of resolvedColumns) {
-        const rawA = (row[worker.colIndexA] ?? '').toString();
-        const rawP = worker.colIndexP !== null ? (row[worker.colIndexP] ?? '').toString() : '';
+        const rawAP = (row[worker.colIndexAP] ?? '').toString();
+        const rawOT = worker.colIndexOT !== null ? (row[worker.colIndexOT] ?? '').toString() : '';
 
-        const parsedA = parseCellValue(rawA);
-        const parsedP = worker.colIndexP !== null ? parseCellValue(rawP) : { isNumeric: false, hours: 0, code: null };
+        const parsedAP = parseCellValue(rawAP);
+        const parsedOT = worker.colIndexOT !== null ? parseCellValue(rawOT) : { isNumeric: false, hours: 0, code: null };
 
         // Determine status + hours.
         let status: AttendanceStatusLiteral = 'UNKNOWN';
@@ -382,13 +384,13 @@ export async function runAttendanceSync(
         let otMultiplier = 1.0;
 
         // Any absence code in either cell wins.
-        const absenceCode = parsedA.code ?? parsedP.code ?? null;
+        const absenceCode = parsedAP.code ?? parsedOT.code ?? null;
         if (absenceCode) {
           status = absenceCode;
         } else if (worker.workerType === 'EMPLOYEE') {
-          // Two-cell employee: P = regular hours, A = overtime hours.
-          regularHours = parsedP.isNumeric ? Math.max(0, parsedP.hours) : 0;
-          overtimeHours = parsedA.isNumeric ? Math.max(0, parsedA.hours) : 0;
+          // Two-cell employee: A/P column = regular hours, O.T column = overtime.
+          regularHours = parsedAP.isNumeric ? Math.max(0, parsedAP.hours) : 0;
+          overtimeHours = parsedOT.isNumeric ? Math.max(0, parsedOT.hours) : 0;
           if (regularHours + overtimeHours > 0) {
             status = 'PRESENT';
             if (dayIsFriday) otMultiplier = 1.5;
@@ -400,13 +402,13 @@ export async function runAttendanceSync(
             status = 'UNKNOWN';
             softWarnings.push({
               row: r + 1,
-              column: worker.colIndexA + 1,
+              column: worker.colIndexAP + 1,
               message: `Empty cells for employee ${worker.identifier} on non-Friday ${isoDate}`,
             });
           }
         } else {
           // Manpower slot: single cell, regular hours only.
-          regularHours = parsedA.isNumeric ? Math.max(0, parsedA.hours) : 0;
+          regularHours = parsedAP.isNumeric ? Math.max(0, parsedAP.hours) : 0;
           if (regularHours > 0) {
             status = 'PRESENT';
           } else if (dayIsHoliday) {
@@ -418,7 +420,7 @@ export async function runAttendanceSync(
           }
         }
 
-        const hash = rowHash([worker.identifier, isoDate, rawA, rawP, status, regularHours, overtimeHours]);
+        const hash = rowHash([worker.identifier, isoDate, rawAP, rawOT, status, regularHours, overtimeHours]);
 
         const whereClause: Prisma.AttendanceRecordWhereInput = {
           workerType: worker.workerType,
@@ -444,8 +446,8 @@ export async function runAttendanceSync(
               otMultiplier,
               isFriday: dayIsFriday,
               isPublicHoliday: dayIsHoliday,
-              rawCellA: rawA || null,
-              rawCellP: rawP || null,
+              rawCellA: rawAP || null,
+              rawCellP: rawOT || null,
               sourceRowHash: hash,
               lastImportBatchId: syncLog.id,
               lastImportedAt,
@@ -465,8 +467,8 @@ export async function runAttendanceSync(
               otMultiplier,
               isFriday: dayIsFriday,
               isPublicHoliday: dayIsHoliday,
-              rawCellA: rawA || null,
-              rawCellP: rawP || null,
+              rawCellA: rawAP || null,
+              rawCellP: rawOT || null,
               sourceRowHash: hash,
               lastImportBatchId: syncLog.id,
               lastImportedAt,

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -9,7 +9,7 @@ const resolvedVersion = process.env.NEXT_PUBLIC_APP_VERSION ?? '0.0.0';
 export const APP_VERSION = {
   version: resolvedVersion,
   date: 'April 12, 2026',
-  type: 'minor' as const, // 18.1.0
+  type: 'patch' as const, // 18.1.1
   // version is injected from package.json via NEXT_PUBLIC_APP_VERSION
   name: 'Hexa Steel Operation Tracking System',
 };


### PR DESCRIPTION
## Summary

The first production sync against the `Overtime` tab on 2026-04-12 came back as `PARTIAL: 479 read, 0 created, 0 updated, 0 unchanged, 101 orphans`. The probe dump made it obvious what was wrong — the parser was pointed at the **role labels row** and at the **daily-totals columns**, not at the per-worker data.

This PR fixes three wrong constants and one semantic inversion. No schema change; pure code fix.

## Sheet reality (from the probe, 2026-04-12)

| Sheet row | Content |
|---|---|
| 1–9 | Reporting header block (totals, month labels, legend) |
| 10 | `Laser Operator / Fabricator / Welder …` — **role** labels |
| 11 | `A/P, O.T, A/P, O.T …` — column-type labels |
| 12 | `25-Mustafa Ibrahim / SH-W1 / AHR-H1 …` — **real worker name row** |
| 13 | Monthly totals per worker |
| 14 | `Date / Month / Total / …` column labels |
| **15+** | Daily data (`Wed-01-1-25`, `Thu-02-1-25`, …) |

And horizontally: columns A–P hold dates / summary breakdowns, per-worker cells start at **col Q (index 16)**.

## What this PR changes

**`src/lib/services/hr/sync-attendance-from-sheet.ts`**

| Constant | Before | After |
|---|---|---|
| `HEADER_ID_NAME_ROW_INDEX` | `9` (sheet row 10 — role row) | `11` (sheet row 12 — worker name row) |
| `DATA_START_ROW_INDEX` | `11` (sheet row 12 — still header) | `14` (sheet row 15 — first daily row) |
| `FIRST_WORKER_COL_INDEX` | `4` (col E — daily breakdowns) | `16` (col Q — first per-worker cell) |

**A/P ↔ O.T semantic fix**

In the sheet each employee has two adjacent columns: the first labelled `A/P` (Absence/Presence → regular hours) and the second labelled `O.T` (Overtime hours). The parser had them swapped in the upsert:

```diff
- regularHours  = parsedP.hours   // P was the second (O.T) col → overtime, not regular
- overtimeHours = parsedA.hours   // A was the first (A/P) col → regular, not overtime
+ regularHours  = parsedAP.hours
+ overtimeHours = parsedOT.hours
```

So even if the row/col offsets had been right, every present day would have landed in the DB with `regularHours = 0` and `overtimeHours = 8`.

Internal field names renamed `colIndexA` / `colIndexP` → `colIndexAP` / `colIndexOT` to make the confusion impossible to reintroduce.

**Other files**

- `src/app/api/hr/attendance/sync/probe/route.ts` — probe sample range updated to `slice(14, 19)`; notes describe the real layout.
- `src/components/hr/timesheet-client.tsx` — tooltip now labels the raw cells as `A/P` and `O.T` instead of `A` / `P`.

**No schema change** — the DB columns `rawCellA` / `rawCellP` keep their names; they now store the A/P cell and the O.T cell respectively. Renaming them would need a migration and they're just raw debug breadcrumbs anyway.

## Version bump

`18.1.0` → `18.1.1` (patch, bugfix only).

## Test plan

1. Merge + deploy.
2. From `/hr/attendance/sync` click **Probe sheet layout** — verify `firstFiveDataRowsAssumedFrom15[0][0]` is `Wed-01-1-25` and row 12's col index 16 is `25-Mustafa Ibrahim`.
3. Click **Sync now**. Expected result:
   - `rowsRead` ≈ number of workdays 2026-01-01 → today (not 479 anymore — 479 was the full row count including empty/total rows).
   - `rowsCreated` > 0 on the first run after the fix.
   - Employee orphans: 0 (or very small — only workers whose `employmentId` prefix doesn't match an OTS Employee).
   - Slot orphans: 0 (or only slots whose codes Walid hasn't configured yet).
   - **Not** `Helper / Fabricator / Welder / Project Supervisor …` — those were role labels being misread as slot codes.
4. Open `/hr/attendance/timesheet/EMPLOYEE/<mustafa-id>?month=2026-04` — verify the calendar shows regular hours on the working days, not overtime.

https://claude.ai/code/session_011rpxCt8Kzc7q9FwxXAcoss