### PR TITLE
fix(manpower-invoices): show all payroll periods in Generate dialog

### DIFF
--- a/src/app/hr/manpower-invoices/page.tsx
+++ b/src/app/hr/manpower-invoices/page.tsx
@@ -35,7 +35,6 @@ export default async function ManpowerInvoicesPage() {
   });
 
   const periods = await prisma.payrollPeriod.findMany({
-    where: { status: { in: ['APPROVED', 'PAID', 'LOCKED'] } },
     orderBy: [{ year: 'desc' }, { month: 'desc' }],
     select: { id: true, year: true, month: true, status: true },
   });


### PR DESCRIPTION
Removed the APPROVED/PAID/LOCKED status filter so all payroll periods
appear in the period dropdown, not just approved ones.

https://claude.ai/code/session_01VATcxDJydQmZV6ZQpnfqRa