### PR TITLE
fix(hr): vacation balance shows 0 employees — fix status filter & Dolibarr mapStatus

### DIFF
--- a/src/app/api/hr/vacation-entitlement/route.ts
+++ b/src/app/api/hr/vacation-entitlement/route.ts
@@ -15,7 +15,7 @@ export const GET = withApiContext(async () => {
   try {
     const [employees, leaveTypes, approvedRequests] = await Promise.all([
       prisma.employee.findMany({
-        where: { deletedAt: null, status: 'ACTIVE' },
+        where: { deletedAt: null, status: { notIn: ['TERMINATED', 'RESIGNED'] } },
         select: {
           id: true,
           fullNameEn: true,

--- a/src/lib/services/hr/sync-dolibarr-employees.ts
+++ b/src/lib/services/hr/sync-dolibarr-employees.ts
@@ -118,10 +118,13 @@ function buildFullName(apiUser: DolibarrUser): string {
 type EmployeeStatus = 'ACTIVE' | 'ON_LEAVE' | 'SUSPENDED' | 'TERMINATED' | 'RESIGNED';
 
 function mapStatus(apiUser: DolibarrUser): EmployeeStatus {
+  const statut = apiUser.statut === undefined ? '1' : String(apiUser.statut);
+  // Dolibarr statut=1 means the user account is active — trust it as ACTIVE
+  // regardless of dateemploymentend (contract end date ≠ employment end date
+  // for renewable contracts common in Saudi Arabia).
+  if (statut === '1') return 'ACTIVE';
   const leavingTs = tsToDate(apiUser.dateemploymentend);
   if (leavingTs && leavingTs.getTime() < Date.now()) return 'TERMINATED';
-  const statut = apiUser.statut === undefined ? '1' : String(apiUser.statut);
-  if (statut === '1') return 'ACTIVE';
   return 'TERMINATED';
 }
 


### PR DESCRIPTION
## Root Cause

Two compounding bugs caused the Vacation Balance tab to show "No active employees found":

1. **`mapStatus` in Dolibarr employee sync** — The function checked `dateemploymentend < now` BEFORE checking Dolibarr's `statut` flag. For Saudi renewable contracts, `dateemploymentend` is the contract end date (not actual leaving date). Once a contract period passed, the sync marked the employee `TERMINATED` in OTS — even though Dolibarr still shows them as `statut=1` (active). This silently turned all contract workers into TERMINATED records on every sync.

2. **Vacation-entitlement API** filtered `status: 'ACTIVE'` only — missing ON_LEAVE, SUSPENDED, and employees incorrectly tagged TERMINATED.

## Fixes

- **`sync-dolibarr-employees.ts`**: `mapStatus` now checks `statut === '1'` first and returns `ACTIVE` immediately, bypassing the `dateemploymentend` check for active Dolibarr accounts.
- **`vacation-entitlement/route.ts`**: Status filter changed from `ACTIVE` to `notIn: ['TERMINATED', 'RESIGNED']` so the report includes all current employees regardless of leave/suspension status.

## Test plan

- [ ] Run a Dolibarr employee sync → active employees (statut=1) should now keep `ACTIVE` status even if their `contractEndDate` is in the past
- [ ] Open `/hr/leaves` → Vacation Balance tab → employees should now appear with correct entitlement and annual consumed days
- [ ] Employees on `ON_LEAVE` or `SUSPENDED` status still appear in the table
- [ ] Employees with `TERMINATED` or `RESIGNED` status do NOT appear

https://claude.ai/code/session_018NLRovA1WyMmCGxzZRdsC6