### PR TITLE
fix: use session.userId instead of session.sub in loans/custodies all routes

### DIFF
--- a/src/app/api/hr/custodies/all/route.ts
+++ b/src/app/api/hr/custodies/all/route.ts
@@ -7,8 +7,8 @@ import { logger } from '@/lib/logger';
 export const GET = withApiContext(async (_req, session) => {
   try {
     const [perms, user] = await Promise.all([
-      resolveUserPermissions(session!.sub),
-      prisma.user.findUnique({ where: { id: session!.sub }, select: { employeeId: true } }),
+      resolveUserPermissions(session!.userId),
+      prisma.user.findUnique({ where: { id: session!.userId }, select: { employeeId: true } }),
     ]);
 
     const canViewAll = perms.includes('hr.custodies.view') || perms.includes('hr.custodies.manage');

--- a/src/app/api/hr/loans/all/route.ts
+++ b/src/app/api/hr/loans/all/route.ts
@@ -7,8 +7,8 @@ import { logger } from '@/lib/logger';
 export const GET = withApiContext(async (_req, session) => {
   try {
     const [perms, user] = await Promise.all([
-      resolveUserPermissions(session!.sub),
-      prisma.user.findUnique({ where: { id: session!.sub }, select: { employeeId: true } }),
+      resolveUserPermissions(session!.userId),
+      prisma.user.findUnique({ where: { id: session!.userId }, select: { employeeId: true } }),
     ]);
 
     const canViewAll = perms.includes('hr.loans.view') || perms.includes('hr.loans.manage');


### PR DESCRIPTION
SessionData (from withApiContext) exposes userId, not sub. Passing undefined
to resolveUserPermissions caused a 500 on GET /api/hr/loans/all and
GET /api/hr/custodies/all.

https://claude.ai/code/session_017HvjutqMFddLF4ZcMrcz7w