### PR TITLE
feat(hr): add Absence & Leave Analytics module (v19.4.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,9 @@
 ## Project Overview
 Enterprise ERP for steel fabrication projects. Next.js 15 App Router + TypeScript + Prisma + MySQL.
 Deployed at `hexasteel.sa/ots` with optional `NEXT_PUBLIC_BASE_PATH` subpath.
-**Current version:** `19.3.6` — **Patch:** 2nd and 3rd place employees shown in the Employee of the Month card with silver 🥈 and bronze 🥉 styling — smaller rows beneath the gold winner; all three get medal icons and colored left-border highlights in the employee grid rows.
+**Current version:** `19.4.0` — **Minor:** HR Absence Analytics module. New `/hr/analytics` page surfaces behavioral patterns in team attendance and leave data so management can see "the data behind the data". Detects four pattern types from `AttendanceRecord` + `LeaveRequest` — Consecutive Absence (3+ consecutive ANP days, weekends transparent), Weekend Extension (>60% of ANP days fall on Monday/Friday), Escalating Absences (monotonically increasing ANP over last 3 months), and Frequent Leaves (≥3 approved leave requests in a single month). UI: violet hero, 4 KPI tiles (ANP Days, Flagged Employees, Avg ANP/Employee, Approved Leaves), collapsible Behavior Flags table (severity HIGH/MEDIUM badges), Absence Frequency Matrix (employee × month heatmap), ANP by Day-of-Week bar chart, Monthly Company Trend stacked bar chart, and Leave Request Frequency table. New API `GET /api/hr/analytics/absence?months=N&section=&occupation=`. New permission `hr.analytics.view` added to HR role bundle. No schema changes.
+
+**Previous version:** `19.3.6` — **Patch:** 2nd and 3rd place employees shown in the Employee of the Month card with silver 🥈 and bronze 🥉 styling — smaller rows beneath the gold winner; all three get medal icons and colored left-border highlights in the employee grid rows.
 
 **Previous version:** `19.3.5` — **Patch:** Total Hours card added to attendance grid — three tiles showing Our Staff hours, Manpower hours, and Combined total (regular + OT breakdown per tile); collapsible like all other grid sections.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexa-steel-ots",
-  "version": "19.3.6",
+  "version": "19.4.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/api/hr/analytics/absence/route.ts
+++ b/src/app/api/hr/analytics/absence/route.ts
@@ -1,0 +1,479 @@
+/**
+ * GET /api/hr/analytics/absence
+ *
+ * Behavioral pattern analysis over AttendanceRecord + LeaveRequest data.
+ * Surfaces consecutive-absence streaks, Monday/Friday extension patterns,
+ * escalating absence trends, and leave-request frequency anomalies so
+ * management can intervene before payroll deductions become the only signal.
+ *
+ * Query params:
+ *   months      Lookback in full calendar months (1–12, default 6)
+ *   section     Optional employee section filter
+ *   occupation  Optional employee occupation filter
+ *
+ * Gated by hr.analytics.view (19.4.0).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import { checkPermission } from '@/lib/permission-checker';
+import { logger } from '@/lib/logger';
+import prisma from '@/lib/db';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type AlertType =
+  | 'CONSECUTIVE_ABSENCE'
+  | 'WEEKEND_EXTENSION'
+  | 'ESCALATING_ABSENCES'
+  | 'FREQUENT_LEAVES';
+
+type Severity = 'HIGH' | 'MEDIUM';
+
+export interface PatternFlag {
+  employeeId: string;
+  employmentId: string;
+  fullNameEn: string;
+  occupation: string | null;
+  section: string | null;
+  alertType: AlertType;
+  severity: Severity;
+  detail: string;
+  meta: Record<string, unknown>;
+}
+
+export interface EmployeeAbsenceStat {
+  employeeId: string;
+  employmentId: string;
+  fullNameEn: string;
+  occupation: string | null;
+  section: string | null;
+  monthlyAnp: Record<string, number>;
+  totalAnp: number;
+  totalAp: number;
+  totalSick: number;
+  totalAv: number;
+  longestConsecutiveAnp: number;
+  mondayFridayPct: number;
+  leaveRequestCount: number;
+  leavesByType: Record<string, number>;
+}
+
+export interface AbsenceAnalyticsResult {
+  period: { from: string; to: string; months: number };
+  summary: {
+    totalAnpDays: number;
+    totalApDays: number;
+    employeesWithAnp: number;
+    flaggedEmployees: number;
+    totalApprovedLeaves: number;
+  };
+  flags: PatternFlag[];
+  employeeStats: EmployeeAbsenceStat[];
+  dayOfWeekDistribution: Record<string, number>;
+  monthlyTrend: Array<{ month: string; anpDays: number; apDays: number; sickDays: number }>;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+function isoDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function monthKey(d: Date): string {
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`;
+}
+
+/** Two ANP dates are part of the same consecutive streak if their gap is ≤ 3 days
+ *  (bridges a Fri/Sat/Sun weekend so Thu→Mon counts as consecutive). */
+function isConsecutiveGap(a: Date, b: Date): boolean {
+  const diffMs = b.getTime() - a.getTime();
+  const diffDays = diffMs / 86_400_000;
+  return diffDays > 0 && diffDays <= 3;
+}
+
+/** Find longest run of "consecutive" ANP dates (weekends transparent). */
+function longestStreak(dates: Date[]): { length: number; start: Date; end: Date } | null {
+  if (dates.length === 0) return null;
+  const sorted = [...dates].sort((a, b) => a.getTime() - b.getTime());
+  let best = { length: 1, start: sorted[0], end: sorted[0] };
+  let runStart = sorted[0];
+  let runLen = 1;
+  for (let i = 1; i < sorted.length; i++) {
+    if (isConsecutiveGap(sorted[i - 1], sorted[i])) {
+      runLen++;
+      if (runLen > best.length) {
+        best = { length: runLen, start: runStart, end: sorted[i] };
+      }
+    } else {
+      runStart = sorted[i];
+      runLen = 1;
+    }
+  }
+  return best;
+}
+
+// ---------------------------------------------------------------------------
+// Main handler
+// ---------------------------------------------------------------------------
+
+export async function GET(req: NextRequest) {
+  const store = await cookies();
+  const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+  const session = token ? await verifySession(token) : null;
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const canView = await checkPermission('hr.analytics.view');
+  if (!canView) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  const url = new URL(req.url);
+  const monthsRaw = Number(url.searchParams.get('months') ?? '6');
+  const months = Math.min(Math.max(1, Number.isNaN(monthsRaw) ? 6 : monthsRaw), 12);
+  const section = url.searchParams.get('section') || null;
+  const occupation = url.searchParams.get('occupation') || null;
+
+  // Period: last N complete calendar months ending on last day of previous month.
+  const now = new Date();
+  const endDate = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 0)); // last day of prev month
+  const startDate = new Date(Date.UTC(endDate.getUTCFullYear(), endDate.getUTCMonth() - months + 1, 1));
+  // If we're past the 1st, include the current partial month too
+  const todayUtc = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  const effectiveEnd = todayUtc > endDate ? todayUtc : endDate;
+
+  const employeeFilter = {
+    deletedAt: null as null,
+    ...(section ? { section } : {}),
+    ...(occupation ? { occupation } : {}),
+  };
+
+  try {
+    // Fetch attendance records (EMPLOYEE only) + leave requests in parallel
+    const [records, leaveRequests] = await Promise.all([
+      prisma.attendanceRecord.findMany({
+        where: {
+          workerType: 'EMPLOYEE',
+          date: { gte: startDate, lte: effectiveEnd },
+          employee: employeeFilter,
+        },
+        select: {
+          employeeId: true,
+          date: true,
+          status: true,
+          employee: {
+            select: {
+              id: true,
+              employmentId: true,
+              fullNameEn: true,
+              occupation: true,
+              section: true,
+            },
+          },
+        },
+        take: 200_000,
+        orderBy: { date: 'asc' },
+      }),
+      prisma.leaveRequest.findMany({
+        where: {
+          status: 'APPROVED',
+          startDate: { lte: effectiveEnd },
+          endDate: { gte: startDate },
+          deletedAt: null,
+          employee: employeeFilter,
+        },
+        select: {
+          employeeId: true,
+          startDate: true,
+          endDate: true,
+          calendarDays: true,
+          leaveType: { select: { code: true, nameEn: true } },
+        },
+      }),
+    ]);
+
+    // ---------------------------------------------------------------------------
+    // Build per-employee accumulators
+    // ---------------------------------------------------------------------------
+
+    type EmpAcc = {
+      employeeId: string;
+      employmentId: string;
+      fullNameEn: string;
+      occupation: string | null;
+      section: string | null;
+      anpDates: Date[];
+      apCount: number;
+      sickCount: number;
+      avCount: number;
+      monthlyAnp: Map<string, number>;
+      dayOfWeekAnp: number[]; // index 0=Sun..6=Sat
+    };
+
+    const empMap = new Map<string, EmpAcc>();
+
+    function getEmp(rec: (typeof records)[0]): EmpAcc {
+      const emp = rec.employee;
+      if (!emp) throw new Error('Missing employee on attendance record');
+      let acc = empMap.get(emp.id);
+      if (!acc) {
+        acc = {
+          employeeId: emp.id,
+          employmentId: emp.employmentId,
+          fullNameEn: emp.fullNameEn,
+          occupation: emp.occupation,
+          section: emp.section,
+          anpDates: [],
+          apCount: 0,
+          sickCount: 0,
+          avCount: 0,
+          monthlyAnp: new Map(),
+          dayOfWeekAnp: [0, 0, 0, 0, 0, 0, 0],
+        };
+        empMap.set(emp.id, acc);
+      }
+      return acc;
+    }
+
+    // Day-of-week distribution (company-wide ANP)
+    const dowDistribution: number[] = [0, 0, 0, 0, 0, 0, 0];
+
+    // Monthly trend accumulator
+    const monthlyTrendMap = new Map<string, { anpDays: number; apDays: number; sickDays: number }>();
+
+    for (const rec of records) {
+      if (!rec.employee) continue;
+      const acc = getEmp(rec);
+      const date = new Date(rec.date);
+      const mk = monthKey(date);
+      const dow = date.getUTCDay();
+
+      if (!monthlyTrendMap.has(mk)) {
+        monthlyTrendMap.set(mk, { anpDays: 0, apDays: 0, sickDays: 0 });
+      }
+      const trend = monthlyTrendMap.get(mk)!;
+
+      switch (rec.status) {
+        case 'ABSENT_NO_PERMISSION':
+          acc.anpDates.push(date);
+          acc.dayOfWeekAnp[dow]++;
+          dowDistribution[dow]++;
+          acc.monthlyAnp.set(mk, (acc.monthlyAnp.get(mk) ?? 0) + 1);
+          trend.anpDays++;
+          break;
+        case 'ABSENT_WITH_PERMISSION':
+          acc.apCount++;
+          trend.apDays++;
+          break;
+        case 'SICK_LEAVE':
+          acc.sickCount++;
+          trend.sickDays++;
+          break;
+        case 'ANNUAL_VACATION':
+          acc.avCount++;
+          break;
+      }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Build per-employee leave request stats
+    // ---------------------------------------------------------------------------
+
+    type LeaveAcc = {
+      totalCount: number;
+      monthlyCount: Map<string, number>;
+      byType: Map<string, number>;
+    };
+
+    const leaveMap = new Map<string, LeaveAcc>();
+
+    for (const lr of leaveRequests) {
+      let lacc = leaveMap.get(lr.employeeId);
+      if (!lacc) {
+        lacc = { totalCount: 0, monthlyCount: new Map(), byType: new Map() };
+        leaveMap.set(lr.employeeId, lacc);
+      }
+      lacc.totalCount++;
+      const mk = monthKey(new Date(lr.startDate));
+      lacc.monthlyCount.set(mk, (lacc.monthlyCount.get(mk) ?? 0) + 1);
+      const typeCode = lr.leaveType?.code ?? 'UNKNOWN';
+      lacc.byType.set(typeCode, (lacc.byType.get(typeCode) ?? 0) + 1);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Compute stats + detect patterns
+    // ---------------------------------------------------------------------------
+
+    const flags: PatternFlag[] = [];
+    const employeeStats: EmployeeAbsenceStat[] = [];
+
+    for (const acc of empMap.values()) {
+      const streak = longestStreak(acc.anpDates);
+      const longestConsecutiveAnp = streak?.length ?? 0;
+
+      // Monday/Friday ratio among ANP days (mon=1, fri=5 in getUTCDay)
+      const totalAnp = acc.anpDates.length;
+      const monFriAnp = acc.dayOfWeekAnp[1] + acc.dayOfWeekAnp[5];
+      const mondayFridayPct = totalAnp > 0 ? Math.round((monFriAnp / totalAnp) * 100) : 0;
+
+      const lacc = leaveMap.get(acc.employeeId);
+      const leaveRequestCount = lacc?.totalCount ?? 0;
+      const leavesByType: Record<string, number> = {};
+      lacc?.byType.forEach((v: number, k: string) => { leavesByType[k] = v; });
+
+      // Build monthlyAnp as plain object
+      const monthlyAnp: Record<string, number> = {};
+      acc.monthlyAnp.forEach((v: number, k: string) => { monthlyAnp[k] = v; });
+
+      employeeStats.push({
+        employeeId: acc.employeeId,
+        employmentId: acc.employmentId,
+        fullNameEn: acc.fullNameEn,
+        occupation: acc.occupation,
+        section: acc.section,
+        monthlyAnp,
+        totalAnp,
+        totalAp: acc.apCount,
+        totalSick: acc.sickCount,
+        totalAv: acc.avCount,
+        longestConsecutiveAnp,
+        mondayFridayPct,
+        leaveRequestCount,
+        leavesByType,
+      });
+
+      // --- Pattern A: Consecutive Absence ---
+      if (longestConsecutiveAnp >= 3 && streak) {
+        const severity: Severity = longestConsecutiveAnp >= 5 ? 'HIGH' : 'MEDIUM';
+        flags.push({
+          employeeId: acc.employeeId,
+          employmentId: acc.employmentId,
+          fullNameEn: acc.fullNameEn,
+          occupation: acc.occupation,
+          section: acc.section,
+          alertType: 'CONSECUTIVE_ABSENCE',
+          severity,
+          detail: `${longestConsecutiveAnp} consecutive absent-without-permission days (${isoDate(streak.start)} → ${isoDate(streak.end)})`,
+          meta: { streakDays: longestConsecutiveAnp, from: isoDate(streak.start), to: isoDate(streak.end) },
+        });
+      }
+
+      // --- Pattern B: Weekend Extension (Mon/Fri bias) ---
+      if (totalAnp >= 5 && mondayFridayPct > 60) {
+        const severity: Severity = mondayFridayPct > 70 ? 'HIGH' : 'MEDIUM';
+        flags.push({
+          employeeId: acc.employeeId,
+          employmentId: acc.employmentId,
+          fullNameEn: acc.fullNameEn,
+          occupation: acc.occupation,
+          section: acc.section,
+          alertType: 'WEEKEND_EXTENSION',
+          severity,
+          detail: `${mondayFridayPct}% of absences fall on Monday or Friday (${monFriAnp} of ${totalAnp} ANP days)`,
+          meta: { mondayFridayPct, monFriAnp, totalAnp, mondayAnp: acc.dayOfWeekAnp[1], fridayAnp: acc.dayOfWeekAnp[5] },
+        });
+      }
+
+      // --- Pattern C: Escalating Absences ---
+      const sortedMonths = Object.keys(monthlyAnp).sort();
+      if (sortedMonths.length >= 3) {
+        const last3 = sortedMonths.slice(-3);
+        const [m1, m2, m3] = last3.map(m => monthlyAnp[m] ?? 0);
+        if (m1 < m2 && m2 < m3 && m3 >= 2) {
+          const severity: Severity = m3 > 5 ? 'HIGH' : 'MEDIUM';
+          flags.push({
+            employeeId: acc.employeeId,
+            employmentId: acc.employmentId,
+            fullNameEn: acc.fullNameEn,
+            occupation: acc.occupation,
+            section: acc.section,
+            alertType: 'ESCALATING_ABSENCES',
+            severity,
+            detail: `ANP days increasing: ${m1}→${m2}→${m3} over last 3 months (${last3.join(', ')})`,
+            meta: { trend: [m1, m2, m3], months: last3 },
+          });
+        }
+      }
+
+      // --- Pattern D: Frequent Leave Requests ---
+      if (lacc) {
+        let maxMonthlyLeaves = 0;
+        let peakMonth = '';
+        lacc.monthlyCount.forEach((v: number, k: string) => {
+          if (v > maxMonthlyLeaves) { maxMonthlyLeaves = v; peakMonth = k; }
+        });
+        if (maxMonthlyLeaves >= 3) {
+          const severity: Severity = maxMonthlyLeaves >= 4 ? 'HIGH' : 'MEDIUM';
+          flags.push({
+            employeeId: acc.employeeId,
+            employmentId: acc.employmentId,
+            fullNameEn: acc.fullNameEn,
+            occupation: acc.occupation,
+            section: acc.section,
+            alertType: 'FREQUENT_LEAVES',
+            severity,
+            detail: `${maxMonthlyLeaves} approved leave requests in a single month (${peakMonth}); ${leaveRequestCount} total over period`,
+            meta: { maxMonthlyLeaves, peakMonth, totalLeaves: leaveRequestCount },
+          });
+        }
+      }
+    }
+
+    // Deduplicate flags: one flag per employee per alert type (keep highest severity)
+    const flagKey = (f: PatternFlag) => `${f.employeeId}:${f.alertType}`;
+    const flagMap = new Map<string, PatternFlag>();
+    for (const f of flags) {
+      const k = flagKey(f);
+      const existing = flagMap.get(k);
+      if (!existing || (existing.severity === 'MEDIUM' && f.severity === 'HIGH')) {
+        flagMap.set(k, f);
+      }
+    }
+    const dedupedFlags = [...flagMap.values()].sort(
+      (a, b) => (a.severity === 'HIGH' ? -1 : 1) - (b.severity === 'HIGH' ? -1 : 1),
+    );
+
+    // ---------------------------------------------------------------------------
+    // Summaries
+    // ---------------------------------------------------------------------------
+
+    const totalAnpDays = employeeStats.reduce((s, e) => s + e.totalAnp, 0);
+    const totalApDays = employeeStats.reduce((s, e) => s + e.totalAp, 0);
+    const employeesWithAnp = employeeStats.filter(e => e.totalAnp > 0).length;
+    const flaggedEmployeeIds = new Set(dedupedFlags.map(f => f.employeeId));
+
+    const dowDistributionObj: Record<string, number> = {};
+    DAY_NAMES.forEach((name, i) => {
+      if (i >= 1 && i <= 5) dowDistributionObj[name] = dowDistribution[i]; // Mon–Fri only
+    });
+
+    const monthlyTrend = [...monthlyTrendMap.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([month, v]) => ({ month, ...v }));
+
+    const result: AbsenceAnalyticsResult = {
+      period: { from: isoDate(startDate), to: isoDate(effectiveEnd), months },
+      summary: {
+        totalAnpDays,
+        totalApDays,
+        employeesWithAnp,
+        flaggedEmployees: flaggedEmployeeIds.size,
+        totalApprovedLeaves: leaveRequests.length,
+      },
+      flags: dedupedFlags,
+      employeeStats: employeeStats.sort((a, b) => b.totalAnp - a.totalAnp),
+      dayOfWeekDistribution: dowDistributionObj,
+      monthlyTrend,
+    };
+
+    return NextResponse.json(result);
+  } catch (error) {
+    logger.error({ error }, '[HR Analytics] Failed to compute absence analytics');
+    return NextResponse.json({ error: 'Failed to compute absence analytics' }, { status: 500 });
+  }
+}

--- a/src/app/changelog/_page-client.tsx
+++ b/src/app/changelog/_page-client.tsx
@@ -23,10 +23,38 @@ type ChangelogVersion = {
 // Version order: Most recent first
 const hardcodedVersions: ChangelogVersion[] = [
   {
-    version: '19.3.0',
+    version: '19.4.0',
     date: 'April 19, 2026',
     type: 'minor',
     status: 'current',
+    mainTitle: 'HR Absence & Leave Analytics Module',
+    highlights: [
+      'New /hr/analytics page lets management study behavioral patterns hidden in attendance and leave data',
+      'Detects four pattern types: Consecutive Absence, Weekend Extension (Mon/Fri bias), Escalating Absences, and Frequent Leaves',
+      'Absence Frequency Matrix heatmap shows each employee\'s ANP days per month color-coded by severity',
+      'Day-of-week distribution chart reveals which days are disproportionately missed across the team',
+    ],
+    changes: {
+      added: [
+        'GET /api/hr/analytics/absence — behavioral pattern analysis over AttendanceRecord + LeaveRequest data; query params: months (1–12), section, occupation',
+        '/hr/analytics page with violet hero, 4 KPI tiles (ANP Days, Flagged Employees, Avg ANP/Employee, Approved Leaves), and five collapsible analysis cards',
+        'Pattern Alert card: table of flagged employees with alert type badge (CONSECUTIVE_ABSENCE / WEEKEND_EXTENSION / ESCALATING_ABSENCES / FREQUENT_LEAVES) and severity (HIGH / MEDIUM)',
+        'Absence Frequency Matrix: employee × month heatmap with color-coded cells (white→amber→rose by ANP count)',
+        'ANP by Day-of-Week bar chart: Monday and Friday bars highlighted in amber to expose weekend-extension patterns',
+        'Monthly Company Trend stacked bar chart: ANP (rose) / AP (amber) / Sick (orange) per month',
+        'Leave Request Frequency table: employees with ≥ 2 approved leaves sorted by count with leave-type breakdown',
+        'hr.analytics.view permission added to HR role bundle',
+        '"Absence Analytics" sidebar item under HR section (between HR Dashboard and Employees)',
+      ],
+      fixed: [],
+      changed: [],
+    },
+  },
+  {
+    version: '19.3.0',
+    date: 'April 19, 2026',
+    type: 'minor',
+    status: 'previous',
     mainTitle: 'Employee Widget Fix, Leave Balances, Loan Payments & Attendance Monthly Grid',
     highlights: [
       'Employee Self-Service widget now linkable to any user via Edit User — CEO and all staff can see their HR profile on the dashboard',

--- a/src/app/hr/analytics/page.tsx
+++ b/src/app/hr/analytics/page.tsx
@@ -1,0 +1,47 @@
+import type { Metadata } from 'next';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { verifySession } from '@/lib/jwt';
+import { getCurrentUserPermissions } from '@/lib/permission-checker';
+import prisma from '@/lib/db';
+import { AbsenceAnalyticsClient } from '@/components/hr/absence-analytics-client';
+
+export const metadata: Metadata = { title: 'Absence Analytics' };
+
+export default async function AbsenceAnalyticsPage() {
+  const store = await cookies();
+  const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+  const session = token ? verifySession(token) : null;
+  if (!session) redirect('/login');
+
+  const perms = await getCurrentUserPermissions();
+  if (!perms.includes('hr.analytics.view')) {
+    redirect('/unauthorized?from=/hr/analytics');
+  }
+
+  // Fetch filter options for dropdowns
+  const [sections, occupations] = await Promise.all([
+    prisma.employee.findMany({
+      where: { deletedAt: null, section: { not: null } },
+      select: { section: true },
+      distinct: ['section'],
+      orderBy: { section: 'asc' },
+    }),
+    prisma.employee.findMany({
+      where: { deletedAt: null, occupation: { not: null } },
+      select: { occupation: true },
+      distinct: ['occupation'],
+      orderBy: { occupation: 'asc' },
+    }),
+  ]);
+
+  const sectionOptions = sections.map((e: { section: string | null }) => e.section).filter((s): s is string => s !== null);
+  const occupationOptions = occupations.map((e: { occupation: string | null }) => e.occupation).filter((o): o is string => o !== null);
+
+  return (
+    <AbsenceAnalyticsClient
+      sectionOptions={sectionOptions}
+      occupationOptions={occupationOptions}
+    />
+  );
+}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -253,6 +253,7 @@ const navigationSections: NavigationSection[] = [
     icon: UserCog,
     items: [
       { name: 'HR Dashboard', href: '/hr/dashboard', icon: BarChart3, newSince: '2026-04-12' },
+      { name: 'Absence Analytics', href: '/hr/analytics', icon: TrendingUp, newSince: '2026-04-18' },
       { name: 'Employees', href: '/hr/employees', icon: Users, newSince: '2026-04-12' },
       { name: 'Attendance', href: '/hr/attendance', icon: Calendar, newSince: '2026-04-12' },
       { name: 'Agencies', href: '/hr/agencies', icon: Briefcase, newSince: '2026-04-12' },

--- a/src/components/hr/absence-analytics-client.tsx
+++ b/src/components/hr/absence-analytics-client.tsx
@@ -1,0 +1,564 @@
+'use client';
+
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  TrendingUp,
+  AlertTriangle,
+  Users,
+  CalendarX,
+  CalendarCheck,
+  ChevronDown,
+  ChevronUp,
+  Loader2,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { AbsenceAnalyticsResult, PatternFlag, EmployeeAbsenceStat } from '@/app/api/hr/analytics/absence/route';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface Props {
+  sectionOptions: string[];
+  occupationOptions: string[];
+}
+
+// ---------------------------------------------------------------------------
+// KPI tile
+// ---------------------------------------------------------------------------
+
+type Tone = 'rose' | 'amber' | 'violet' | 'sky' | 'emerald';
+
+const TONE: Record<Tone, string> = {
+  rose:    'from-rose-50 to-white border-rose-200 text-rose-700',
+  amber:   'from-amber-50 to-white border-amber-200 text-amber-700',
+  violet:  'from-violet-50 to-white border-violet-200 text-violet-700',
+  sky:     'from-sky-50 to-white border-sky-200 text-sky-700',
+  emerald: 'from-emerald-50 to-white border-emerald-200 text-emerald-700',
+};
+
+function KpiTile({
+  label,
+  value,
+  hint,
+  tone,
+  icon: Icon,
+}: {
+  label: string;
+  value: string | number;
+  hint: string;
+  tone: Tone;
+  icon: React.ElementType;
+}) {
+  return (
+    <div className={cn('rounded-xl border bg-gradient-to-b p-4 shadow-sm', TONE[tone])}>
+      <div className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide opacity-80">
+        <Icon className="h-3.5 w-3.5" />
+        {label}
+      </div>
+      <div className="mt-1 text-3xl font-bold text-slate-900 tabular-nums">{value}</div>
+      <div className="mt-0.5 text-[11px] text-slate-500">{hint}</div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Alert type badges
+// ---------------------------------------------------------------------------
+
+const ALERT_STYLES: Record<string, string> = {
+  CONSECUTIVE_ABSENCE: 'bg-rose-100 text-rose-700 border-rose-200',
+  WEEKEND_EXTENSION:   'bg-amber-100 text-amber-700 border-amber-200',
+  ESCALATING_ABSENCES: 'bg-orange-100 text-orange-700 border-orange-200',
+  FREQUENT_LEAVES:     'bg-violet-100 text-violet-700 border-violet-200',
+};
+
+const ALERT_LABELS: Record<string, string> = {
+  CONSECUTIVE_ABSENCE: 'Consecutive Absence',
+  WEEKEND_EXTENSION:   'Weekend Extension',
+  ESCALATING_ABSENCES: 'Escalating Trend',
+  FREQUENT_LEAVES:     'Frequent Leaves',
+};
+
+const SEVERITY_STYLES: Record<string, string> = {
+  HIGH:   'bg-rose-600 text-white',
+  MEDIUM: 'bg-amber-500 text-white',
+};
+
+// ---------------------------------------------------------------------------
+// Absence frequency cell colors
+// ---------------------------------------------------------------------------
+
+function anpCellStyle(count: number): string {
+  if (count === 0) return 'text-slate-300 bg-white';
+  if (count <= 2)  return 'bg-amber-50 text-amber-700';
+  if (count <= 4)  return 'bg-amber-100 text-amber-800';
+  if (count <= 7)  return 'bg-rose-100 text-rose-700';
+  return 'bg-rose-200 text-rose-900 font-bold';
+}
+
+// ---------------------------------------------------------------------------
+// Collapsible card
+// ---------------------------------------------------------------------------
+
+function CollapsibleCard({
+  title,
+  badge,
+  defaultOpen = true,
+  children,
+}: {
+  title: string;
+  badge?: React.ReactNode;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className="rounded-2xl border bg-white shadow-sm overflow-hidden">
+      <button
+        onClick={() => setOpen(v => !v)}
+        className="w-full flex items-center justify-between px-6 py-4 border-b bg-slate-50 hover:bg-slate-100 transition-colors"
+      >
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-semibold text-slate-700">{title}</span>
+          {badge}
+        </div>
+        {open ? <ChevronUp className="h-4 w-4 text-slate-400" /> : <ChevronDown className="h-4 w-4 text-slate-400" />}
+      </button>
+      {open && <div>{children}</div>}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main client component
+// ---------------------------------------------------------------------------
+
+export function AbsenceAnalyticsClient({ sectionOptions, occupationOptions }: Props) {
+  const [months, setMonths] = useState(6);
+  const [section, setSection] = useState('');
+  const [occupation, setOccupation] = useState('');
+  const [data, setData] = useState<AbsenceAnalyticsResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams({ months: String(months) });
+      if (section) params.set('section', section);
+      if (occupation) params.set('occupation', occupation);
+      const res = await fetch(`/api/hr/analytics/absence?${params}`);
+      if (!res.ok) throw new Error('Failed to load analytics data');
+      const json = await res.json() as AbsenceAnalyticsResult;
+      setData(json);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error');
+    } finally {
+      setLoading(false);
+    }
+  }, [months, section, occupation]);
+
+  useEffect(() => { void fetchData(); }, [fetchData]);
+
+  // Build sorted month list for frequency matrix columns
+  const monthCols = data
+    ? [...new Set(data.employeeStats.flatMap(e => Object.keys(e.monthlyAnp)))].sort()
+    : [];
+
+  // Employees with any ANP for the matrix
+  const matrixRows = data
+    ? data.employeeStats.filter(e => e.totalAnp > 0).slice(0, 50)
+    : [];
+
+  // Top leave requesters
+  const topLeaveRequesters = data
+    ? [...data.employeeStats]
+        .filter(e => e.leaveRequestCount >= 2)
+        .sort((a, b) => b.leaveRequestCount - a.leaveRequestCount)
+        .slice(0, 20)
+    : [];
+
+  // Day of week bar chart data
+  const dowEntries = data
+    ? Object.entries(data.dayOfWeekDistribution)
+    : [];
+  const dowMax = dowEntries.length > 0 ? Math.max(...dowEntries.map(([, v]) => v)) : 1;
+  const totalDow = dowEntries.reduce((s, [, v]) => s + v, 0);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-slate-50 to-white">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-6">
+
+        {/* Hero Banner */}
+        <div className="rounded-2xl border bg-gradient-to-br from-violet-600 via-violet-500 to-purple-600 p-6 md:p-8 text-white shadow-lg relative overflow-hidden">
+          <div className="absolute -top-4 -right-4 w-32 h-32 bg-white/10 rounded-full blur-2xl" />
+          <div className="absolute -bottom-8 -left-8 w-48 h-48 bg-white/5 rounded-full blur-3xl" />
+          <div className="absolute inset-0 opacity-10 pointer-events-none">
+            <TrendingUp className="absolute -right-8 -top-8 h-48 w-48" />
+          </div>
+          <div className="relative flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+            <div>
+              <div className="inline-flex items-center gap-2 rounded-full bg-white/15 px-3 py-1 text-xs font-medium backdrop-blur-sm">
+                <TrendingUp className="h-3.5 w-3.5" />
+                HR · Analytics
+              </div>
+              <h1 className="mt-3 text-3xl md:text-4xl font-bold tracking-tight">Absence &amp; Leave Analytics</h1>
+              <p className="mt-1 text-violet-100 text-sm md:text-base">
+                Uncover behavioral patterns in team attendance and leave data
+                {data && (
+                  <span className="ml-2 opacity-75">· {data.period.from} → {data.period.to}</span>
+                )}
+              </p>
+            </div>
+
+            {/* Filter controls */}
+            <div className="flex flex-wrap gap-2 shrink-0">
+              <select
+                value={months}
+                onChange={e => setMonths(Number(e.target.value))}
+                className="rounded-lg bg-white/20 backdrop-blur-sm border border-white/30 text-white text-sm px-3 py-2 focus:outline-none focus:ring-2 focus:ring-white/50"
+              >
+                {[3, 6, 9, 12].map(m => (
+                  <option key={m} value={m} className="text-slate-900">{m} months</option>
+                ))}
+              </select>
+              {sectionOptions.length > 0 && (
+                <select
+                  value={section}
+                  onChange={e => setSection(e.target.value)}
+                  className="rounded-lg bg-white/20 backdrop-blur-sm border border-white/30 text-white text-sm px-3 py-2 focus:outline-none focus:ring-2 focus:ring-white/50"
+                >
+                  <option value="" className="text-slate-900">All sections</option>
+                  {sectionOptions.map(s => (
+                    <option key={s} value={s} className="text-slate-900">{s}</option>
+                  ))}
+                </select>
+              )}
+              {occupationOptions.length > 0 && (
+                <select
+                  value={occupation}
+                  onChange={e => setOccupation(e.target.value)}
+                  className="rounded-lg bg-white/20 backdrop-blur-sm border border-white/30 text-white text-sm px-3 py-2 focus:outline-none focus:ring-2 focus:ring-white/50"
+                >
+                  <option value="" className="text-slate-900">All positions</option>
+                  {occupationOptions.map(o => (
+                    <option key={o} value={o} className="text-slate-900">{o}</option>
+                  ))}
+                </select>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Loading / Error */}
+        {loading && (
+          <div className="flex items-center justify-center py-20">
+            <Loader2 className="h-8 w-8 animate-spin text-violet-500" />
+            <span className="ml-3 text-slate-500">Analysing attendance patterns…</span>
+          </div>
+        )}
+
+        {error && (
+          <div className="rounded-xl border border-rose-200 bg-rose-50 px-6 py-4 text-rose-700 text-sm">
+            {error}
+          </div>
+        )}
+
+        {data && !loading && (
+          <>
+            {/* KPI Tiles */}
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-4">
+              <KpiTile
+                label="ANP Days"
+                value={data.summary.totalAnpDays}
+                hint="absent without permission"
+                tone="rose"
+                icon={CalendarX}
+              />
+              <KpiTile
+                label="Flagged"
+                value={data.summary.flaggedEmployees}
+                hint="employees with pattern alerts"
+                tone="amber"
+                icon={AlertTriangle}
+              />
+              <KpiTile
+                label="Avg ANP"
+                value={
+                  data.summary.employeesWithAnp > 0
+                    ? (data.summary.totalAnpDays / data.summary.employeesWithAnp).toFixed(1)
+                    : '0'
+                }
+                hint="days per employee with ANP"
+                tone="violet"
+                icon={Users}
+              />
+              <KpiTile
+                label="Leaves"
+                value={data.summary.totalApprovedLeaves}
+                hint="approved leave requests in period"
+                tone="sky"
+                icon={CalendarCheck}
+              />
+            </div>
+
+            {/* Behavior Flags */}
+            <CollapsibleCard
+              title="Pattern Alerts"
+              badge={
+                data.flags.length > 0 ? (
+                  <span className="rounded-full bg-rose-100 text-rose-700 border border-rose-200 text-xs font-semibold px-2 py-0.5">
+                    {data.flags.length}
+                  </span>
+                ) : null
+              }
+            >
+              {data.flags.length === 0 ? (
+                <div className="flex flex-col items-center py-12 text-slate-400 gap-2">
+                  <CalendarCheck className="h-10 w-10 text-emerald-400" />
+                  <p className="text-sm font-medium text-emerald-600">No behavioral patterns detected in this period</p>
+                  <p className="text-xs text-slate-400">All team members are within normal absence thresholds</p>
+                </div>
+              ) : (
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b bg-slate-50 text-xs text-slate-500 uppercase tracking-wide">
+                        <th className="px-4 py-3 text-left font-semibold">Employee</th>
+                        <th className="px-4 py-3 text-left font-semibold">Occupation</th>
+                        <th className="px-4 py-3 text-left font-semibold">Section</th>
+                        <th className="px-4 py-3 text-left font-semibold">Pattern</th>
+                        <th className="px-4 py-3 text-left font-semibold">Severity</th>
+                        <th className="px-4 py-3 text-left font-semibold">Detail</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-slate-100">
+                      {data.flags.map((flag, i) => (
+                        <FlagRow key={i} flag={flag} />
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </CollapsibleCard>
+
+            {/* Absence Frequency Matrix */}
+            {matrixRows.length > 0 && (
+              <CollapsibleCard title="Absence Frequency Matrix (ANP Days by Employee × Month)">
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b bg-slate-50 text-xs text-slate-500 uppercase tracking-wide">
+                        <th className="px-4 py-3 text-left font-semibold sticky left-0 bg-slate-50 z-10 min-w-[180px]">Employee</th>
+                        <th className="px-4 py-3 text-left font-semibold min-w-[100px]">Section</th>
+                        {monthCols.map(m => (
+                          <th key={m} className="px-3 py-3 text-center font-semibold min-w-[60px]">
+                            {formatMonthHeader(m)}
+                          </th>
+                        ))}
+                        <th className="px-4 py-3 text-center font-semibold min-w-[60px] bg-slate-100">Total</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-slate-100">
+                      {matrixRows.map(emp => (
+                        <tr key={emp.employeeId} className="hover:bg-slate-50 transition-colors">
+                          <td className="px-4 py-2.5 sticky left-0 bg-white z-10">
+                            <div className="font-medium text-slate-800">{emp.fullNameEn}</div>
+                            <div className="text-xs text-slate-400">{emp.employmentId}</div>
+                          </td>
+                          <td className="px-4 py-2.5 text-xs text-slate-500">{emp.section ?? '—'}</td>
+                          {monthCols.map(m => {
+                            const count = emp.monthlyAnp[m] ?? 0;
+                            return (
+                              <td key={m} className={cn('px-3 py-2.5 text-center text-xs font-mono', anpCellStyle(count))}>
+                                {count === 0 ? '' : count}
+                              </td>
+                            );
+                          })}
+                          <td className={cn('px-4 py-2.5 text-center text-xs font-bold', anpCellStyle(emp.totalAnp))}>
+                            {emp.totalAnp}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+                <div className="px-4 py-3 border-t flex items-center gap-3 text-xs text-slate-500">
+                  <span className="font-medium">Legend:</span>
+                  <span className="px-2 py-0.5 rounded bg-amber-50 text-amber-700 border border-amber-200">1–2 days</span>
+                  <span className="px-2 py-0.5 rounded bg-amber-100 text-amber-800 border border-amber-200">3–4 days</span>
+                  <span className="px-2 py-0.5 rounded bg-rose-100 text-rose-700 border border-rose-200">5–7 days</span>
+                  <span className="px-2 py-0.5 rounded bg-rose-200 text-rose-900 border border-rose-300 font-bold">8+ days</span>
+                </div>
+              </CollapsibleCard>
+            )}
+
+            {/* Day of Week Distribution */}
+            {dowEntries.length > 0 && (
+              <CollapsibleCard title="ANP Absences by Day of Week">
+                <div className="px-6 py-6">
+                  <div className="flex items-end gap-4 h-36">
+                    {dowEntries.map(([day, count]) => {
+                      const heightPct = dowMax > 0 ? (count / dowMax) * 100 : 0;
+                      const isWeekendAdj = day === 'Monday' || day === 'Friday';
+                      return (
+                        <div key={day} className="flex flex-col items-center gap-1 flex-1">
+                          <span className="text-xs font-semibold text-slate-600 tabular-nums">{count}</span>
+                          <div className="w-full flex flex-col justify-end" style={{ height: '100px' }}>
+                            <div
+                              className={cn(
+                                'w-full rounded-t-md transition-all',
+                                isWeekendAdj ? 'bg-amber-400' : 'bg-violet-400',
+                              )}
+                              style={{ height: `${Math.max(heightPct, 4)}%` }}
+                            />
+                          </div>
+                          <span className="text-[11px] text-slate-500 text-center leading-tight">{day.slice(0, 3)}</span>
+                          {totalDow > 0 && (
+                            <span className="text-[10px] text-slate-400">{Math.round((count / totalDow) * 100)}%</span>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                  <p className="mt-3 text-xs text-slate-400">
+                    <span className="inline-block w-3 h-3 rounded-sm bg-amber-400 mr-1 align-middle" />
+                    Monday &amp; Friday highlighted — disproportionate spikes may indicate weekend-extension behavior.
+                  </p>
+                </div>
+              </CollapsibleCard>
+            )}
+
+            {/* Monthly Company Trend */}
+            {data.monthlyTrend.length > 0 && (
+              <CollapsibleCard title="Monthly Company Absence Trend">
+                <div className="px-6 py-6">
+                  <div className="flex items-end gap-3">
+                    {data.monthlyTrend.map(({ month, anpDays, apDays, sickDays }) => {
+                      const total = anpDays + apDays + sickDays;
+                      const maxTotal = Math.max(...data.monthlyTrend.map(m => m.anpDays + m.apDays + m.sickDays));
+                      const scale = maxTotal > 0 ? (total / maxTotal) * 100 : 0;
+                      const anpH = total > 0 ? (anpDays / total) * scale : 0;
+                      const apH = total > 0 ? (apDays / total) * scale : 0;
+                      const sickH = total > 0 ? (sickDays / total) * scale : 0;
+                      return (
+                        <div key={month} className="flex flex-col items-center gap-1 flex-1 min-w-[48px]">
+                          <span className="text-[10px] text-slate-500 tabular-nums">{total}</span>
+                          <div className="w-full flex flex-col justify-end" style={{ height: '80px' }}>
+                            <div className="w-full flex flex-col justify-end rounded-t-sm overflow-hidden" style={{ height: `${Math.max(scale, 4)}%` }}>
+                              <div className="w-full bg-rose-400" style={{ height: `${anpH}%` }} title={`ANP: ${anpDays}`} />
+                              <div className="w-full bg-amber-400" style={{ height: `${apH}%` }} title={`AP: ${apDays}`} />
+                              <div className="w-full bg-orange-300" style={{ height: `${sickH}%` }} title={`Sick: ${sickDays}`} />
+                            </div>
+                          </div>
+                          <span className="text-[10px] text-slate-400 text-center">{formatMonthHeader(month)}</span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                  <div className="mt-3 flex items-center gap-4 text-xs text-slate-500">
+                    <span className="flex items-center gap-1.5"><span className="w-3 h-3 rounded-sm bg-rose-400 inline-block" />ANP (no permission)</span>
+                    <span className="flex items-center gap-1.5"><span className="w-3 h-3 rounded-sm bg-amber-400 inline-block" />AP (with permission)</span>
+                    <span className="flex items-center gap-1.5"><span className="w-3 h-3 rounded-sm bg-orange-300 inline-block" />Sick leave</span>
+                  </div>
+                </div>
+              </CollapsibleCard>
+            )}
+
+            {/* Top Leave Requesters */}
+            {topLeaveRequesters.length > 0 && (
+              <CollapsibleCard title="Leave Request Frequency" defaultOpen={false}>
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b bg-slate-50 text-xs text-slate-500 uppercase tracking-wide">
+                        <th className="px-4 py-3 text-left font-semibold">Employee</th>
+                        <th className="px-4 py-3 text-left font-semibold">Section</th>
+                        <th className="px-4 py-3 text-left font-semibold">Occupation</th>
+                        <th className="px-4 py-3 text-center font-semibold">Total Leaves</th>
+                        <th className="px-4 py-3 text-left font-semibold">By Type</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-slate-100">
+                      {topLeaveRequesters.map(emp => (
+                        <tr key={emp.employeeId} className="hover:bg-slate-50 transition-colors">
+                          <td className="px-4 py-3">
+                            <div className="font-medium text-slate-800">{emp.fullNameEn}</div>
+                            <div className="text-xs text-slate-400">{emp.employmentId}</div>
+                          </td>
+                          <td className="px-4 py-3 text-xs text-slate-500">{emp.section ?? '—'}</td>
+                          <td className="px-4 py-3 text-xs text-slate-500">{emp.occupation ?? '—'}</td>
+                          <td className="px-4 py-3 text-center">
+                            <span className={cn(
+                              'rounded-full px-2.5 py-0.5 text-xs font-bold',
+                              emp.leaveRequestCount >= 4 ? 'bg-rose-100 text-rose-700' :
+                              emp.leaveRequestCount >= 3 ? 'bg-amber-100 text-amber-700' :
+                              'bg-slate-100 text-slate-600',
+                            )}>
+                              {emp.leaveRequestCount}
+                            </span>
+                          </td>
+                          <td className="px-4 py-3">
+                            <div className="flex flex-wrap gap-1">
+                              {Object.entries(emp.leavesByType).map(([code, count]) => (
+                                <span key={code} className="rounded bg-violet-50 text-violet-700 border border-violet-200 text-xs px-1.5 py-0.5">
+                                  {code}: {count}
+                                </span>
+                              ))}
+                            </div>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </CollapsibleCard>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function FlagRow({ flag }: { flag: PatternFlag }) {
+  return (
+    <tr className="hover:bg-slate-50 transition-colors">
+      <td className="px-4 py-3">
+        <div className="font-medium text-slate-800">{flag.fullNameEn}</div>
+        <div className="text-xs text-slate-400">{flag.employmentId}</div>
+      </td>
+      <td className="px-4 py-3 text-xs text-slate-500">{flag.occupation ?? '—'}</td>
+      <td className="px-4 py-3 text-xs text-slate-500">{flag.section ?? '—'}</td>
+      <td className="px-4 py-3">
+        <span className={cn(
+          'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium',
+          ALERT_STYLES[flag.alertType] ?? 'bg-slate-100 text-slate-600 border-slate-200',
+        )}>
+          {ALERT_LABELS[flag.alertType] ?? flag.alertType}
+        </span>
+      </td>
+      <td className="px-4 py-3">
+        <span className={cn(
+          'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-bold',
+          SEVERITY_STYLES[flag.severity] ?? 'bg-slate-200 text-slate-700',
+        )}>
+          {flag.severity}
+        </span>
+      </td>
+      <td className="px-4 py-3 text-xs text-slate-600 max-w-xs">{flag.detail}</td>
+    </tr>
+  );
+}
+
+function formatMonthHeader(yyyymm: string): string {
+  const [y, m] = yyyymm.split('-');
+  const d = new Date(Number(y), Number(m) - 1, 1);
+  return d.toLocaleString('en-US', { month: 'short', year: '2-digit' });
+}

--- a/src/lib/navigation-permissions.ts
+++ b/src/lib/navigation-permissions.ts
@@ -190,6 +190,9 @@ export const NAVIGATION_PERMISSIONS: NavigationPermissionMap = {
   '/hr/loans': ['hr.loans.view', 'hr.loans.manage'],
   '/hr/custodies': ['hr.custodies.view', 'hr.custodies.manage'],
 
+  // HR Absence Analytics (19.4.0)
+  '/hr/analytics': ['hr.analytics.view'],
+
   '/admin/identity-reconciliation': ['admin.identity.reconcile'],
 
   // Organization

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -394,6 +394,8 @@ export const PERMISSIONS: PermissionCategory[] = [
       { id: 'hr.letters.view', name: 'View Letters', description: 'View HR letters and correspondence issued to employees', category: 'hr' },
       { id: 'hr.letters.manage', name: 'Manage Letters', description: 'Create, edit, and delete HR letters and correspondence', category: 'hr' },
       { id: 'hr.letters.approveCeo', name: 'CEO-Approve Letters', description: 'Final CEO sign-off on HR letters — approve or reject letters pending approval', category: 'hr' },
+      // 19.4.0 — HR Absence Analytics
+      { id: 'hr.analytics.view', name: 'View HR Analytics', description: 'Access the absence and leave behavioral analytics dashboard', category: 'hr' },
     ],
   },
   {
@@ -507,6 +509,8 @@ export const DEFAULT_ROLE_PERMISSIONS: Record<string, string[]> = {
     // 18.16.0 — Letters & Correspondence
     'hr.letters.view',
     'hr.letters.manage',
+    // 19.4.0 — HR Absence Analytics
+    'hr.analytics.view',
   ],
   Manager: [
     // User Management


### PR DESCRIPTION
New /hr/analytics page surfaces behavioral patterns in attendance and
leave data so management can act on signals before payroll is the only
indicator. Detects four pattern types from existing AttendanceRecord +
LeaveRequest data — no schema changes required:

• CONSECUTIVE_ABSENCE — 3+ consecutive ANP days (weekends transparent)
• WEEKEND_EXTENSION  — >60% of ANP days fall on Monday or Friday
• ESCALATING_ABSENCES — ANP count increasing month-over-month (3m trend)
• FREQUENT_LEAVES     — ≥3 approved leave requests in a single month

API: GET /api/hr/analytics/absence?months=N&section=&occupation=
Returns: summary KPIs, deduplicated pattern flags with HIGH/MEDIUM
severity, per-employee stats, day-of-week distribution, monthly trend.

UI: violet hero, 4 KPI tiles, collapsible Pattern Alerts table,
Absence Frequency Matrix (employee × month heatmap), ANP by Day-of-Week
bar chart, Monthly Company Trend stacked bars, Leave Request Frequency
table. Filters: lookback period (3/6/9/12 months), section, occupation.

Permission hr.analytics.view added to HR role bundle.
Sidebar: "Absence Analytics" item under HR (between Dashboard and Employees).

https://claude.ai/code/session_016KKHu2sjTF8yDns5RRU4rQ