### PR TITLE
feat(letters): phase 1 — CEO approval workflow, per-type serials, bilingual print

### DIFF
--- a/prisma/manual_migrations/add_hr_letter_enhancements.sql
+++ b/prisma/manual_migrations/add_hr_letter_enhancements.sql
@@ -1,0 +1,102 @@
+-- 19.1.0 — HR Letter Enhancements
+-- Adds CEO approval workflow + per-type serial number config to HR Letters
+-- Idempotent: stored-procedure pattern throughout
+
+DROP PROCEDURE IF EXISTS add_hr_letter_enhancements;
+DELIMITER $$
+CREATE PROCEDURE add_hr_letter_enhancements()
+BEGIN
+  -- status column on HrLetter (PENDING_CEO is the default for new letters)
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'HrLetter' AND COLUMN_NAME = 'status'
+  ) THEN
+    ALTER TABLE HrLetter
+      ADD COLUMN status ENUM('DRAFT','PENDING_CEO','APPROVED','REJECTED') NOT NULL DEFAULT 'PENDING_CEO';
+    CREATE INDEX HrLetter_status_idx ON HrLetter(status);
+  END IF;
+
+  -- language column
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'HrLetter' AND COLUMN_NAME = 'language'
+  ) THEN
+    ALTER TABLE HrLetter
+      ADD COLUMN language ENUM('ARABIC','ENGLISH','BILINGUAL') NOT NULL DEFAULT 'ARABIC';
+  END IF;
+
+  -- approvedById
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'HrLetter' AND COLUMN_NAME = 'approvedById'
+  ) THEN
+    ALTER TABLE HrLetter ADD COLUMN approvedById CHAR(36) NULL;
+    ALTER TABLE HrLetter
+      ADD CONSTRAINT fk_hr_letter_approved_by
+      FOREIGN KEY (approvedById) REFERENCES User(id) ON DELETE SET NULL;
+  END IF;
+
+  -- approvedAt
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'HrLetter' AND COLUMN_NAME = 'approvedAt'
+  ) THEN
+    ALTER TABLE HrLetter ADD COLUMN approvedAt DATETIME(3) NULL;
+  END IF;
+
+  -- rejectedById
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'HrLetter' AND COLUMN_NAME = 'rejectedById'
+  ) THEN
+    ALTER TABLE HrLetter ADD COLUMN rejectedById CHAR(36) NULL;
+    ALTER TABLE HrLetter
+      ADD CONSTRAINT fk_hr_letter_rejected_by
+      FOREIGN KEY (rejectedById) REFERENCES User(id) ON DELETE SET NULL;
+  END IF;
+
+  -- rejectedAt
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'HrLetter' AND COLUMN_NAME = 'rejectedAt'
+  ) THEN
+    ALTER TABLE HrLetter ADD COLUMN rejectedAt DATETIME(3) NULL;
+  END IF;
+
+  -- rejectionReason
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'HrLetter' AND COLUMN_NAME = 'rejectionReason'
+  ) THEN
+    ALTER TABLE HrLetter ADD COLUMN rejectionReason VARCHAR(500) NULL;
+  END IF;
+
+  -- HrLetterSerialConfig table
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'HrLetterSerialConfig'
+  ) THEN
+    CREATE TABLE HrLetterSerialConfig (
+      id            CHAR(36)     NOT NULL,
+      letterType    ENUM(
+        'QUESTIONING','ATTENTION','FIRST_WARNING','FINAL_WARNING',
+        'NON_RENEWAL_NOTICE','DISMISSAL','CIRCULATION','WORK_COMMENCEMENT',
+        'SALARY_CERTIFICATE','LEAVE_NOTICE','RETURN_FROM_LEAVE',
+        'PROBATION_EVALUATION','PERFORMANCE_APPRAISAL','CLEARANCE_FORM',
+        'SALARY_NON_DISCLOSURE','OTHER'
+      ) NOT NULL,
+      prefix        VARCHAR(20)  NOT NULL,
+      mask          VARCHAR(100) NOT NULL DEFAULT '{PREFIX}-{YY}-{NNNN}',
+      currentSeq    INT          NOT NULL DEFAULT 0,
+      lastResetYear INT          NULL,
+      resetYearly   TINYINT(1)   NOT NULL DEFAULT 1,
+      createdAt     DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+      updatedAt     DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+      PRIMARY KEY (id),
+      UNIQUE KEY HrLetterSerialConfig_letterType_key (letterType)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+  END IF;
+END$$
+DELIMITER ;
+CALL add_hr_letter_enhancements();
+DROP PROCEDURE IF EXISTS add_hr_letter_enhancements;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -313,9 +313,11 @@ model User {
   deletedContracts Contract[] @relation("ContractDeletedBy")
 
   // 18.16.0 — Letters & Correspondence
-  createdLetters HrLetter[] @relation("HrLetterCreatedBy")
-  updatedLetters HrLetter[] @relation("HrLetterUpdatedBy")
-  deletedLetters HrLetter[] @relation("HrLetterDeletedBy")
+  createdLetters  HrLetter[] @relation("HrLetterCreatedBy")
+  updatedLetters  HrLetter[] @relation("HrLetterUpdatedBy")
+  deletedLetters  HrLetter[] @relation("HrLetterDeletedBy")
+  approvedLetters HrLetter[] @relation("HrLetterApprovedBy")
+  rejectedLetters HrLetter[] @relation("HrLetterRejectedBy")
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -5420,18 +5422,41 @@ enum HrLetterClass {
   EXTERNAL
 }
 
+enum HrLetterStatus {
+  DRAFT
+  PENDING_CEO
+  APPROVED
+  REJECTED
+}
+
+enum HrLetterLanguage {
+  ARABIC
+  ENGLISH
+  BILINGUAL
+}
+
 model HrLetter {
-  id            String        @id @default(uuid()) @db.Char(36)
-  letterNumber  String        @unique @db.VarChar(30)
-  letterType    HrLetterType
-  classification HrLetterClass @default(INTERNAL)
-  employeeId    String        @db.Char(36)
-  employee      Employee      @relation("EmployeeLetters", fields: [employeeId], references: [id])
-  subject       String        @db.VarChar(500)
-  content       String?       @db.Text
-  attachmentUrl String?       @db.VarChar(1000)
-  issuedAt      DateTime      @default(now()) @db.Date
-  notes         String?       @db.VarChar(500)
+  id             String           @id @default(uuid()) @db.Char(36)
+  letterNumber   String           @unique @db.VarChar(30)
+  letterType     HrLetterType
+  classification HrLetterClass    @default(INTERNAL)
+  language       HrLetterLanguage @default(ARABIC)
+  status         HrLetterStatus   @default(PENDING_CEO)
+  employeeId     String           @db.Char(36)
+  employee       Employee         @relation("EmployeeLetters", fields: [employeeId], references: [id])
+  subject        String           @db.VarChar(500)
+  content        String?          @db.Text
+  attachmentUrl  String?          @db.VarChar(1000)
+  issuedAt       DateTime         @default(now()) @db.Date
+  notes          String?          @db.VarChar(500)
+
+  approvedById    String?   @db.Char(36)
+  approvedBy      User?     @relation("HrLetterApprovedBy", fields: [approvedById], references: [id])
+  approvedAt      DateTime?
+  rejectedById    String?   @db.Char(36)
+  rejectedBy      User?     @relation("HrLetterRejectedBy", fields: [rejectedById], references: [id])
+  rejectedAt      DateTime?
+  rejectionReason String?   @db.VarChar(500)
 
   createdById  String    @db.Char(36)
   createdBy    User      @relation("HrLetterCreatedBy", fields: [createdById], references: [id])
@@ -5446,9 +5471,23 @@ model HrLetter {
 
   @@index([employeeId])
   @@index([letterType, classification])
+  @@index([status])
   @@index([issuedAt])
   @@index([deletedAt])
   @@map("HrLetter")
+}
+
+model HrLetterSerialConfig {
+  id            String       @id @default(uuid()) @db.Char(36)
+  letterType    HrLetterType @unique
+  prefix        String       @db.VarChar(20)
+  mask          String       @default("{PREFIX}-{YY}-{NNNN}") @db.VarChar(100)
+  currentSeq    Int          @default(0)
+  lastResetYear Int?
+  resetYearly   Boolean      @default(true)
+  createdAt     DateTime     @default(now())
+  updatedAt     DateTime     @updatedAt
+  @@map("HrLetterSerialConfig")
 }
 
 // ============================================================================

--- a/src/app/api/hr/letter-serial-configs/[id]/route.ts
+++ b/src/app/api/hr/letter-serial-configs/[id]/route.ts
@@ -1,0 +1,66 @@
+/**
+ * PUT    /api/hr/letter-serial-configs/[id]  — update prefix / mask / resetYearly
+ * DELETE /api/hr/letter-serial-configs/[id]  — delete config (reverts to INT/EXT default)
+ *
+ * 19.1.0
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import prisma from '@/lib/db';
+import { withApiContext } from '@/lib/api-utils';
+import { logger } from '@/lib/logger';
+
+const updateSchema = z.object({
+  prefix: z.string().min(1).max(20).regex(/^[A-Z0-9]+$/, 'Prefix must be uppercase letters/digits only').optional(),
+  mask: z.string().min(1).max(100).optional(),
+  resetYearly: z.boolean().optional(),
+  resetSeq: z.boolean().optional(), // if true, resets currentSeq to 0
+});
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+export const PUT = withApiContext(async (req: NextRequest, _session, ctx: RouteParams) => {
+  const { id } = await ctx.params;
+  const config = await prisma.hrLetterSerialConfig.findUnique({ where: { id } });
+  if (!config) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+  const body: unknown = await req.json();
+  const parsed = updateSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input', details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const d = parsed.data;
+  try {
+    const updated = await prisma.hrLetterSerialConfig.update({
+      where: { id },
+      data: {
+        ...(d.prefix !== undefined ? { prefix: d.prefix.toUpperCase() } : {}),
+        ...(d.mask !== undefined ? { mask: d.mask } : {}),
+        ...(d.resetYearly !== undefined ? { resetYearly: d.resetYearly } : {}),
+        ...(d.resetSeq ? { currentSeq: 0, lastResetYear: null } : {}),
+      },
+    });
+    logger.info({ id }, '[LetterSerial] Config updated');
+    return NextResponse.json(updated);
+  } catch (error) {
+    logger.error({ error, id }, 'Failed to update letter serial config');
+    return NextResponse.json({ error: 'Failed to update config' }, { status: 500 });
+  }
+});
+
+export const DELETE = withApiContext(async (_req: NextRequest, _session, ctx: RouteParams) => {
+  const { id } = await ctx.params;
+  const config = await prisma.hrLetterSerialConfig.findUnique({ where: { id } });
+  if (!config) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+  try {
+    await prisma.hrLetterSerialConfig.delete({ where: { id } });
+    logger.info({ id, letterType: config.letterType }, '[LetterSerial] Config deleted');
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    logger.error({ error, id }, 'Failed to delete letter serial config');
+    return NextResponse.json({ error: 'Failed to delete config' }, { status: 500 });
+  }
+});

--- a/src/app/api/hr/letter-serial-configs/route.ts
+++ b/src/app/api/hr/letter-serial-configs/route.ts
@@ -1,0 +1,71 @@
+/**
+ * GET  /api/hr/letter-serial-configs  — list all serial configs
+ * POST /api/hr/letter-serial-configs  — create a new serial config for a letter type
+ *
+ * 19.1.0
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import prisma from '@/lib/db';
+import { withApiContext } from '@/lib/api-utils';
+import { logger } from '@/lib/logger';
+
+const LETTER_TYPES = [
+  'QUESTIONING', 'ATTENTION', 'FIRST_WARNING', 'FINAL_WARNING',
+  'NON_RENEWAL_NOTICE', 'DISMISSAL', 'CIRCULATION', 'WORK_COMMENCEMENT',
+  'SALARY_CERTIFICATE', 'LEAVE_NOTICE', 'RETURN_FROM_LEAVE',
+  'PROBATION_EVALUATION', 'PERFORMANCE_APPRAISAL', 'CLEARANCE_FORM',
+  'SALARY_NON_DISCLOSURE', 'OTHER',
+] as const;
+
+const createSchema = z.object({
+  letterType: z.enum(LETTER_TYPES),
+  prefix: z.string().min(1).max(20).regex(/^[A-Z0-9]+$/, 'Prefix must be uppercase letters/digits only'),
+  mask: z.string().min(1).max(100).default('{PREFIX}-{YY}-{NNNN}'),
+  resetYearly: z.boolean().default(true),
+});
+
+export const GET = withApiContext(async () => {
+  try {
+    const configs = await prisma.hrLetterSerialConfig.findMany({
+      orderBy: { letterType: 'asc' },
+    });
+    return NextResponse.json(configs);
+  } catch (error) {
+    logger.error({ error }, 'Failed to fetch letter serial configs');
+    return NextResponse.json({ error: 'Failed to fetch configs' }, { status: 500 });
+  }
+});
+
+export const POST = withApiContext(async (req: NextRequest) => {
+  const body: unknown = await req.json();
+  const parsed = createSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input', details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const d = parsed.data;
+
+  const existing = await prisma.hrLetterSerialConfig.findUnique({ where: { letterType: d.letterType } });
+  if (existing) {
+    return NextResponse.json({ error: 'Config already exists for this letter type' }, { status: 409 });
+  }
+
+  try {
+    const config = await prisma.hrLetterSerialConfig.create({
+      data: {
+        letterType: d.letterType,
+        prefix: d.prefix.toUpperCase(),
+        mask: d.mask,
+        resetYearly: d.resetYearly,
+        currentSeq: 0,
+      },
+    });
+    logger.info({ configId: config.id, letterType: d.letterType }, '[LetterSerial] Config created');
+    return NextResponse.json(config, { status: 201 });
+  } catch (error) {
+    logger.error({ error }, 'Failed to create letter serial config');
+    return NextResponse.json({ error: 'Failed to create config' }, { status: 500 });
+  }
+});

--- a/src/app/api/hr/letters/[id]/approve/route.ts
+++ b/src/app/api/hr/letters/[id]/approve/route.ts
@@ -1,0 +1,68 @@
+/**
+ * POST /api/hr/letters/[id]/approve  — CEO approves a pending letter
+ *
+ * 19.1.0
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '@/lib/db';
+import { withApiContext } from '@/lib/api-utils';
+import { logger } from '@/lib/logger';
+import { NotificationService } from '@/lib/services/notification.service';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+export const POST = withApiContext(async (_req: NextRequest, session, ctx: RouteParams) => {
+  const { id } = await ctx.params;
+
+  const permissions: string[] = (session as unknown as { permissions?: string[] }).permissions ?? [];
+  if (!permissions.includes('hr.letters.approveCeo') && !permissions.includes('ALL')) {
+    return NextResponse.json({ error: 'Forbidden — CEO approval permission required' }, { status: 403 });
+  }
+
+  const letter = await prisma.hrLetter.findFirst({
+    where: { id, deletedAt: null },
+    include: {
+      employee: { select: { fullNameEn: true } },
+      createdBy: { select: { id: true, name: true } },
+    },
+  });
+  if (!letter) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  if (letter.status !== 'PENDING_CEO') {
+    return NextResponse.json({ error: `Letter is ${letter.status} — only PENDING_CEO letters can be approved` }, { status: 422 });
+  }
+
+  try {
+    const updated = await prisma.hrLetter.update({
+      where: { id },
+      data: {
+        status: 'APPROVED',
+        approvedById: session!.userId,
+        approvedAt: new Date(),
+        updatedById: session!.userId,
+      },
+      include: {
+        employee: { select: { id: true, fullNameEn: true, employmentId: true } },
+        createdBy: { select: { id: true, name: true } },
+        approvedBy: { select: { id: true, name: true } },
+      },
+    });
+
+    // Notify the HR user who created the letter
+    const approverName = updated.approvedBy?.name ?? 'CEO';
+    NotificationService.createNotification({
+      userId: letter.createdBy.id,
+      type: 'APPROVED',
+      title: 'Letter Approved',
+      message: `${approverName} approved letter ${letter.letterNumber} for ${letter.employee.fullNameEn}`,
+      relatedEntityType: 'hr_letter',
+      relatedEntityId: id,
+    }).catch((err) => logger.warn({ err }, 'Failed to send letter approval notification'));
+
+    logger.info({ letterId: id, letterNumber: letter.letterNumber, approvedBy: session!.userId }, '[Letters] Approved');
+    return NextResponse.json(updated);
+  } catch (error) {
+    logger.error({ error, id }, 'Failed to approve HR letter');
+    return NextResponse.json({ error: 'Failed to approve letter' }, { status: 500 });
+  }
+});

--- a/src/app/api/hr/letters/[id]/reject/route.ts
+++ b/src/app/api/hr/letters/[id]/reject/route.ts
@@ -1,0 +1,80 @@
+/**
+ * POST /api/hr/letters/[id]/reject  — CEO rejects a pending letter
+ *
+ * 19.1.0
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import prisma from '@/lib/db';
+import { withApiContext } from '@/lib/api-utils';
+import { logger } from '@/lib/logger';
+import { NotificationService } from '@/lib/services/notification.service';
+
+const rejectSchema = z.object({
+  reason: z.string().min(1).max(500),
+});
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+export const POST = withApiContext(async (req: NextRequest, session, ctx: RouteParams) => {
+  const { id } = await ctx.params;
+
+  const permissions: string[] = (session as unknown as { permissions?: string[] }).permissions ?? [];
+  if (!permissions.includes('hr.letters.approveCeo') && !permissions.includes('ALL')) {
+    return NextResponse.json({ error: 'Forbidden — CEO approval permission required' }, { status: 403 });
+  }
+
+  const body: unknown = await req.json();
+  const parsed = rejectSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Rejection reason is required', details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const letter = await prisma.hrLetter.findFirst({
+    where: { id, deletedAt: null },
+    include: {
+      employee: { select: { fullNameEn: true } },
+      createdBy: { select: { id: true, name: true } },
+    },
+  });
+  if (!letter) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  if (letter.status !== 'PENDING_CEO') {
+    return NextResponse.json({ error: `Letter is ${letter.status} — only PENDING_CEO letters can be rejected` }, { status: 422 });
+  }
+
+  try {
+    const updated = await prisma.hrLetter.update({
+      where: { id },
+      data: {
+        status: 'REJECTED',
+        rejectedById: session!.userId,
+        rejectedAt: new Date(),
+        rejectionReason: parsed.data.reason,
+        updatedById: session!.userId,
+      },
+      include: {
+        employee: { select: { id: true, fullNameEn: true, employmentId: true } },
+        createdBy: { select: { id: true, name: true } },
+        rejectedBy: { select: { id: true, name: true } },
+      },
+    });
+
+    // Notify the HR creator
+    const rejectorName = updated.rejectedBy?.name ?? 'CEO';
+    NotificationService.createNotification({
+      userId: letter.createdBy.id,
+      type: 'REJECTED',
+      title: 'Letter Rejected',
+      message: `${rejectorName} rejected letter ${letter.letterNumber} for ${letter.employee.fullNameEn}: ${parsed.data.reason}`,
+      relatedEntityType: 'hr_letter',
+      relatedEntityId: id,
+    }).catch((err) => logger.warn({ err }, 'Failed to send letter rejection notification'));
+
+    logger.info({ letterId: id, letterNumber: letter.letterNumber, rejectedBy: session!.userId }, '[Letters] Rejected');
+    return NextResponse.json(updated);
+  } catch (error) {
+    logger.error({ error, id }, 'Failed to reject HR letter');
+    return NextResponse.json({ error: 'Failed to reject letter' }, { status: 500 });
+  }
+});

--- a/src/app/api/hr/letters/[id]/route.ts
+++ b/src/app/api/hr/letters/[id]/route.ts
@@ -1,9 +1,9 @@
 /**
  * GET    /api/hr/letters/[id]
- * PUT    /api/hr/letters/[id]
+ * PUT    /api/hr/letters/[id]  — only editable while PENDING_CEO or REJECTED
  * DELETE /api/hr/letters/[id]  — soft delete
  *
- * 18.16.0
+ * 19.1.0
  */
 
 import { NextRequest, NextResponse } from 'next/server';
@@ -25,7 +25,15 @@ const updateSchema = z.object({
     'PROBATION_EVALUATION', 'PERFORMANCE_APPRAISAL', 'CLEARANCE_FORM',
     'SALARY_NON_DISCLOSURE', 'OTHER',
   ]).optional(),
+  language: z.enum(['ARABIC', 'ENGLISH', 'BILINGUAL']).optional(),
 });
+
+const LETTER_INCLUDE = {
+  employee: { select: { id: true, fullNameEn: true, fullNameAr: true, employmentId: true, department: true, occupation: true } },
+  createdBy: { select: { id: true, name: true } },
+  approvedBy: { select: { id: true, name: true } },
+  rejectedBy: { select: { id: true, name: true } },
+} as const;
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -33,10 +41,7 @@ export const GET = withApiContext(async (_req: NextRequest, _session, ctx: Route
   const { id } = await ctx.params;
   const letter = await prisma.hrLetter.findFirst({
     where: { id, deletedAt: null },
-    include: {
-      employee: { select: { id: true, fullNameEn: true, employmentId: true } },
-      createdBy: { select: { id: true, name: true } },
-    },
+    include: LETTER_INCLUDE,
   });
   if (!letter) return NextResponse.json({ error: 'Not found' }, { status: 404 });
   return NextResponse.json(letter);
@@ -44,8 +49,12 @@ export const GET = withApiContext(async (_req: NextRequest, _session, ctx: Route
 
 export const PUT = withApiContext(async (req: NextRequest, session, ctx: RouteParams) => {
   const { id } = await ctx.params;
-  const letter = await prisma.hrLetter.findFirst({ where: { id, deletedAt: null }, select: { id: true } });
+  const letter = await prisma.hrLetter.findFirst({ where: { id, deletedAt: null }, select: { id: true, status: true } });
   if (!letter) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+  if (letter.status === 'APPROVED') {
+    return NextResponse.json({ error: 'Approved letters cannot be edited' }, { status: 422 });
+  }
 
   const body: unknown = await req.json();
   const parsed = updateSchema.safeParse(body);
@@ -64,8 +73,10 @@ export const PUT = withApiContext(async (req: NextRequest, session, ctx: RoutePa
         ...(d.issuedAt !== undefined ? { issuedAt: new Date(d.issuedAt) } : {}),
         ...(d.notes !== undefined ? { notes: d.notes } : {}),
         ...(d.letterType !== undefined ? { letterType: d.letterType } : {}),
+        ...(d.language !== undefined ? { language: d.language } : {}),
         updatedById: session!.userId,
       },
+      include: LETTER_INCLUDE,
     });
     return NextResponse.json(updated);
   } catch (error) {
@@ -76,8 +87,12 @@ export const PUT = withApiContext(async (req: NextRequest, session, ctx: RoutePa
 
 export const DELETE = withApiContext(async (_req: NextRequest, session, ctx: RouteParams) => {
   const { id } = await ctx.params;
-  const letter = await prisma.hrLetter.findFirst({ where: { id, deletedAt: null }, select: { id: true } });
+  const letter = await prisma.hrLetter.findFirst({ where: { id, deletedAt: null }, select: { id: true, status: true } });
   if (!letter) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+  if (letter.status === 'APPROVED') {
+    return NextResponse.json({ error: 'Approved letters cannot be deleted' }, { status: 422 });
+  }
 
   try {
     await prisma.hrLetter.update({

--- a/src/app/api/hr/letters/route.ts
+++ b/src/app/api/hr/letters/route.ts
@@ -1,8 +1,8 @@
 /**
- * GET  /api/hr/letters  — list letters (optional ?employeeId=, ?type=, ?classification=)
- * POST /api/hr/letters  — create a new letter with auto-number
+ * GET  /api/hr/letters  — list letters (optional ?employeeId=, ?type=, ?classification=, ?status=)
+ * POST /api/hr/letters  — create a new letter with per-type serial number, notify CEO
  *
- * 18.16.0
+ * 19.1.0
  */
 
 import { NextRequest, NextResponse } from 'next/server';
@@ -10,17 +10,21 @@ import { z } from 'zod';
 import prisma from '@/lib/db';
 import { withApiContext } from '@/lib/api-utils';
 import { logger } from '@/lib/logger';
+import { NotificationService } from '@/lib/services/notification.service';
+
+const LETTER_TYPES = [
+  'QUESTIONING', 'ATTENTION', 'FIRST_WARNING', 'FINAL_WARNING',
+  'NON_RENEWAL_NOTICE', 'DISMISSAL', 'CIRCULATION', 'WORK_COMMENCEMENT',
+  'SALARY_CERTIFICATE', 'LEAVE_NOTICE', 'RETURN_FROM_LEAVE',
+  'PROBATION_EVALUATION', 'PERFORMANCE_APPRAISAL', 'CLEARANCE_FORM',
+  'SALARY_NON_DISCLOSURE', 'OTHER',
+] as const;
 
 const createSchema = z.object({
   employeeId: z.string().uuid(),
-  letterType: z.enum([
-    'QUESTIONING', 'ATTENTION', 'FIRST_WARNING', 'FINAL_WARNING',
-    'NON_RENEWAL_NOTICE', 'DISMISSAL', 'CIRCULATION', 'WORK_COMMENCEMENT',
-    'SALARY_CERTIFICATE', 'LEAVE_NOTICE', 'RETURN_FROM_LEAVE',
-    'PROBATION_EVALUATION', 'PERFORMANCE_APPRAISAL', 'CLEARANCE_FORM',
-    'SALARY_NON_DISCLOSURE', 'OTHER',
-  ]),
+  letterType: z.enum(LETTER_TYPES),
   classification: z.enum(['INTERNAL', 'EXTERNAL']).default('INTERNAL'),
+  language: z.enum(['ARABIC', 'ENGLISH', 'BILINGUAL']).default('ARABIC'),
   subject: z.string().min(1).max(500),
   content: z.string().max(50000).optional(),
   attachmentUrl: z.string().max(1000).optional(),
@@ -28,7 +32,35 @@ const createSchema = z.object({
   notes: z.string().max(500).optional(),
 });
 
-async function generateLetterNumber(classification: 'INTERNAL' | 'EXTERNAL', attempt = 0): Promise<string> {
+/** Generate next number from per-type serial config, or fall back to INT/EXT-YY-NNNN */
+async function resolveLetterNumber(
+  letterType: string,
+  classification: 'INTERNAL' | 'EXTERNAL',
+  attempt = 0,
+): Promise<{ number: string; configId?: string; newSeq?: number; newYear?: number }> {
+  const config = await prisma.hrLetterSerialConfig.findUnique({
+    where: { letterType: letterType as never },
+  });
+
+  if (config) {
+    const year = new Date().getFullYear();
+    const twoDigitYear = year.toString().slice(-2);
+    const needsReset = config.resetYearly && config.lastResetYear !== null && config.lastResetYear !== year;
+    const newSeq = needsReset ? 1 + attempt : config.currentSeq + 1 + attempt;
+
+    // Apply mask: replace {PREFIX}, {YY}, {YYYY}, and any run of N chars
+    const nCount = (config.mask.match(/N+/) ?? ['NNNN'])[0].length;
+    const numStr = newSeq.toString().padStart(nCount, '0');
+    const number = config.mask
+      .replace('{PREFIX}', config.prefix)
+      .replace('{YYYY}', year.toString())
+      .replace('{YY}', twoDigitYear)
+      .replace(/N+/, numStr);
+
+    return { number, configId: config.id, newSeq, newYear: year };
+  }
+
+  // Fallback: INT/EXT-YY-NNNN (original behaviour)
   const prefix = classification === 'INTERNAL' ? 'INT' : 'EXT';
   const year = new Date().getFullYear().toString().slice(-2);
   const last = await prisma.hrLetter.findFirst({
@@ -37,14 +69,35 @@ async function generateLetterNumber(classification: 'INTERNAL' | 'EXTERNAL', att
     select: { letterNumber: true },
   });
   const seq = (last ? parseInt(last.letterNumber.split('-')[2] ?? '0', 10) : 0) + 1 + attempt;
-  return `${prefix}-${year}-${seq.toString().padStart(4, '0')}`;
+  return { number: `${prefix}-${year}-${seq.toString().padStart(4, '0')}` };
 }
+
+/** Find all users who hold the hr.letters.approveCeo permission */
+async function findCeoApprovers(): Promise<{ id: string }[]> {
+  return prisma.user.findMany({
+    where: {
+      status: 'active',
+      role: {
+        permissions: { path: '$', string_contains: 'hr.letters.approveCeo' },
+      },
+    },
+    select: { id: true },
+  });
+}
+
+const LETTER_INCLUDE = {
+  employee: { select: { id: true, fullNameEn: true, fullNameAr: true, employmentId: true, department: true, occupation: true } },
+  createdBy: { select: { id: true, name: true } },
+  approvedBy: { select: { id: true, name: true } },
+  rejectedBy: { select: { id: true, name: true } },
+} as const;
 
 export const GET = withApiContext(async (req: NextRequest) => {
   const { searchParams } = new URL(req.url);
   const employeeId = searchParams.get('employeeId');
   const type = searchParams.get('type');
   const classification = searchParams.get('classification');
+  const status = searchParams.get('status');
 
   try {
     const letters = await prisma.hrLetter.findMany({
@@ -53,12 +106,10 @@ export const GET = withApiContext(async (req: NextRequest) => {
         ...(employeeId ? { employeeId } : {}),
         ...(type ? { letterType: type as never } : {}),
         ...(classification ? { classification: classification as never } : {}),
+        ...(status ? { status: status as never } : {}),
       },
       orderBy: { issuedAt: 'desc' },
-      include: {
-        employee: { select: { id: true, fullNameEn: true, employmentId: true } },
-        createdBy: { select: { id: true, name: true } },
-      },
+      include: LETTER_INCLUDE,
     });
     return NextResponse.json(letters);
   } catch (error) {
@@ -78,39 +129,66 @@ export const POST = withApiContext(async (req: NextRequest, session) => {
 
   const employee = await prisma.employee.findFirst({
     where: { id: d.employeeId, deletedAt: null },
-    select: { id: true },
+    select: { id: true, fullNameEn: true },
   });
   if (!employee) return NextResponse.json({ error: 'Employee not found' }, { status: 404 });
 
   for (let attempt = 0; attempt < 5; attempt++) {
-  try {
-    const letterNumber = await generateLetterNumber(d.classification, attempt);
-    const letter = await prisma.hrLetter.create({
-      data: {
-        letterNumber,
-        letterType: d.letterType,
-        classification: d.classification,
-        employeeId: d.employeeId,
-        subject: d.subject,
-        content: d.content ?? null,
-        attachmentUrl: d.attachmentUrl ?? null,
-        issuedAt: new Date(d.issuedAt),
-        notes: d.notes ?? null,
-        createdById: session!.userId,
-      },
-      include: {
-        employee: { select: { id: true, fullNameEn: true, employmentId: true } },
-        createdBy: { select: { id: true, name: true } },
-      },
-    });
-    logger.info({ letterId: letter.id, letterNumber, employeeId: d.employeeId }, '[Letters] Created');
-    return NextResponse.json(letter, { status: 201 });
-  } catch (error: unknown) {
-    const isPrismaUnique = typeof error === 'object' && error !== null && 'code' in error && (error as { code: string }).code === 'P2002';
-    if (isPrismaUnique && attempt < 4) continue;
-    logger.error({ error }, 'Failed to create HR letter');
-    return NextResponse.json({ error: 'Failed to create letter' }, { status: 500 });
-  }
+    try {
+      const resolved = await resolveLetterNumber(d.letterType, d.classification, attempt);
+
+      const letter = await prisma.$transaction(async (tx) => {
+        // If using a serial config, atomically update its sequence
+        if (resolved.configId && resolved.newSeq !== undefined && resolved.newYear !== undefined) {
+          await tx.hrLetterSerialConfig.update({
+            where: { id: resolved.configId },
+            data: { currentSeq: resolved.newSeq, lastResetYear: resolved.newYear },
+          });
+        }
+
+        return tx.hrLetter.create({
+          data: {
+            letterNumber: resolved.number,
+            letterType: d.letterType,
+            classification: d.classification,
+            language: d.language,
+            status: 'PENDING_CEO',
+            employeeId: d.employeeId,
+            subject: d.subject,
+            content: d.content ?? null,
+            attachmentUrl: d.attachmentUrl ?? null,
+            issuedAt: new Date(d.issuedAt),
+            notes: d.notes ?? null,
+            createdById: session!.userId,
+          },
+          include: LETTER_INCLUDE,
+        });
+      });
+
+      logger.info({ letterId: letter.id, letterNumber: resolved.number, employeeId: d.employeeId }, '[Letters] Created');
+
+      // Notify all CEO approvers (fire-and-forget)
+      findCeoApprovers().then((ceos) => {
+        const creatorName = letter.createdBy?.name ?? 'HR';
+        ceos.forEach((ceo) => {
+          NotificationService.createNotification({
+            userId: ceo.id,
+            type: 'APPROVAL_REQUIRED',
+            title: 'Letter Approval Required',
+            message: `${creatorName} issued letter ${resolved.number} for ${employee.fullNameEn} — awaiting your approval`,
+            relatedEntityType: 'hr_letter',
+            relatedEntityId: letter.id,
+          }).catch((err) => logger.warn({ err, userId: ceo.id }, 'Failed to notify CEO about letter'));
+        });
+      }).catch((err) => logger.warn({ err }, 'Failed to fetch CEO approvers'));
+
+      return NextResponse.json(letter, { status: 201 });
+    } catch (error: unknown) {
+      const isPrismaUnique = typeof error === 'object' && error !== null && 'code' in error && (error as { code: string }).code === 'P2002';
+      if (isPrismaUnique && attempt < 4) continue;
+      logger.error({ error }, 'Failed to create HR letter');
+      return NextResponse.json({ error: 'Failed to create letter' }, { status: 500 });
+    }
   }
   return NextResponse.json({ error: 'Failed to generate unique letter number' }, { status: 500 });
 });

--- a/src/app/hr/letters/[id]/print/page.tsx
+++ b/src/app/hr/letters/[id]/print/page.tsx
@@ -1,0 +1,45 @@
+/**
+ * /hr/letters/[id]/print
+ * Printable bilingual letter view — supports Arabic (RTL), English (LTR), and Bilingual modes.
+ * Uses browser CSS @media print — no external PDF library required.
+ *
+ * 19.1.0
+ */
+
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import { redirect, notFound } from 'next/navigation';
+import prisma from '@/lib/db';
+import { PrintLetterClient } from './print-client';
+
+export default async function PrintLetterPage({ params }: { params: Promise<{ id: string }> }) {
+  const store = await cookies();
+  const token = store.get(process.env.COOKIE_NAME ?? 'ots_session')?.value;
+  const session = token ? verifySession(token) : null;
+  if (!session) redirect('/login');
+
+  const { id } = await params;
+  const letter = await prisma.hrLetter.findFirst({
+    where: { id, deletedAt: null },
+    include: {
+      employee: {
+        select: {
+          fullNameEn: true,
+          fullNameAr: true,
+          employmentId: true,
+          department: true,
+          occupation: true,
+          nationalId: true,
+          dateOfJoining: true,
+        },
+      },
+      createdBy: { select: { name: true } },
+      approvedBy: { select: { name: true } },
+      rejectedBy: { select: { name: true } },
+    },
+  });
+
+  if (!letter) notFound();
+
+  return <PrintLetterClient letter={letter as Parameters<typeof PrintLetterClient>[0]['letter']} />;
+}

--- a/src/app/hr/letters/[id]/print/print-client.tsx
+++ b/src/app/hr/letters/[id]/print/print-client.tsx
@@ -1,0 +1,314 @@
+'use client';
+
+/**
+ * PrintLetterClient — bilingual printable letter
+ * Supports Arabic (RTL), English (LTR), and Bilingual display.
+ * CSS @media print hides the control bar.
+ *
+ * 19.1.0
+ */
+
+import { useState } from 'react';
+import { Printer, X } from 'lucide-react';
+
+const LETTER_TYPE_LABELS: Record<string, { en: string; ar: string }> = {
+  QUESTIONING:           { en: 'Questioning Letter',        ar: 'خطاب مسائلة' },
+  ATTENTION:             { en: 'Attention Letter',           ar: 'خطاب لفت نظر' },
+  FIRST_WARNING:         { en: 'First Warning',             ar: 'إنذار أول' },
+  FINAL_WARNING:         { en: 'Final Warning',             ar: 'إنذار نهائي' },
+  NON_RENEWAL_NOTICE:    { en: 'Non-Renewal Notice',        ar: 'إشعار عدم تجديد' },
+  DISMISSAL:             { en: 'Dismissal Letter',          ar: 'خطاب فصل' },
+  CIRCULATION:           { en: 'Circular',                  ar: 'تعميم' },
+  WORK_COMMENCEMENT:     { en: 'Work Commencement',         ar: 'خطاب مباشرة عمل' },
+  SALARY_CERTIFICATE:    { en: 'Salary Certificate',        ar: 'شهادة راتب' },
+  LEAVE_NOTICE:          { en: 'Leave Notice',              ar: 'إشعار إجازة' },
+  RETURN_FROM_LEAVE:     { en: 'Return from Leave',         ar: 'خطاب عودة من إجازة' },
+  PROBATION_EVALUATION:  { en: 'Probation Evaluation',      ar: 'تقييم فترة التجربة' },
+  PERFORMANCE_APPRAISAL: { en: 'Performance Appraisal',     ar: 'تقييم الأداء' },
+  CLEARANCE_FORM:        { en: 'Clearance Form',            ar: 'إخلاء طرف' },
+  SALARY_NON_DISCLOSURE: { en: 'Salary Non-Disclosure',     ar: 'إقرار عدم الإفصاح عن الراتب' },
+  OTHER:                 { en: 'Letter',                    ar: 'خطاب' },
+};
+
+type Letter = {
+  id: string;
+  letterNumber: string;
+  letterType: string;
+  classification: string;
+  language: string;
+  status: string;
+  subject: string;
+  content: string | null;
+  issuedAt: Date | string;
+  notes: string | null;
+  approvedAt: Date | string | null;
+  rejectionReason: string | null;
+  employee: {
+    fullNameEn: string;
+    fullNameAr: string | null;
+    employmentId: string;
+    department: string | null;
+    occupation: string | null;
+    nationalId: string | null;
+    dateOfJoining: Date | string;
+  };
+  createdBy: { name: string } | null;
+  approvedBy: { name: string } | null;
+  rejectedBy: { name: string } | null;
+};
+
+const fmt = (d: Date | string | null | undefined) =>
+  d ? new Date(d).toLocaleDateString('en-GB', { day: '2-digit', month: 'long', year: 'numeric' }) : '—';
+
+const fmtAr = (d: Date | string | null | undefined) =>
+  d ? new Date(d).toLocaleDateString('ar-SA', { day: '2-digit', month: 'long', year: 'numeric' }) : '—';
+
+export function PrintLetterClient({ letter }: { letter: Letter }) {
+  const [lang, setLang] = useState<'ARABIC' | 'ENGLISH' | 'BILINGUAL'>(
+    (letter.language as 'ARABIC' | 'ENGLISH' | 'BILINGUAL') ?? 'ARABIC',
+  );
+
+  const typeLabel = LETTER_TYPE_LABELS[letter.letterType] ?? { en: 'Letter', ar: 'خطاب' };
+  const isApproved = letter.status === 'APPROVED';
+
+  const showAr = lang === 'ARABIC' || lang === 'BILINGUAL';
+  const showEn = lang === 'ENGLISH' || lang === 'BILINGUAL';
+
+  return (
+    <>
+      {/* Print control bar — hidden when printing */}
+      <div className="print:hidden fixed top-0 left-0 right-0 z-50 bg-slate-800 text-white px-6 py-3 flex items-center justify-between gap-4 shadow-lg">
+        <div className="flex items-center gap-3">
+          <span className="font-mono text-blue-300 text-sm">{letter.letterNumber}</span>
+          <span className="text-slate-400 text-sm">·</span>
+          <span className="text-sm text-slate-200 truncate max-w-xs">{letter.subject}</span>
+        </div>
+        <div className="flex items-center gap-3">
+          {/* Language selector */}
+          <div className="flex rounded-md overflow-hidden border border-slate-600">
+            {(['ARABIC', 'ENGLISH', 'BILINGUAL'] as const).map((l) => (
+              <button
+                key={l}
+                onClick={() => setLang(l)}
+                className={`px-3 py-1.5 text-xs font-medium transition-colors ${lang === l ? 'bg-blue-600 text-white' : 'bg-slate-700 text-slate-300 hover:bg-slate-600'}`}
+              >
+                {l === 'ARABIC' ? 'Arabic' : l === 'ENGLISH' ? 'English' : 'Bilingual'}
+              </button>
+            ))}
+          </div>
+          <button
+            onClick={() => window.print()}
+            className="flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white px-4 py-1.5 rounded-md text-sm font-medium transition-colors"
+          >
+            <Printer className="h-4 w-4" />
+            Print / Save PDF
+          </button>
+          <button
+            onClick={() => window.close()}
+            className="text-slate-400 hover:text-white p-1.5 rounded transition-colors"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+
+      {/* Print styles */}
+      <style>{`
+        @media print {
+          @page { size: A4; margin: 20mm 15mm; }
+          body { font-family: 'Arial', sans-serif; font-size: 12pt; }
+        }
+        .letter-body { white-space: pre-wrap; line-height: 1.8; }
+      `}</style>
+
+      {/* Letter content */}
+      <div className="print:mt-0 mt-16 bg-white min-h-screen">
+        <div className="max-w-[210mm] mx-auto px-8 py-10">
+
+          {/* ── ARABIC VERSION ── */}
+          {showAr && (
+            <div dir="rtl" className={lang === 'BILINGUAL' ? 'mb-12 pb-10 border-b-2 border-slate-300' : ''}>
+              {/* Letterhead */}
+              <div className="text-center mb-8">
+                <div className="text-2xl font-bold text-slate-800 mb-1">هيكسا ستيل®</div>
+                <div className="text-sm text-slate-500 mb-4">Hexa Steel® — شركة هيكسا للصلب</div>
+                <div className="border-t-4 border-b border-slate-800 pt-2 pb-1 mb-1" />
+                <div className="h-px bg-slate-300" />
+              </div>
+
+              {/* Letter header */}
+              <div className="flex justify-between items-start mb-8">
+                <div className="text-right">
+                  <div className="text-lg font-bold text-slate-800 mb-1">{typeLabel.ar}</div>
+                  <div className="text-sm text-slate-600">رقم الخطاب: <span className="font-mono font-bold">{letter.letterNumber}</span></div>
+                  <div className="text-sm text-slate-600">التصنيف: {letter.classification === 'INTERNAL' ? 'داخلي' : 'خارجي'}</div>
+                </div>
+                <div className="text-left">
+                  <div className="text-sm text-slate-600">التاريخ: {fmtAr(letter.issuedAt)}</div>
+                </div>
+              </div>
+
+              {/* Employee info box */}
+              <div className="border border-slate-300 rounded-lg p-4 mb-8 bg-slate-50">
+                <div className="text-sm font-semibold text-slate-700 mb-3 border-b pb-2">بيانات الموظف</div>
+                <div className="grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
+                  <div><span className="text-slate-500">الاسم: </span><span className="font-medium">{letter.employee.fullNameAr ?? letter.employee.fullNameEn}</span></div>
+                  <div><span className="text-slate-500">رقم الموظف: </span><span className="font-mono font-medium">{letter.employee.employmentId}</span></div>
+                  {letter.employee.nationalId && (
+                    <div><span className="text-slate-500">رقم الهوية: </span><span className="font-medium">{letter.employee.nationalId}</span></div>
+                  )}
+                  {letter.employee.department && (
+                    <div><span className="text-slate-500">القسم: </span><span className="font-medium">{letter.employee.department}</span></div>
+                  )}
+                  {letter.employee.occupation && (
+                    <div><span className="text-slate-500">المسمى الوظيفي: </span><span className="font-medium">{letter.employee.occupation}</span></div>
+                  )}
+                  <div><span className="text-slate-500">تاريخ التعيين: </span><span className="font-medium">{fmtAr(letter.employee.dateOfJoining)}</span></div>
+                </div>
+              </div>
+
+              {/* Subject */}
+              <div className="mb-6">
+                <span className="font-bold text-slate-800">الموضوع: </span>
+                <span className="text-slate-700 font-medium">{letter.subject}</span>
+              </div>
+
+              {/* Body */}
+              {letter.content && (
+                <div className="letter-body text-slate-800 text-sm leading-8 mb-10 text-justify">
+                  {letter.content}
+                </div>
+              )}
+
+              {/* Signature area */}
+              <div className="mt-12 flex justify-between items-end">
+                <div className="text-center">
+                  <div className="border-t border-slate-400 w-48 pt-2">
+                    <div className="text-sm text-slate-600">المدير العام / الرئيس التنفيذي</div>
+                    {isApproved && letter.approvedBy && (
+                      <div className="text-xs text-emerald-600 font-medium mt-1">✓ {letter.approvedBy.name}</div>
+                    )}
+                    {isApproved && letter.approvedAt && (
+                      <div className="text-xs text-slate-500">{fmtAr(letter.approvedAt)}</div>
+                    )}
+                  </div>
+                </div>
+                <div className="text-center">
+                  <div className="border-t border-slate-400 w-48 pt-2">
+                    <div className="text-sm text-slate-600">توقيع الموظف واستلام نسخة</div>
+                  </div>
+                </div>
+              </div>
+
+              {/* Approval stamp */}
+              {isApproved && (
+                <div className="mt-8 border-2 border-emerald-500 rounded-lg p-3 text-center text-emerald-700 font-bold text-sm bg-emerald-50">
+                  ✓ معتمد — {letter.approvedBy?.name} — {fmtAr(letter.approvedAt)}
+                </div>
+              )}
+
+              {/* Audit footer */}
+              <div className="mt-8 pt-4 border-t border-slate-200 text-xs text-slate-400 flex justify-between">
+                <span>أُصدر بواسطة: {letter.createdBy?.name}</span>
+                <span className="font-mono">{letter.letterNumber}</span>
+              </div>
+            </div>
+          )}
+
+          {/* ── PAGE BREAK between bilingual versions ── */}
+          {lang === 'BILINGUAL' && <div className="print:block hidden" style={{ pageBreakAfter: 'always' }} />}
+
+          {/* ── ENGLISH VERSION ── */}
+          {showEn && (
+            <div dir="ltr">
+              {/* Letterhead */}
+              <div className="text-center mb-8">
+                <div className="text-2xl font-bold text-slate-800 mb-1">Hexa Steel®</div>
+                <div className="text-sm text-slate-500 mb-4">هيكسا للصلب — Hexa Steel Company</div>
+                <div className="border-t-4 border-b border-slate-800 pt-2 pb-1 mb-1" />
+                <div className="h-px bg-slate-300" />
+              </div>
+
+              {/* Letter header */}
+              <div className="flex justify-between items-start mb-8">
+                <div>
+                  <div className="text-lg font-bold text-slate-800 mb-1">{typeLabel.en}</div>
+                  <div className="text-sm text-slate-600">Letter No: <span className="font-mono font-bold">{letter.letterNumber}</span></div>
+                  <div className="text-sm text-slate-600">Classification: {letter.classification === 'INTERNAL' ? 'Internal' : 'External'}</div>
+                </div>
+                <div className="text-right">
+                  <div className="text-sm text-slate-600">Date: {fmt(letter.issuedAt)}</div>
+                </div>
+              </div>
+
+              {/* Employee info box */}
+              <div className="border border-slate-300 rounded-lg p-4 mb-8 bg-slate-50">
+                <div className="text-sm font-semibold text-slate-700 mb-3 border-b pb-2">Employee Information</div>
+                <div className="grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
+                  <div><span className="text-slate-500">Name: </span><span className="font-medium">{letter.employee.fullNameEn}</span></div>
+                  <div><span className="text-slate-500">Employee ID: </span><span className="font-mono font-medium">{letter.employee.employmentId}</span></div>
+                  {letter.employee.nationalId && (
+                    <div><span className="text-slate-500">National ID: </span><span className="font-medium">{letter.employee.nationalId}</span></div>
+                  )}
+                  {letter.employee.department && (
+                    <div><span className="text-slate-500">Department: </span><span className="font-medium">{letter.employee.department}</span></div>
+                  )}
+                  {letter.employee.occupation && (
+                    <div><span className="text-slate-500">Position: </span><span className="font-medium">{letter.employee.occupation}</span></div>
+                  )}
+                  <div><span className="text-slate-500">Date of Joining: </span><span className="font-medium">{fmt(letter.employee.dateOfJoining)}</span></div>
+                </div>
+              </div>
+
+              {/* Subject */}
+              <div className="mb-6">
+                <span className="font-bold text-slate-800">Subject: </span>
+                <span className="text-slate-700 font-medium">{letter.subject}</span>
+              </div>
+
+              {/* Body */}
+              {letter.content && (
+                <div className="letter-body text-slate-800 text-sm leading-8 mb-10 text-justify">
+                  {letter.content}
+                </div>
+              )}
+
+              {/* Signature area */}
+              <div className="mt-12 flex justify-between items-end">
+                <div className="text-center">
+                  <div className="border-t border-slate-400 w-48 pt-2">
+                    <div className="text-sm text-slate-600">General Manager / CEO</div>
+                    {isApproved && letter.approvedBy && (
+                      <div className="text-xs text-emerald-600 font-medium mt-1">✓ {letter.approvedBy.name}</div>
+                    )}
+                    {isApproved && letter.approvedAt && (
+                      <div className="text-xs text-slate-500">{fmt(letter.approvedAt)}</div>
+                    )}
+                  </div>
+                </div>
+                <div className="text-center">
+                  <div className="border-t border-slate-400 w-48 pt-2">
+                    <div className="text-sm text-slate-600">Employee Signature & Copy Received</div>
+                  </div>
+                </div>
+              </div>
+
+              {/* Approval stamp */}
+              {isApproved && (
+                <div className="mt-8 border-2 border-emerald-500 rounded-lg p-3 text-center text-emerald-700 font-bold text-sm bg-emerald-50">
+                  ✓ Approved — {letter.approvedBy?.name} — {fmt(letter.approvedAt)}
+                </div>
+              )}
+
+              {/* Audit footer */}
+              <div className="mt-8 pt-4 border-t border-slate-200 text-xs text-slate-400 flex justify-between">
+                <span>Issued by: {letter.createdBy?.name}</span>
+                <span className="font-mono">{letter.letterNumber}</span>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -393,6 +393,7 @@ export const PERMISSIONS: PermissionCategory[] = [
       // 18.16.0 — Letters & Correspondence
       { id: 'hr.letters.view', name: 'View Letters', description: 'View HR letters and correspondence issued to employees', category: 'hr' },
       { id: 'hr.letters.manage', name: 'Manage Letters', description: 'Create, edit, and delete HR letters and correspondence', category: 'hr' },
+      { id: 'hr.letters.approveCeo', name: 'CEO-Approve Letters', description: 'Final CEO sign-off on HR letters — approve or reject letters pending approval', category: 'hr' },
     ],
   },
   {

--- a/src/lib/startup-migrations.ts
+++ b/src/lib/startup-migrations.ts
@@ -57,6 +57,9 @@ const STARTUP_MIGRATIONS = [
   // ── Ops Agent (19.x) ─────────────────────────────────────────────────────
   'add_ops_agent_module.sql',
   'add_ops_agent_ai_config.sql',
+
+  // ── Letters enhancements (19.1.0) ─────────────────────────────────────────
+  'add_hr_letter_enhancements.sql',
 ];
 
 /**


### PR DESCRIPTION
Backend/infrastructure:
- SQL migration add_hr_letter_enhancements.sql: adds status/language/approval
  columns to HrLetter + creates HrLetterSerialConfig table (idempotent)
- Prisma schema: HrLetterStatus, HrLetterLanguage enums; new fields on HrLetter
  (status, language, approvedById/At, rejectedById/At, rejectionReason);
  HrLetterSerialConfig model with per-type prefix/mask/seq/resetYearly
- Permissions: hr.letters.approveCeo added (CEO-only sign-off)
- Startup migrations: add_hr_letter_enhancements.sql registered

API routes:
- POST /api/hr/letters: uses HrLetterSerialConfig for numbering when configured,
  falls back to INT/EXT-YY-NNNN; creates letters with status=PENDING_CEO;
  notifies all users holding hr.letters.approveCeo via NotificationService
- GET /api/hr/letters: returns approval/rejection fields; supports ?status= filter
- PUT /api/hr/letters/[id]: blocks edits on APPROVED letters
- DELETE /api/hr/letters/[id]: blocks deletion of APPROVED letters
- POST /api/hr/letters/[id]/approve: CEO approve → APPROVED, notifies creator
- POST /api/hr/letters/[id]/reject: CEO reject with reason → REJECTED, notifies creator
- GET/POST /api/hr/letter-serial-configs: CRUD for per-type serial configs
- PUT/DELETE /api/hr/letter-serial-configs/[id]: update prefix/mask/resetYearly

Print page:
- /hr/letters/[id]/print: bilingual A4-formatted print view
- Language switcher (Arabic / English / Bilingual) in print toolbar
- Full Arabic RTL letterhead, employee info, subject, body, signature area
- Full English LTR counterpart
- Bilingual mode renders both with page-break between them
- Approval stamp shown when status=APPROVED
- CSS @media print hides control bar; browser Print→Save as PDF works natively

https://claude.ai/code/session_01T47K4rXoxNrGNf4ZbjY8zk