### PR TITLE
fix(hr-contracts): run migration, seed permissions, guard HR dashboard

### DIFF
--- a/prisma/manual_migrations/add_contracts.sql
+++ b/prisma/manual_migrations/add_contracts.sql
@@ -34,3 +34,53 @@ CREATE TABLE IF NOT EXISTS `Contract` (
   CONSTRAINT `Contract_updatedById_fkey` FOREIGN KEY (`updatedById`) REFERENCES `User` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
   CONSTRAINT `Contract_deletedById_fkey` FOREIGN KEY (`deletedById`) REFERENCES `User` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ─── Seed hr.contracts.view + hr.contracts.manage into HR and CEO roles ───────
+-- Idempotent: JSON_SEARCH guard prevents duplicate entries.
+
+DROP PROCEDURE IF EXISTS add_contracts_permissions;
+DELIMITER $$
+CREATE PROCEDURE add_contracts_permissions()
+BEGIN
+  -- HR role: view
+  IF EXISTS (SELECT 1 FROM `Role` WHERE `name` = 'HR') THEN
+    UPDATE `Role`
+    SET `permissions` = JSON_ARRAY_APPEND(IFNULL(`permissions`, JSON_ARRAY()), '$', 'hr.contracts.view')
+    WHERE `name` = 'HR'
+      AND JSON_SEARCH(IFNULL(`permissions`, JSON_ARRAY()), 'one', 'hr.contracts.view') IS NULL;
+    -- HR role: manage
+    UPDATE `Role`
+    SET `permissions` = JSON_ARRAY_APPEND(IFNULL(`permissions`, JSON_ARRAY()), '$', 'hr.contracts.manage')
+    WHERE `name` = 'HR'
+      AND JSON_SEARCH(IFNULL(`permissions`, JSON_ARRAY()), 'one', 'hr.contracts.manage') IS NULL;
+  END IF;
+
+  -- CEO role: view
+  IF EXISTS (SELECT 1 FROM `Role` WHERE `name` = 'CEO') THEN
+    UPDATE `Role`
+    SET `permissions` = JSON_ARRAY_APPEND(IFNULL(`permissions`, JSON_ARRAY()), '$', 'hr.contracts.view')
+    WHERE `name` = 'CEO'
+      AND JSON_SEARCH(IFNULL(`permissions`, JSON_ARRAY()), 'one', 'hr.contracts.view') IS NULL;
+    -- CEO role: manage
+    UPDATE `Role`
+    SET `permissions` = JSON_ARRAY_APPEND(IFNULL(`permissions`, JSON_ARRAY()), '$', 'hr.contracts.manage')
+    WHERE `name` = 'CEO'
+      AND JSON_SEARCH(IFNULL(`permissions`, JSON_ARRAY()), 'one', 'hr.contracts.manage') IS NULL;
+  END IF;
+
+  -- Admin role: view
+  IF EXISTS (SELECT 1 FROM `Role` WHERE `name` = 'Admin') THEN
+    UPDATE `Role`
+    SET `permissions` = JSON_ARRAY_APPEND(IFNULL(`permissions`, JSON_ARRAY()), '$', 'hr.contracts.view')
+    WHERE `name` = 'Admin'
+      AND JSON_SEARCH(IFNULL(`permissions`, JSON_ARRAY()), 'one', 'hr.contracts.view') IS NULL;
+    -- Admin role: manage
+    UPDATE `Role`
+    SET `permissions` = JSON_ARRAY_APPEND(IFNULL(`permissions`, JSON_ARRAY()), '$', 'hr.contracts.manage')
+    WHERE `name` = 'Admin'
+      AND JSON_SEARCH(IFNULL(`permissions`, JSON_ARRAY()), 'one', 'hr.contracts.manage') IS NULL;
+  END IF;
+END$$
+DELIMITER ;
+CALL add_contracts_permissions();
+DROP PROCEDURE IF EXISTS add_contracts_permissions;

--- a/scripts/update-hr-role-permissions.ts
+++ b/scripts/update-hr-role-permissions.ts
@@ -70,6 +70,13 @@ const HR_BASE_PERMISSIONS = [
   'hr.loans.manage',
   'hr.custodies.view',
   'hr.custodies.manage',
+  // 18.13.0 — Manpower Billing
+  'hr.billing.view',
+  'hr.billing.manage',
+  'hr.billing.push',
+  // 18.14.0 — Contracts & Documents
+  'hr.contracts.view',
+  'hr.contracts.manage',
 ];
 
 function mergePermissions(existing: unknown, additions: string[]): string[] {

--- a/src/app/hr/dashboard/page.tsx
+++ b/src/app/hr/dashboard/page.tsx
@@ -44,12 +44,13 @@ export default async function HrDashboardPage() {
       select: { section: true },
       distinct: ['section'],
     }),
+    // Graceful fallback: returns null if the Contract table doesn't exist yet (pre-migration)
     Promise.all([
       prisma.contract.count({ where: { deletedAt: null, status: 'ACTIVE' } }),
       prisma.contract.count({ where: { deletedAt: null, status: 'ACTIVE', expiryDate: { gte: today, lte: in7Days } } }),
       prisma.contract.count({ where: { deletedAt: null, status: 'ACTIVE', expiryDate: { gte: today, lte: in30Days } } }),
       prisma.contract.count({ where: { deletedAt: null, status: 'EXPIRED' } }),
-    ]),
+    ]).catch(() => null),
   ]);
 
   const occupations = occupationRows
@@ -61,7 +62,9 @@ export default async function HrDashboardPage() {
     .filter((v): v is string => !!v)
     .sort((a, b) => a.localeCompare(b));
 
-  const [totalActive, expiringIn7, expiringIn30, expired] = contractCounts;
+  const contractStats = contractCounts
+    ? { totalActive: contractCounts[0], expiringIn7: contractCounts[1], expiringIn30: contractCounts[2], expired: contractCounts[3] }
+    : undefined;
 
   return (
     <HrDashboardClient
@@ -69,7 +72,7 @@ export default async function HrDashboardPage() {
       departments={departments}
       occupations={occupations}
       sections={sections}
-      contractStats={{ totalActive, expiringIn7, expiringIn30, expired }}
+      contractStats={contractStats}
     />
   );
 }


### PR DESCRIPTION
Three root causes for the contracts feature being broken:

1. add_contracts.sql now also seeds hr.contracts.view and
   hr.contracts.manage into the HR, CEO, and Admin roles via an
   idempotent stored-procedure JSON_ARRAY_APPEND pattern.
   Running this migration will both create the Contract table AND
   make the Contracts & Docs sidebar entry visible.

2. HR dashboard page wrapped the prisma.contract.count() calls in
   .catch(() => null) so the dashboard does not crash when the
   Contract table has not yet been migrated.  contractStats is passed
   as undefined in that case and the client hides the KPI widget.

3. update-hr-role-permissions.ts now lists hr.billing.* (18.13.0) and
   hr.contracts.{view,manage} (18.14.0) in HR_BASE_PERMISSIONS so
   running the script also grants these to the CEO role.

https://claude.ai/code/session_017CMZVkFgpVbbn9PoiC4Fwh