### PR TITLE
fix(hr): vacation balance empty — remove status filter, show all non-deleted employees

### DIFF
--- a/src/app/api/hr/vacation-entitlement/route.ts
+++ b/src/app/api/hr/vacation-entitlement/route.ts
@@ -15,7 +15,7 @@ export const GET = withApiContext(async () => {
   try {
     const [employees, leaveTypes, approvedRequests] = await Promise.all([
       prisma.employee.findMany({
-        where: { deletedAt: null, status: 'ACTIVE' },
+        where: { deletedAt: null, status: { notIn: ['TERMINATED', 'RESIGNED'] } },
         select: {
           id: true,
           fullNameEn: true,

--- a/src/app/api/hr/vacation-entitlement/route.ts
+++ b/src/app/api/hr/vacation-entitlement/route.ts
@@ -15,7 +15,7 @@ export const GET = withApiContext(async () => {
   try {
     const [employees, leaveTypes, approvedRequests] = await Promise.all([
       prisma.employee.findMany({
-        where: { deletedAt: null, status: { notIn: ['TERMINATED', 'RESIGNED'] } },
+        where: { deletedAt: null },
         select: {
           id: true,
           fullNameEn: true,

--- a/src/lib/services/hr/sync-dolibarr-employees.ts
+++ b/src/lib/services/hr/sync-dolibarr-employees.ts
@@ -118,10 +118,13 @@ function buildFullName(apiUser: DolibarrUser): string {
 type EmployeeStatus = 'ACTIVE' | 'ON_LEAVE' | 'SUSPENDED' | 'TERMINATED' | 'RESIGNED';
 
 function mapStatus(apiUser: DolibarrUser): EmployeeStatus {
+  const statut = apiUser.statut === undefined ? '1' : String(apiUser.statut);
+  // Dolibarr statut=1 means the user account is active — trust it as ACTIVE
+  // regardless of dateemploymentend (contract end date ≠ employment end date
+  // for renewable contracts common in Saudi Arabia).
+  if (statut === '1') return 'ACTIVE';
   const leavingTs = tsToDate(apiUser.dateemploymentend);
   if (leavingTs && leavingTs.getTime() < Date.now()) return 'TERMINATED';
-  const statut = apiUser.statut === undefined ? '1' : String(apiUser.statut);
-  if (statut === '1') return 'ACTIVE';
   return 'TERMINATED';
 }
 


### PR DESCRIPTION
## Problem

All 433 employees in OTS are stored with `status = TERMINATED` because the previous `mapStatus` logic treated `dateemploymentend < now` as "employee left", which is incorrect for renewable Saudi contracts where the end date is just a contract renewal date.

The `notIn ['TERMINATED', 'RESIGNED']` filter from the previous PR still excluded all of them.

## Fix

Drop the `status` filter entirely from the vacation-entitlement API — the existing `deletedAt: null` guard is sufficient. HR needs to see vacation balances for all employees in their system. The `mapStatus` fix (PR #359) ensures future syncs will correctly assign `ACTIVE` to Dolibarr `statut=1` users.

## Test plan

- [ ] Open `/hr/leaves` → Vacation Balance tab → all 433 employees now appear
- [ ] KPI tiles show correct totals
- [ ] Burn-risk highlighting works on high-balance employees

https://claude.ai/code/session_018NLRovA1WyMmCGxzZRdsC6