### PR TITLE
feat(workflow): add generic workflow/approval engine (v21.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [21.0.0] - 2026-04-26
+
+### Workflow Engine
+
+#### Added
+- **Generic workflow / approval engine** — reusable multi-step, multi-approver flow system for IMS, Procurement, HR, and any future module
+- **WorkflowDefinition** — versioned blueprint with a unique `key` (e.g. `IMS_REVISION_APPROVAL`), entity type, and ordered steps
+- **WorkflowStep** — ordered step config with approver resolver, `minApprovals`, `slaHours`, `onRejectBehavior` (`RETURN_PREVIOUS` / `RESTART` / `TERMINATE`), and optional conditions
+- **WorkflowInstance** — running workflow attached to any entity; snapshots definition version so in-flight instances are unaffected by edits
+- **WorkflowStepInstance** — per-instance step snapshot with resolved approvers (evaluated at activation time), approval counters, and SLA tracking
+- **WorkflowApproval** — individual decisions (`APPROVE`, `REJECT`, `DELEGATE`, `COMMENT`) with optional comment and delegatee
+- **Six approver resolver types**: `ROLE`, `PBAC_PERMISSION`, `DEPARTMENT_HEAD`, `MANAGER_OF_INITIATOR`, `FIXED_USER`, `AMOUNT_BAND`
+- **Safe condition evaluator** — evaluates step conditions against entity metadata with comparison operators (`eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `nin`, `contains`); no `eval()`
+- **WorkflowService** — `startWorkflow`, `recordDecision`, `cancelWorkflow`, `getWorkflowStatus`, `getPendingApprovalsForUser` with full state-machine logic
+- **Automatic step advancement** — on approval threshold, skips conditional steps whose conditions fail, auto-completes when all steps pass
+- **Reject behaviors** — `RETURN_PREVIOUS` reactivates prior step; `RESTART` resets all steps to step 1; `TERMINATE` marks instance rejected
+- **Delegation** — `DELEGATE` decision injects delegatee into resolvedApprovers for the active step
+- **API routes** under `/api/workflow/`: definitions CRUD, `POST /start`, `GET /instances/[id]`, `POST /instances/[id]/decide`, `POST /instances/[id]/cancel`, `GET /my-approvals`, `GET /entity/[type]/[id]`
+- **Admin page** at `/workflow/definitions` — CRUD with step editor (resolver type picker, min-approvals, SLA, on-reject behavior, JSON config, conditional steps)
+- **My Approvals page** at `/workflow/my-approvals` — full inbox with SLA countdown badges
+- **ApprovalInbox component** (`@/components/workflow/ApprovalInbox`) — embeddable inbox with approve/reject/delegate/comment actions and auto-refresh
+- **WorkflowTimeline component** (`@/components/workflow/WorkflowTimeline`) — embeddable step-progression visualization with color-coded status, approver lists, and decision history
+- **6 new PBAC permissions**: `workflow.definitions.view`, `workflow.definitions.manage`, `workflow.instances.view`, `workflow.instances.start`, `workflow.instances.cancel`, `workflow.my-approvals.view`
+- **Workflow sidebar section** — "Definitions" and "My Approvals" navigation items under new "Workflow" group
+- **SystemEventService integration** — all state transitions logged automatically (`WORKFLOW_STARTED`, `WORKFLOW_STEP_APPROVED`, `WORKFLOW_STEP_REJECTED`, `WORKFLOW_COMPLETED`, `WORKFLOW_CANCELLED`, `WORKFLOW_RESTARTED`, `WORKFLOW_DECISION_DELEGATED`)
+
+#### Changed
+- Version bumped to **21.0.0** (major release)
+
+---
+
 ## [20.1.1] - 2026-04-25
 
 ### Business Development Module

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Project Overview
 Hexa Steel® OTS — enterprise ERP for steel fabrication projects. Next.js 15 App Router + TypeScript + Prisma + MySQL. Deployed at `hexasteel.sa/ots` with optional `NEXT_PUBLIC_BASE_PATH` subpath.
 
-**Current version:** `20.1.0` — Payroll Entitlement Adjustments (`ANNUAL_LEAVE_ALLOWANCE`, `TICKET_ALLOWANCE`, `EXIT_REENTRY_VISA`). New `leaveDaysCompensated` column on `PayrollAdjustment` (migration `add_payroll_entitlements.sql`).
+**Current version:** `21.0.0` — Generic Workflow / Approval Engine. New models: `WorkflowDefinition`, `WorkflowStep`, `WorkflowInstance`, `WorkflowStepInstance`, `WorkflowApproval`. Migration `add_workflow_engine.sql`. Service at `@/lib/services/workflow.service.ts`. Reusable components: `ApprovalInbox`, `WorkflowTimeline`. Admin page at `/workflow/definitions`.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexa-steel-ots",
-  "version": "20.1.0",
+  "version": "21.0.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/prisma/manual_migrations/add_workflow_engine.sql
+++ b/prisma/manual_migrations/add_workflow_engine.sql
@@ -1,0 +1,184 @@
+-- Workflow Engine (21.0.0)
+-- Creates WorkflowDefinition, WorkflowStep, WorkflowInstance,
+-- WorkflowStepInstance, WorkflowApproval tables.
+
+-- ── WorkflowDefinition ────────────────────────────────────────────────────────
+DROP PROCEDURE IF EXISTS add_workflow_definition_table;
+DELIMITER $$
+CREATE PROCEDURE add_workflow_definition_table()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'WorkflowDefinition'
+  ) THEN
+    CREATE TABLE `WorkflowDefinition` (
+      `id`          CHAR(36)     NOT NULL,
+      `key`         VARCHAR(100) NOT NULL,
+      `name`        VARCHAR(200) NOT NULL,
+      `description` TEXT         NULL,
+      `entityType`  VARCHAR(100) NOT NULL,
+      `version`     INT          NOT NULL DEFAULT 1,
+      `isActive`    TINYINT(1)   NOT NULL DEFAULT 1,
+      `siteId`      VARCHAR(100) NULL,
+      `createdAt`   DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+      `updatedAt`   DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+      `deletedAt`   DATETIME(3)  NULL,
+      PRIMARY KEY (`id`),
+      UNIQUE KEY `WorkflowDefinition_key_key` (`key`),
+      INDEX `WorkflowDefinition_entityType_idx` (`entityType`),
+      INDEX `WorkflowDefinition_isActive_idx` (`isActive`),
+      INDEX `WorkflowDefinition_deletedAt_idx` (`deletedAt`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+  END IF;
+END$$
+DELIMITER ;
+CALL add_workflow_definition_table();
+DROP PROCEDURE IF EXISTS add_workflow_definition_table;
+
+-- ── WorkflowStep ──────────────────────────────────────────────────────────────
+DROP PROCEDURE IF EXISTS add_workflow_step_table;
+DELIMITER $$
+CREATE PROCEDURE add_workflow_step_table()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'WorkflowStep'
+  ) THEN
+    CREATE TABLE `WorkflowStep` (
+      `id`               CHAR(36)     NOT NULL,
+      `definitionId`     CHAR(36)     NOT NULL,
+      `sequence`         INT          NOT NULL,
+      `name`             VARCHAR(200) NOT NULL,
+      `approverResolver` JSON         NOT NULL,
+      `minApprovals`     INT          NOT NULL DEFAULT 1,
+      `slaHours`         INT          NULL,
+      `onRejectBehavior` VARCHAR(30)  NOT NULL DEFAULT 'RETURN_PREVIOUS',
+      `conditions`       JSON         NULL,
+      `createdAt`        DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+      `updatedAt`        DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+      PRIMARY KEY (`id`),
+      INDEX `WorkflowStep_definitionId_sequence_idx` (`definitionId`, `sequence`),
+      CONSTRAINT `fk_wfstep_definition` FOREIGN KEY (`definitionId`)
+        REFERENCES `WorkflowDefinition`(`id`) ON DELETE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+  END IF;
+END$$
+DELIMITER ;
+CALL add_workflow_step_table();
+DROP PROCEDURE IF EXISTS add_workflow_step_table;
+
+-- ── WorkflowInstance ──────────────────────────────────────────────────────────
+DROP PROCEDURE IF EXISTS add_workflow_instance_table;
+DELIMITER $$
+CREATE PROCEDURE add_workflow_instance_table()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'WorkflowInstance'
+  ) THEN
+    CREATE TABLE `WorkflowInstance` (
+      `id`                CHAR(36)     NOT NULL,
+      `definitionId`      CHAR(36)     NOT NULL,
+      `definitionVersion` INT          NOT NULL,
+      `entityType`        VARCHAR(100) NOT NULL,
+      `entityId`          VARCHAR(100) NOT NULL,
+      `currentStepId`     CHAR(36)     NULL,
+      `status`            VARCHAR(20)  NOT NULL DEFAULT 'PENDING',
+      `initiatedById`     CHAR(36)     NOT NULL,
+      `metadata`          JSON         NULL,
+      `siteId`            VARCHAR(100) NULL,
+      `cancelReason`      TEXT         NULL,
+      `cancelledById`     CHAR(36)     NULL,
+      `cancelledAt`       DATETIME(3)  NULL,
+      `completedAt`       DATETIME(3)  NULL,
+      `createdAt`         DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+      `updatedAt`         DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+      PRIMARY KEY (`id`),
+      INDEX `WorkflowInstance_entityType_entityId_idx` (`entityType`, `entityId`),
+      INDEX `WorkflowInstance_status_idx` (`status`),
+      INDEX `WorkflowInstance_definitionId_idx` (`definitionId`),
+      INDEX `WorkflowInstance_initiatedById_idx` (`initiatedById`),
+      CONSTRAINT `fk_wfinst_definition` FOREIGN KEY (`definitionId`)
+        REFERENCES `WorkflowDefinition`(`id`),
+      CONSTRAINT `fk_wfinst_initiatedBy` FOREIGN KEY (`initiatedById`)
+        REFERENCES `User`(`id`),
+      CONSTRAINT `fk_wfinst_cancelledBy` FOREIGN KEY (`cancelledById`)
+        REFERENCES `User`(`id`) ON DELETE SET NULL
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+  END IF;
+END$$
+DELIMITER ;
+CALL add_workflow_instance_table();
+DROP PROCEDURE IF EXISTS add_workflow_instance_table;
+
+-- ── WorkflowStepInstance ──────────────────────────────────────────────────────
+DROP PROCEDURE IF EXISTS add_workflow_step_instance_table;
+DELIMITER $$
+CREATE PROCEDURE add_workflow_step_instance_table()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'WorkflowStepInstance'
+  ) THEN
+    CREATE TABLE `WorkflowStepInstance` (
+      `id`                CHAR(36)    NOT NULL,
+      `instanceId`        CHAR(36)    NOT NULL,
+      `stepId`            CHAR(36)    NOT NULL,
+      `sequence`          INT         NOT NULL,
+      `status`            VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+      `resolvedApprovers` JSON        NULL,
+      `requiredApprovals` INT         NOT NULL DEFAULT 1,
+      `receivedApprovals` INT         NOT NULL DEFAULT 0,
+      `skipReason`        TEXT        NULL,
+      `activatedAt`       DATETIME(3) NULL,
+      `completedAt`       DATETIME(3) NULL,
+      `createdAt`         DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+      `updatedAt`         DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+      PRIMARY KEY (`id`),
+      INDEX `WorkflowStepInstance_instanceId_sequence_idx` (`instanceId`, `sequence`),
+      INDEX `WorkflowStepInstance_status_idx` (`status`),
+      INDEX `WorkflowStepInstance_instanceId_idx` (`instanceId`),
+      CONSTRAINT `fk_wfsi_instance` FOREIGN KEY (`instanceId`)
+        REFERENCES `WorkflowInstance`(`id`) ON DELETE CASCADE,
+      CONSTRAINT `fk_wfsi_step` FOREIGN KEY (`stepId`)
+        REFERENCES `WorkflowStep`(`id`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+  END IF;
+END$$
+DELIMITER ;
+CALL add_workflow_step_instance_table();
+DROP PROCEDURE IF EXISTS add_workflow_step_instance_table;
+
+-- ── WorkflowApproval ──────────────────────────────────────────────────────────
+DROP PROCEDURE IF EXISTS add_workflow_approval_table;
+DELIMITER $$
+CREATE PROCEDURE add_workflow_approval_table()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'WorkflowApproval'
+  ) THEN
+    CREATE TABLE `WorkflowApproval` (
+      `id`                CHAR(36)    NOT NULL,
+      `stepInstanceId`    CHAR(36)    NOT NULL,
+      `userId`            CHAR(36)    NOT NULL,
+      `decision`          VARCHAR(20) NOT NULL,
+      `comment`           TEXT        NULL,
+      `delegatedToUserId` CHAR(36)    NULL,
+      `createdAt`         DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+      `updatedAt`         DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+      PRIMARY KEY (`id`),
+      INDEX `WorkflowApproval_stepInstanceId_idx` (`stepInstanceId`),
+      INDEX `WorkflowApproval_userId_idx` (`userId`),
+      CONSTRAINT `fk_wfa_stepInstance` FOREIGN KEY (`stepInstanceId`)
+        REFERENCES `WorkflowStepInstance`(`id`) ON DELETE CASCADE,
+      CONSTRAINT `fk_wfa_user` FOREIGN KEY (`userId`)
+        REFERENCES `User`(`id`),
+      CONSTRAINT `fk_wfa_delegatedTo` FOREIGN KEY (`delegatedToUserId`)
+        REFERENCES `User`(`id`) ON DELETE SET NULL
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+  END IF;
+END$$
+DELIMITER ;
+CALL add_workflow_approval_table();
+DROP PROCEDURE IF EXISTS add_workflow_approval_table;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -334,6 +334,12 @@ model User {
   createdTrainingPrograms HrTrainingProgram[] @relation("HrTrainingProgramCreatedBy")
   deletedTrainingPrograms HrTrainingProgram[] @relation("HrTrainingProgramDeletedBy")
 
+  // Workflow Engine back-relations (21.0.0)
+  initiatedWorkflows  WorkflowInstance[] @relation("WorkflowInitiatedBy")
+  cancelledWorkflows  WorkflowInstance[] @relation("WorkflowCancelledBy")
+  workflowApprovals   WorkflowApproval[] @relation("WorkflowApprovalUser")
+  delegatedApprovals  WorkflowApproval[] @relation("WorkflowApprovalDelegatedTo")
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }
@@ -5882,4 +5888,130 @@ model BdArchiveEntry {
   @@unique([companyId, entryType])
   @@index([companyId])
   @@map("BdArchiveEntry")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Workflow Engine (21.0.0)
+// Generic reusable approval workflow engine for IMS, Procurement, HR, etc.
+// ─────────────────────────────────────────────────────────────────────────────
+
+model WorkflowDefinition {
+  id          String  @id @default(uuid()) @db.Char(36)
+  key         String  @unique @db.VarChar(100)
+  name        String  @db.VarChar(200)
+  description String? @db.Text
+  entityType  String  @db.VarChar(100)
+  version     Int     @default(1)
+  isActive    Boolean @default(true)
+  siteId      String? @db.VarChar(100)
+
+  steps     WorkflowStep[]
+  instances WorkflowInstance[]
+
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+  deletedAt DateTime?
+
+  @@index([key])
+  @@index([entityType])
+  @@index([isActive])
+  @@index([deletedAt])
+  @@map("WorkflowDefinition")
+}
+
+model WorkflowStep {
+  id               String             @id @default(uuid()) @db.Char(36)
+  definitionId     String             @db.Char(36)
+  definition       WorkflowDefinition @relation(fields: [definitionId], references: [id], onDelete: Cascade)
+  sequence         Int
+  name             String             @db.VarChar(200)
+  approverResolver Json
+  minApprovals     Int                @default(1)
+  slaHours         Int?
+  onRejectBehavior String             @default("RETURN_PREVIOUS") @db.VarChar(30)
+  conditions       Json?
+
+  stepInstances WorkflowStepInstance[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([definitionId, sequence])
+  @@map("WorkflowStep")
+}
+
+model WorkflowInstance {
+  id                String             @id @default(uuid()) @db.Char(36)
+  definitionId      String             @db.Char(36)
+  definition        WorkflowDefinition @relation(fields: [definitionId], references: [id])
+  definitionVersion Int
+  entityType        String             @db.VarChar(100)
+  entityId          String             @db.VarChar(100)
+  currentStepId     String?            @db.Char(36)
+  status            String             @default("PENDING") @db.VarChar(20)
+  initiatedById     String             @db.Char(36)
+  initiatedBy       User               @relation("WorkflowInitiatedBy", fields: [initiatedById], references: [id])
+  metadata          Json?
+  siteId            String?            @db.VarChar(100)
+  cancelReason      String?            @db.Text
+  cancelledById     String?            @db.Char(36)
+  cancelledBy       User?              @relation("WorkflowCancelledBy", fields: [cancelledById], references: [id])
+  cancelledAt       DateTime?
+  completedAt       DateTime?
+
+  stepInstances WorkflowStepInstance[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([entityType, entityId])
+  @@index([status])
+  @@index([definitionId])
+  @@index([initiatedById])
+  @@map("WorkflowInstance")
+}
+
+model WorkflowStepInstance {
+  id                String           @id @default(uuid()) @db.Char(36)
+  instanceId        String           @db.Char(36)
+  instance          WorkflowInstance @relation(fields: [instanceId], references: [id], onDelete: Cascade)
+  stepId            String           @db.Char(36)
+  step              WorkflowStep     @relation(fields: [stepId], references: [id])
+  sequence          Int
+  status            String           @default("PENDING") @db.VarChar(20)
+  resolvedApprovers Json?
+  requiredApprovals Int              @default(1)
+  receivedApprovals Int              @default(0)
+  skipReason        String?          @db.Text
+  activatedAt       DateTime?
+  completedAt       DateTime?
+
+  approvals WorkflowApproval[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([instanceId, sequence])
+  @@index([status])
+  @@index([instanceId])
+  @@map("WorkflowStepInstance")
+}
+
+model WorkflowApproval {
+  id                String               @id @default(uuid()) @db.Char(36)
+  stepInstanceId    String               @db.Char(36)
+  stepInstance      WorkflowStepInstance @relation(fields: [stepInstanceId], references: [id], onDelete: Cascade)
+  userId            String               @db.Char(36)
+  user              User                 @relation("WorkflowApprovalUser", fields: [userId], references: [id])
+  decision          String               @db.VarChar(20)
+  comment           String?              @db.Text
+  delegatedToUserId String?              @db.Char(36)
+  delegatedTo       User?                @relation("WorkflowApprovalDelegatedTo", fields: [delegatedToUserId], references: [id])
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([stepInstanceId])
+  @@index([userId])
+  @@map("WorkflowApproval")
 }

--- a/src/app/api/workflow/definitions/[id]/route.ts
+++ b/src/app/api/workflow/definitions/[id]/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import prisma from '@/lib/db';
+import { withApiContext } from '@/lib/api-utils';
+import { logger } from '@/lib/logger';
+import { checkPermission } from '@/lib/permission-checker';
+
+const updateSchema = z.object({
+  name: z.string().min(1).max(200).optional(),
+  description: z.string().optional(),
+  isActive: z.boolean().optional(),
+  siteId: z.string().optional(),
+});
+
+export const GET = withApiContext(async (req, session, ctx) => {
+  const { id } = await ctx!.params;
+  const canView = await checkPermission('workflow.definitions.view');
+  if (!canView) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  try {
+    const definition = await prisma.workflowDefinition.findFirst({
+      where: { id, deletedAt: null },
+      include: { steps: { orderBy: { sequence: 'asc' } } },
+    });
+    if (!definition) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    return NextResponse.json(definition);
+  } catch (error) {
+    logger.error({ error, id }, 'Failed to fetch workflow definition');
+    return NextResponse.json({ error: 'Failed to fetch workflow definition' }, { status: 500 });
+  }
+});
+
+export const PATCH = withApiContext(async (req, session, ctx) => {
+  const { id } = await ctx!.params;
+  const canManage = await checkPermission('workflow.definitions.manage');
+  if (!canManage) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  const parsed = updateSchema.safeParse(await req.json());
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input', details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  try {
+    const existing = await prisma.workflowDefinition.findFirst({ where: { id, deletedAt: null } });
+    if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    const hasInFlight = await prisma.workflowInstance.count({
+      where: { definitionId: id, status: 'IN_PROGRESS' },
+    });
+
+    const definition = await prisma.workflowDefinition.update({
+      where: { id },
+      data: {
+        ...parsed.data,
+        ...(hasInFlight ? { version: { increment: 1 } } : {}),
+      },
+      include: { steps: { orderBy: { sequence: 'asc' } } },
+    });
+    return NextResponse.json(definition);
+  } catch (error) {
+    logger.error({ error, id }, 'Failed to update workflow definition');
+    return NextResponse.json({ error: 'Failed to update workflow definition' }, { status: 500 });
+  }
+});
+
+export const DELETE = withApiContext(async (req, session, ctx) => {
+  const { id } = await ctx!.params;
+  const canManage = await checkPermission('workflow.definitions.manage');
+  if (!canManage) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  try {
+    const existing = await prisma.workflowDefinition.findFirst({ where: { id, deletedAt: null } });
+    if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    const hasInFlight = await prisma.workflowInstance.count({
+      where: { definitionId: id, status: 'IN_PROGRESS' },
+    });
+    if (hasInFlight) {
+      return NextResponse.json({ error: 'Cannot delete a definition with active workflow instances' }, { status: 409 });
+    }
+
+    await prisma.workflowDefinition.update({
+      where: { id },
+      data: { deletedAt: new Date(), isActive: false },
+    });
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    logger.error({ error, id }, 'Failed to delete workflow definition');
+    return NextResponse.json({ error: 'Failed to delete workflow definition' }, { status: 500 });
+  }
+});

--- a/src/app/api/workflow/definitions/[id]/steps/route.ts
+++ b/src/app/api/workflow/definitions/[id]/steps/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import prisma from '@/lib/db';
+import { withApiContext } from '@/lib/api-utils';
+import { logger } from '@/lib/logger';
+import { checkPermission } from '@/lib/permission-checker';
+
+const stepSchema = z.object({
+  sequence: z.number().int().min(1),
+  name: z.string().min(1).max(200),
+  approverResolver: z.record(z.unknown()),
+  minApprovals: z.number().int().min(1).default(1),
+  slaHours: z.number().int().positive().optional(),
+  onRejectBehavior: z.enum(['RETURN_PREVIOUS', 'RESTART', 'TERMINATE']).default('RETURN_PREVIOUS'),
+  conditions: z.array(z.record(z.unknown())).optional(),
+});
+
+const replaceStepsSchema = z.object({
+  steps: z.array(stepSchema).min(1),
+});
+
+export const PUT = withApiContext(async (req, session, ctx) => {
+  const { id } = await ctx!.params;
+  const canManage = await checkPermission('workflow.definitions.manage');
+  if (!canManage) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  const parsed = replaceStepsSchema.safeParse(await req.json());
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input', details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  try {
+    const definition = await prisma.workflowDefinition.findFirst({ where: { id, deletedAt: null } });
+    if (!definition) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    const hasInFlight = await prisma.workflowInstance.count({
+      where: { definitionId: id, status: 'IN_PROGRESS' },
+    });
+
+    await prisma.$transaction([
+      prisma.workflowStep.deleteMany({ where: { definitionId: id } }),
+      ...parsed.data.steps.map(s =>
+        prisma.workflowStep.create({
+          data: {
+            definitionId: id,
+            sequence: s.sequence,
+            name: s.name,
+            approverResolver: s.approverResolver,
+            minApprovals: s.minApprovals,
+            slaHours: s.slaHours ?? null,
+            onRejectBehavior: s.onRejectBehavior,
+            conditions: s.conditions ?? null,
+          },
+        })
+      ),
+      ...(hasInFlight
+        ? [prisma.workflowDefinition.update({ where: { id }, data: { version: { increment: 1 } } })]
+        : []),
+    ]);
+
+    const updated = await prisma.workflowDefinition.findUnique({
+      where: { id },
+      include: { steps: { orderBy: { sequence: 'asc' } } },
+    });
+    return NextResponse.json(updated);
+  } catch (error) {
+    logger.error({ error, id }, 'Failed to replace workflow steps');
+    return NextResponse.json({ error: 'Failed to replace workflow steps' }, { status: 500 });
+  }
+});

--- a/src/app/api/workflow/definitions/route.ts
+++ b/src/app/api/workflow/definitions/route.ts
@@ -1,0 +1,94 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import prisma from '@/lib/db';
+import { withApiContext } from '@/lib/api-utils';
+import { logger } from '@/lib/logger';
+import { checkPermission } from '@/lib/permission-checker';
+
+const stepSchema = z.object({
+  sequence: z.number().int().min(1),
+  name: z.string().min(1),
+  approverResolver: z.record(z.unknown()),
+  minApprovals: z.number().int().min(1).default(1),
+  slaHours: z.number().int().positive().optional(),
+  onRejectBehavior: z.enum(['RETURN_PREVIOUS', 'RESTART', 'TERMINATE']).default('RETURN_PREVIOUS'),
+  conditions: z.array(z.record(z.unknown())).optional(),
+});
+
+const createSchema = z.object({
+  key: z.string().min(1).max(100).regex(/^[A-Z0-9_]+$/, 'Key must be uppercase letters, digits, and underscores'),
+  name: z.string().min(1).max(200),
+  description: z.string().optional(),
+  entityType: z.string().min(1).max(100),
+  isActive: z.boolean().default(true),
+  siteId: z.string().optional(),
+  steps: z.array(stepSchema).min(1),
+});
+
+export const GET = withApiContext(async (req) => {
+  const canView = await checkPermission('workflow.definitions.view');
+  if (!canView) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  try {
+    const { searchParams } = new URL(req.url);
+    const entityType = searchParams.get('entityType');
+    const activeOnly = searchParams.get('active') !== 'false';
+
+    const definitions = await prisma.workflowDefinition.findMany({
+      where: {
+        deletedAt: null,
+        ...(entityType ? { entityType } : {}),
+        ...(activeOnly ? { isActive: true } : {}),
+      },
+      include: { steps: { orderBy: { sequence: 'asc' } } },
+      orderBy: { createdAt: 'desc' },
+    });
+    return NextResponse.json(definitions);
+  } catch (error) {
+    logger.error({ error }, 'Failed to fetch workflow definitions');
+    return NextResponse.json({ error: 'Failed to fetch workflow definitions' }, { status: 500 });
+  }
+});
+
+export const POST = withApiContext(async (req, session) => {
+  const canManage = await checkPermission('workflow.definitions.manage');
+  if (!canManage) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  const parsed = createSchema.safeParse(await req.json());
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input', details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const { steps, ...defData } = parsed.data;
+
+  try {
+    const existing = await prisma.workflowDefinition.findFirst({
+      where: { key: defData.key, deletedAt: null },
+    });
+    if (existing) {
+      return NextResponse.json({ error: 'A workflow definition with this key already exists' }, { status: 409 });
+    }
+
+    const definition = await prisma.workflowDefinition.create({
+      data: {
+        ...defData,
+        steps: {
+          create: steps.map(s => ({
+            sequence: s.sequence,
+            name: s.name,
+            approverResolver: s.approverResolver,
+            minApprovals: s.minApprovals,
+            slaHours: s.slaHours ?? null,
+            onRejectBehavior: s.onRejectBehavior,
+            conditions: s.conditions ?? null,
+          })),
+        },
+      },
+      include: { steps: { orderBy: { sequence: 'asc' } } },
+    });
+    return NextResponse.json(definition, { status: 201 });
+  } catch (error) {
+    logger.error({ error }, 'Failed to create workflow definition');
+    return NextResponse.json({ error: 'Failed to create workflow definition' }, { status: 500 });
+  }
+});

--- a/src/app/api/workflow/entity/[entityType]/[entityId]/route.ts
+++ b/src/app/api/workflow/entity/[entityType]/[entityId]/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import { withApiContext } from '@/lib/api-utils';
+import { logger } from '@/lib/logger';
+import { checkPermission } from '@/lib/permission-checker';
+import { workflowService } from '@/lib/services/workflow.service';
+
+export const GET = withApiContext(async (req, session, ctx) => {
+  const { entityType, entityId } = await ctx!.params;
+  const canView = await checkPermission('workflow.instances.view');
+  const canApprove = await checkPermission('workflow.my-approvals.view');
+  if (!canView && !canApprove) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  try {
+    const status = await workflowService.getWorkflowStatus(entityType, entityId);
+    if (!status) return NextResponse.json(null);
+    return NextResponse.json(status);
+  } catch (error) {
+    logger.error({ error, entityType, entityId }, 'Failed to fetch entity workflow status');
+    return NextResponse.json({ error: 'Failed to fetch workflow status' }, { status: 500 });
+  }
+});

--- a/src/app/api/workflow/instances/[id]/cancel/route.ts
+++ b/src/app/api/workflow/instances/[id]/cancel/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withApiContext } from '@/lib/api-utils';
+import { logger } from '@/lib/logger';
+import { checkPermission } from '@/lib/permission-checker';
+import { workflowService } from '@/lib/services/workflow.service';
+
+const cancelSchema = z.object({
+  reason: z.string().optional(),
+});
+
+export const POST = withApiContext(async (req, session, ctx) => {
+  const { id } = await ctx!.params;
+  const canCancel = await checkPermission('workflow.instances.cancel');
+  if (!canCancel) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  const parsed = cancelSchema.safeParse(await req.json());
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input', details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  try {
+    await workflowService.cancelWorkflow(id, session!.userId, parsed.data.reason);
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    logger.error({ error, id }, 'Failed to cancel workflow');
+    const message = error instanceof Error ? error.message : 'Failed to cancel workflow';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+});

--- a/src/app/api/workflow/instances/[id]/decide/route.ts
+++ b/src/app/api/workflow/instances/[id]/decide/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withApiContext } from '@/lib/api-utils';
+import { logger } from '@/lib/logger';
+import { checkPermission } from '@/lib/permission-checker';
+import { workflowService } from '@/lib/services/workflow.service';
+
+const decideSchema = z.object({
+  decision: z.enum(['APPROVE', 'REJECT', 'DELEGATE', 'COMMENT']),
+  comment: z.string().optional(),
+  delegatedToUserId: z.string().optional(),
+});
+
+export const POST = withApiContext(async (req, session, ctx) => {
+  const { id } = await ctx!.params;
+  const canApprove = await checkPermission('workflow.my-approvals.view');
+  if (!canApprove) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  const parsed = decideSchema.safeParse(await req.json());
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input', details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  try {
+    const result = await workflowService.recordDecision(
+      id,
+      session!.userId,
+      parsed.data.decision,
+      parsed.data.comment,
+      parsed.data.delegatedToUserId,
+    );
+    return NextResponse.json(result);
+  } catch (error) {
+    logger.error({ error, id }, 'Failed to record workflow decision');
+    const message = error instanceof Error ? error.message : 'Failed to record decision';
+    const status = message.includes('not an authorized') || message.includes('already submitted') ? 403 : 500;
+    return NextResponse.json({ error: message }, { status });
+  }
+});

--- a/src/app/api/workflow/instances/[id]/route.ts
+++ b/src/app/api/workflow/instances/[id]/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+import { withApiContext } from '@/lib/api-utils';
+import { logger } from '@/lib/logger';
+import { checkPermission } from '@/lib/permission-checker';
+import prisma from '@/lib/db';
+
+export const GET = withApiContext(async (req, session, ctx) => {
+  const { id } = await ctx!.params;
+  const canView = await checkPermission('workflow.instances.view');
+  const canApprove = await checkPermission('workflow.my-approvals.view');
+  if (!canView && !canApprove) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  try {
+    const instance = await prisma.workflowInstance.findUnique({
+      where: { id },
+      include: {
+        definition: { select: { key: true, name: true, entityType: true } },
+        initiatedBy: { select: { id: true, name: true, email: true } },
+        cancelledBy: { select: { id: true, name: true } },
+        stepInstances: {
+          orderBy: { sequence: 'asc' },
+          include: {
+            step: { select: { name: true, sequence: true, slaHours: true, onRejectBehavior: true } },
+            approvals: {
+              include: { user: { select: { id: true, name: true, email: true } } },
+              orderBy: { createdAt: 'asc' },
+            },
+          },
+        },
+      },
+    });
+    if (!instance) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    return NextResponse.json(instance);
+  } catch (error) {
+    logger.error({ error, id }, 'Failed to fetch workflow instance');
+    return NextResponse.json({ error: 'Failed to fetch workflow instance' }, { status: 500 });
+  }
+});

--- a/src/app/api/workflow/my-approvals/route.ts
+++ b/src/app/api/workflow/my-approvals/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import { withApiContext } from '@/lib/api-utils';
+import { logger } from '@/lib/logger';
+import { checkPermission } from '@/lib/permission-checker';
+import { workflowService } from '@/lib/services/workflow.service';
+
+export const GET = withApiContext(async (req, session) => {
+  const canApprove = await checkPermission('workflow.my-approvals.view');
+  if (!canApprove) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  const { searchParams } = new URL(req.url);
+  const siteId = searchParams.get('siteId') ?? undefined;
+
+  try {
+    const pending = await workflowService.getPendingApprovalsForUser(session!.userId, siteId);
+    return NextResponse.json(pending);
+  } catch (error) {
+    logger.error({ error }, 'Failed to fetch pending approvals');
+    return NextResponse.json({ error: 'Failed to fetch pending approvals' }, { status: 500 });
+  }
+});

--- a/src/app/api/workflow/start/route.ts
+++ b/src/app/api/workflow/start/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withApiContext } from '@/lib/api-utils';
+import { logger } from '@/lib/logger';
+import { checkPermission } from '@/lib/permission-checker';
+import { workflowService } from '@/lib/services/workflow.service';
+
+const startSchema = z.object({
+  key: z.string().min(1),
+  entityType: z.string().min(1),
+  entityId: z.string().min(1),
+  siteId: z.string().optional(),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+export const POST = withApiContext(async (req, session) => {
+  const canStart = await checkPermission('workflow.instances.start');
+  if (!canStart) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  const parsed = startSchema.safeParse(await req.json());
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input', details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  try {
+    const instance = await workflowService.startWorkflow(
+      parsed.data.key,
+      parsed.data.entityType,
+      parsed.data.entityId,
+      session!.userId,
+      parsed.data.siteId,
+      parsed.data.metadata,
+    );
+    return NextResponse.json(instance, { status: 201 });
+  } catch (error) {
+    logger.error({ error }, 'Failed to start workflow');
+    const message = error instanceof Error ? error.message : 'Failed to start workflow';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+});

--- a/src/app/workflow/definitions/WorkflowDefinitionsClient.tsx
+++ b/src/app/workflow/definitions/WorkflowDefinitionsClient.tsx
@@ -1,0 +1,631 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import {
+  GitBranch, Plus, Pencil, Trash2, ChevronDown, ChevronUp,
+  GripVertical, Save, X, Check, AlertCircle, Power, PowerOff,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Badge } from '@/components/ui/badge';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface WorkflowStep {
+  id?: string;
+  sequence: number;
+  name: string;
+  approverResolver: Record<string, unknown>;
+  minApprovals: number;
+  slaHours: number | null;
+  onRejectBehavior: 'RETURN_PREVIOUS' | 'RESTART' | 'TERMINATE';
+  conditions: unknown[] | null;
+}
+
+interface WorkflowDefinition {
+  id: string;
+  key: string;
+  name: string;
+  description: string | null;
+  entityType: string;
+  version: number;
+  isActive: boolean;
+  siteId: string | null;
+  steps: WorkflowStep[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface Props {
+  canManage: boolean;
+}
+
+// ─── Resolver type display ────────────────────────────────────────────────────
+
+const RESOLVER_TYPES = [
+  { value: 'ROLE', label: 'By Role' },
+  { value: 'PBAC_PERMISSION', label: 'By Permission' },
+  { value: 'DEPARTMENT_HEAD', label: 'Department Head' },
+  { value: 'MANAGER_OF_INITIATOR', label: 'Manager of Initiator' },
+  { value: 'FIXED_USER', label: 'Fixed User' },
+  { value: 'AMOUNT_BAND', label: 'Amount Band' },
+] as const;
+
+function resolverSummary(resolver: Record<string, unknown>): string {
+  const type = resolver.type as string;
+  switch (type) {
+    case 'ROLE':             return `Role: ${resolver.role}`;
+    case 'PBAC_PERMISSION':  return `Permission: ${resolver.permission}`;
+    case 'DEPARTMENT_HEAD':  return 'Department Head';
+    case 'MANAGER_OF_INITIATOR': return 'Manager of Initiator';
+    case 'FIXED_USER':       return `User: ${resolver.userId}`;
+    case 'AMOUNT_BAND':      return `Amount band on "${resolver.field}"`;
+    default:                 return type ?? 'Unknown';
+  }
+}
+
+// ─── Step editor row ─────────────────────────────────────────────────────────
+
+interface StepRowProps {
+  step: WorkflowStep;
+  index: number;
+  onChange: (index: number, step: WorkflowStep) => void;
+  onRemove: (index: number) => void;
+  canManage: boolean;
+}
+
+function StepRow({ step, index, onChange, onRemove, canManage }: StepRowProps) {
+  const [resolverJson, setResolverJson] = useState(JSON.stringify(step.approverResolver, null, 2));
+  const [jsonError, setJsonError] = useState('');
+
+  const update = (field: keyof WorkflowStep, value: unknown) => {
+    onChange(index, { ...step, [field]: value });
+  };
+
+  const handleResolverChange = (val: string) => {
+    setResolverJson(val);
+    try {
+      const parsed = JSON.parse(val);
+      setJsonError('');
+      update('approverResolver', parsed);
+    } catch {
+      setJsonError('Invalid JSON');
+    }
+  };
+
+  const resolverType = (step.approverResolver.type as string) ?? '';
+
+  return (
+    <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 space-y-3">
+      <div className="flex items-center gap-2">
+        <GripVertical className="h-4 w-4 text-slate-300 shrink-0" />
+        <span className="text-xs font-bold text-slate-500 w-6">#{step.sequence}</span>
+        <Input
+          value={step.name}
+          onChange={e => update('name', e.target.value)}
+          placeholder="Step name"
+          className="flex-1 h-8 text-sm"
+          disabled={!canManage}
+        />
+        {canManage && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-rose-500 hover:text-rose-700 h-8 px-2"
+            onClick={() => onRemove(index)}
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </Button>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        <div className="space-y-1">
+          <label className="text-xs font-medium text-slate-500">Resolver type</label>
+          <Select
+            value={resolverType}
+            onValueChange={val => {
+              const base: Record<string, unknown> = { type: val };
+              if (val === 'ROLE') base.role = '';
+              if (val === 'PBAC_PERMISSION') base.permission = '';
+              if (val === 'FIXED_USER') base.userId = '';
+              if (val === 'AMOUNT_BAND') base.field = 'amount';
+              update('approverResolver', base);
+              setResolverJson(JSON.stringify(base, null, 2));
+            }}
+            disabled={!canManage}
+          >
+            <SelectTrigger className="h-8 text-xs">
+              <SelectValue placeholder="Select…" />
+            </SelectTrigger>
+            <SelectContent>
+              {RESOLVER_TYPES.map(r => (
+                <SelectItem key={r.value} value={r.value}>{r.label}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-1">
+          <label className="text-xs font-medium text-slate-500">Min approvals</label>
+          <Input
+            type="number"
+            min={1}
+            value={step.minApprovals}
+            onChange={e => update('minApprovals', parseInt(e.target.value) || 1)}
+            className="h-8 text-sm"
+            disabled={!canManage}
+          />
+        </div>
+
+        <div className="space-y-1">
+          <label className="text-xs font-medium text-slate-500">SLA (hours)</label>
+          <Input
+            type="number"
+            min={1}
+            value={step.slaHours ?? ''}
+            onChange={e => update('slaHours', e.target.value ? parseInt(e.target.value) : null)}
+            placeholder="No SLA"
+            className="h-8 text-sm"
+            disabled={!canManage}
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div className="space-y-1">
+          <label className="text-xs font-medium text-slate-500">On reject</label>
+          <Select
+            value={step.onRejectBehavior}
+            onValueChange={val => update('onRejectBehavior', val)}
+            disabled={!canManage}
+          >
+            <SelectTrigger className="h-8 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="RETURN_PREVIOUS">Return to previous step</SelectItem>
+              <SelectItem value="RESTART">Restart from step 1</SelectItem>
+              <SelectItem value="TERMINATE">Terminate (rejected)</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-1">
+          <label className="text-xs font-medium text-slate-500">Resolver config (JSON)</label>
+          <Textarea
+            value={resolverJson}
+            onChange={e => handleResolverChange(e.target.value)}
+            rows={3}
+            className="text-xs font-mono"
+            disabled={!canManage}
+          />
+          {jsonError && <p className="text-xs text-rose-500">{jsonError}</p>}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Definition form dialog ───────────────────────────────────────────────────
+
+interface DefinitionFormProps {
+  initial: Partial<WorkflowDefinition> | null;
+  onClose: () => void;
+  onSave: () => void;
+}
+
+function DefinitionForm({ initial, onClose, onSave }: DefinitionFormProps) {
+  const isEdit = !!initial?.id;
+  const [key, setKey] = useState(initial?.key ?? '');
+  const [name, setName] = useState(initial?.name ?? '');
+  const [description, setDescription] = useState(initial?.description ?? '');
+  const [entityType, setEntityType] = useState(initial?.entityType ?? '');
+  const [steps, setSteps] = useState<WorkflowStep[]>(
+    initial?.steps ?? [{ sequence: 1, name: '', approverResolver: { type: 'ROLE', role: '' }, minApprovals: 1, slaHours: null, onRejectBehavior: 'RETURN_PREVIOUS', conditions: null }]
+  );
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+
+  const addStep = () => {
+    setSteps(prev => [...prev, {
+      sequence: prev.length + 1,
+      name: '',
+      approverResolver: { type: 'ROLE', role: '' },
+      minApprovals: 1,
+      slaHours: null,
+      onRejectBehavior: 'RETURN_PREVIOUS',
+      conditions: null,
+    }]);
+  };
+
+  const updateStep = (index: number, step: WorkflowStep) => {
+    setSteps(prev => prev.map((s, i) => i === index ? { ...step, sequence: i + 1 } : s));
+  };
+
+  const removeStep = (index: number) => {
+    setSteps(prev => prev.filter((_, i) => i !== index).map((s, i) => ({ ...s, sequence: i + 1 })));
+  };
+
+  const handleSave = async () => {
+    setError('');
+    setSaving(true);
+    try {
+      let res: Response;
+      if (isEdit) {
+        // Update definition metadata
+        res = await fetch(`/api/workflow/definitions/${initial!.id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name, description: description || undefined }),
+        });
+        if (res.ok) {
+          // Replace steps
+          res = await fetch(`/api/workflow/definitions/${initial!.id}/steps`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ steps }),
+          });
+        }
+      } else {
+        res = await fetch('/api/workflow/definitions', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ key, name, description: description || undefined, entityType, steps }),
+        });
+      }
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.error ?? 'Save failed');
+      }
+      onSave();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Save failed');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-2xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{isEdit ? 'Edit' : 'New'} Workflow Definition</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="space-y-1.5">
+              <label className="text-xs font-medium text-slate-600">Key <span className="text-slate-400">(UPPER_SNAKE)</span></label>
+              <Input
+                value={key}
+                onChange={e => setKey(e.target.value.toUpperCase().replace(/[^A-Z0-9_]/g, '_'))}
+                placeholder="IMS_REVISION_APPROVAL"
+                disabled={isEdit}
+                className="font-mono text-sm"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <label className="text-xs font-medium text-slate-600">Entity type</label>
+              <Input
+                value={entityType}
+                onChange={e => setEntityType(e.target.value)}
+                placeholder="IMS_DOCUMENT"
+                disabled={isEdit}
+                className="font-mono text-sm"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-slate-600">Name</label>
+            <Input value={name} onChange={e => setName(e.target.value)} placeholder="IMS Revision Approval" />
+          </div>
+
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-slate-600">Description</label>
+            <Textarea value={description} onChange={e => setDescription(e.target.value)} rows={2} placeholder="Optional description…" />
+          </div>
+
+          {/* Steps */}
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <p className="text-sm font-semibold text-slate-700">Steps ({steps.length})</p>
+              <Button variant="outline" size="sm" onClick={addStep} className="h-7 text-xs gap-1">
+                <Plus className="h-3.5 w-3.5" /> Add step
+              </Button>
+            </div>
+            {steps.map((step, idx) => (
+              <StepRow
+                key={idx}
+                step={step}
+                index={idx}
+                onChange={updateStep}
+                onRemove={removeStep}
+                canManage
+              />
+            ))}
+          </div>
+
+          {error && (
+            <div className="flex items-center gap-2 text-sm text-rose-600 bg-rose-50 border border-rose-200 rounded-lg p-3">
+              <AlertCircle className="h-4 w-4 shrink-0" />
+              {error}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={saving}>Cancel</Button>
+          <Button
+            className="bg-violet-600 hover:bg-violet-700 text-white"
+            onClick={handleSave}
+            disabled={saving || !key || !name || !entityType || steps.length === 0}
+          >
+            <Save className="h-3.5 w-3.5 mr-1.5" />
+            {saving ? 'Saving…' : isEdit ? 'Save changes' : 'Create'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export function WorkflowDefinitionsClient({ canManage }: Props) {
+  const [definitions, setDefinitions] = useState<WorkflowDefinition[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [editTarget, setEditTarget] = useState<WorkflowDefinition | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<WorkflowDefinition | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  const fetchDefinitions = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/workflow/definitions?active=false');
+      if (res.ok) setDefinitions(await res.json());
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { fetchDefinitions(); }, [fetchDefinitions]);
+
+  const handleToggleActive = async (def: WorkflowDefinition) => {
+    await fetch(`/api/workflow/definitions/${def.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ isActive: !def.isActive }),
+    });
+    fetchDefinitions();
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    await fetch(`/api/workflow/definitions/${deleteTarget.id}`, { method: 'DELETE' });
+    setDeleteTarget(null);
+    fetchDefinitions();
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-slate-50 to-white">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
+
+        {/* Hero */}
+        <div className="rounded-2xl border bg-gradient-to-br from-violet-600 via-violet-500 to-purple-600 p-6 md:p-8 text-white shadow-lg relative overflow-hidden">
+          <div className="absolute -top-4 -right-4 w-32 h-32 bg-white/10 rounded-full blur-2xl" />
+          <div className="absolute -bottom-8 -left-8 w-48 h-48 bg-white/5 rounded-full blur-3xl" />
+          <div className="relative z-10">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-3 mb-2">
+                <div className="p-2 bg-white/20 rounded-lg backdrop-blur-sm">
+                  <GitBranch className="h-5 w-5" />
+                </div>
+                <h1 className="text-2xl font-bold">Workflow Definitions</h1>
+              </div>
+              {canManage && (
+                <Button
+                  className="bg-white text-violet-700 hover:bg-violet-50 shadow"
+                  onClick={() => { setEditTarget(null); setShowForm(true); }}
+                >
+                  <Plus className="h-4 w-4 mr-1.5" /> New Definition
+                </Button>
+              )}
+            </div>
+            <p className="text-violet-100 text-sm">
+              Configure multi-step approval flows for IMS, Procurement, HR, and any other module.
+            </p>
+          </div>
+        </div>
+
+        {/* KPI strip */}
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+          {[
+            { label: 'Total', value: definitions.length, color: 'violet' },
+            { label: 'Active', value: definitions.filter(d => d.isActive).length, color: 'emerald' },
+            { label: 'Inactive', value: definitions.filter(d => !d.isActive).length, color: 'slate' },
+            { label: 'Entity types', value: new Set(definitions.map(d => d.entityType)).size, color: 'sky' },
+          ].map(kpi => (
+            <div key={kpi.label} className={`rounded-xl border p-4 shadow-sm bg-gradient-to-b from-${kpi.color}-50 to-white border-${kpi.color}-200`}>
+              <p className={`text-xs font-medium uppercase tracking-wide text-${kpi.color}-600`}>{kpi.label}</p>
+              <p className={`text-2xl font-bold text-${kpi.color}-700 mt-1`}>{kpi.value}</p>
+            </div>
+          ))}
+        </div>
+
+        {/* List */}
+        <div className="rounded-2xl border bg-white shadow-sm overflow-hidden">
+          <div className="flex items-center justify-between px-6 py-4 border-b">
+            <h2 className="text-sm font-semibold text-slate-700">All Definitions</h2>
+          </div>
+
+          {loading ? (
+            <div className="py-16 text-center text-slate-400 text-sm">Loading…</div>
+          ) : definitions.length === 0 ? (
+            <div className="py-16 text-center text-slate-400">
+              <GitBranch className="h-10 w-10 mx-auto mb-3 opacity-30" />
+              <p className="text-sm">No workflow definitions yet.</p>
+              {canManage && (
+                <Button
+                  variant="outline"
+                  className="mt-4"
+                  onClick={() => { setEditTarget(null); setShowForm(true); }}
+                >
+                  <Plus className="h-4 w-4 mr-1.5" /> Create the first one
+                </Button>
+              )}
+            </div>
+          ) : (
+            <ul className="divide-y">
+              {definitions.map(def => (
+                <li key={def.id} className="p-5 hover:bg-slate-50 transition-colors">
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2 mb-1">
+                        <span className="text-sm font-semibold text-slate-800">{def.name}</span>
+                        <code className="text-xs bg-slate-100 text-slate-600 px-1.5 py-0.5 rounded">{def.key}</code>
+                        <Badge className={def.isActive
+                          ? 'bg-emerald-100 text-emerald-700 border-emerald-200'
+                          : 'bg-slate-100 text-slate-500 border-slate-200'
+                        }>
+                          {def.isActive ? 'Active' : 'Inactive'}
+                        </Badge>
+                        <span className="text-xs text-slate-400">v{def.version}</span>
+                      </div>
+                      <p className="text-xs text-slate-500">
+                        Entity: <span className="font-mono text-slate-700">{def.entityType}</span>
+                        {' · '}{def.steps.length} step{def.steps.length !== 1 ? 's' : ''}
+                      </p>
+                      {def.description && (
+                        <p className="text-xs text-slate-400 mt-0.5 line-clamp-1">{def.description}</p>
+                      )}
+                    </div>
+
+                    <div className="flex items-center gap-2 shrink-0">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-7 px-2 text-slate-400"
+                        onClick={() => setExpandedId(expandedId === def.id ? null : def.id)}
+                      >
+                        {expandedId === def.id ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+                      </Button>
+                      {canManage && (
+                        <>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-7 px-2 text-slate-400 hover:text-slate-700"
+                            onClick={() => handleToggleActive(def)}
+                            title={def.isActive ? 'Deactivate' : 'Activate'}
+                          >
+                            {def.isActive ? <PowerOff className="h-4 w-4" /> : <Power className="h-4 w-4" />}
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-7 px-2 text-slate-400 hover:text-slate-700"
+                            onClick={() => { setEditTarget(def); setShowForm(true); }}
+                          >
+                            <Pencil className="h-3.5 w-3.5" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-7 px-2 text-rose-400 hover:text-rose-600"
+                            onClick={() => setDeleteTarget(def)}
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </Button>
+                        </>
+                      )}
+                    </div>
+                  </div>
+
+                  {/* Expanded steps */}
+                  {expandedId === def.id && def.steps.length > 0 && (
+                    <div className="mt-4 space-y-2">
+                      {def.steps.map(step => (
+                        <div key={step.sequence} className="flex items-start gap-3 rounded-lg border border-slate-100 bg-slate-50 px-4 py-2.5">
+                          <span className="text-xs font-bold text-slate-400 w-5 shrink-0">#{step.sequence}</span>
+                          <div className="min-w-0 flex-1">
+                            <p className="text-xs font-semibold text-slate-700">{step.name}</p>
+                            <p className="text-xs text-slate-400">
+                              {resolverSummary(step.approverResolver)}
+                              {' · '}{step.minApprovals} approval{step.minApprovals !== 1 ? 's' : ''}
+                              {step.slaHours ? ` · ${step.slaHours}h SLA` : ''}
+                              {' · on-reject: '}{step.onRejectBehavior.toLowerCase().replace(/_/g, ' ')}
+                            </p>
+                          </div>
+                          {step.conditions && (Array.isArray(step.conditions) && step.conditions.length > 0) && (
+                            <span className="text-xs bg-sky-100 text-sky-700 border border-sky-200 px-1.5 py-0.5 rounded shrink-0">
+                              conditional
+                            </span>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      {/* Form dialog */}
+      {showForm && (
+        <DefinitionForm
+          initial={editTarget}
+          onClose={() => { setShowForm(false); setEditTarget(null); }}
+          onSave={() => { setShowForm(false); setEditTarget(null); fetchDefinitions(); }}
+        />
+      )}
+
+      {/* Delete confirm */}
+      <AlertDialog open={!!deleteTarget} onOpenChange={() => setDeleteTarget(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete workflow definition?</AlertDialogTitle>
+            <AlertDialogDescription>
+              "{deleteTarget?.name}" will be soft-deleted. Active workflow instances will not be affected.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction className="bg-rose-600 hover:bg-rose-700" onClick={handleDelete}>
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/app/workflow/definitions/page.tsx
+++ b/src/app/workflow/definitions/page.tsx
@@ -1,0 +1,22 @@
+import { redirect } from 'next/navigation';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import { checkPermission } from '@/lib/permission-checker';
+import { WorkflowDefinitionsClient } from './WorkflowDefinitionsClient';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = { title: 'Workflow Definitions — OTS' };
+
+export default async function WorkflowDefinitionsPage() {
+  const store = await cookies();
+  const token = store.get(process.env.COOKIE_NAME ?? 'ots_session')?.value;
+  const session = token ? await verifySession(token) : null;
+  if (!session) redirect('/login');
+
+  const canView = await checkPermission('workflow.definitions.view');
+  if (!canView) redirect('/unauthorized?from=/workflow/definitions');
+
+  const canManage = await checkPermission('workflow.definitions.manage');
+
+  return <WorkflowDefinitionsClient canManage={canManage} />;
+}

--- a/src/app/workflow/my-approvals/ApprovalInboxPage.tsx
+++ b/src/app/workflow/my-approvals/ApprovalInboxPage.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { CheckCircle } from 'lucide-react';
+import { ApprovalInbox } from '@/components/workflow/ApprovalInbox';
+
+export function ApprovalInboxPage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-slate-50 to-white">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
+
+        {/* Hero */}
+        <div className="rounded-2xl border bg-gradient-to-br from-amber-500 via-amber-400 to-orange-500 p-6 md:p-8 text-white shadow-lg relative overflow-hidden">
+          <div className="absolute -top-4 -right-4 w-32 h-32 bg-white/10 rounded-full blur-2xl" />
+          <div className="absolute -bottom-8 -left-8 w-48 h-48 bg-white/5 rounded-full blur-3xl" />
+          <div className="relative z-10">
+            <div className="flex items-center gap-3 mb-2">
+              <div className="p-2 bg-white/20 rounded-lg backdrop-blur-sm">
+                <CheckCircle className="h-5 w-5" />
+              </div>
+              <h1 className="text-2xl font-bold">My Approvals</h1>
+            </div>
+            <p className="text-amber-100 text-sm">
+              All workflow steps waiting for your decision.
+            </p>
+          </div>
+        </div>
+
+        {/* Inbox */}
+        <div className="rounded-2xl border bg-white shadow-sm p-6">
+          <ApprovalInbox />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/workflow/my-approvals/page.tsx
+++ b/src/app/workflow/my-approvals/page.tsx
@@ -1,0 +1,20 @@
+import { redirect } from 'next/navigation';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import { checkPermission } from '@/lib/permission-checker';
+import { ApprovalInboxPage } from './ApprovalInboxPage';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = { title: 'My Approvals — OTS' };
+
+export default async function MyApprovalsPage() {
+  const store = await cookies();
+  const token = store.get(process.env.COOKIE_NAME ?? 'ots_session')?.value;
+  const session = token ? await verifySession(token) : null;
+  if (!session) redirect('/login');
+
+  const canView = await checkPermission('workflow.my-approvals.view');
+  if (!canView) redirect('/unauthorized?from=/workflow/my-approvals');
+
+  return <ApprovalInboxPage />;
+}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -335,6 +335,14 @@ const navigationSections: NavigationSection[] = [
     ],
   },
   {
+    name: 'Workflow',
+    icon: GitBranch,
+    items: [
+      { name: 'Definitions', href: '/workflow/definitions', icon: GitBranch, newSince: '2026-04-26' },
+      { name: 'My Approvals', href: '/workflow/my-approvals', icon: CheckCircle, newSince: '2026-04-26' },
+    ],
+  },
+  {
     name: 'Settings',
     icon: Settings,
     items: [

--- a/src/components/workflow/ApprovalInbox.tsx
+++ b/src/components/workflow/ApprovalInbox.tsx
@@ -1,0 +1,347 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { CheckCircle, XCircle, UserCheck, MessageSquare, Clock, RefreshCw, Inbox } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface ResolvedApprover {
+  userId: string;
+  name: string;
+  email: string;
+}
+
+interface PendingApprovalStep {
+  id: string;
+  instanceId: string;
+  sequence: number;
+  status: string;
+  resolvedApprovers: ResolvedApprover[];
+  requiredApprovals: number;
+  receivedApprovals: number;
+  activatedAt: string | null;
+  step: {
+    name: string;
+    sequence: number;
+    slaHours: number | null;
+  };
+  instance: {
+    id: string;
+    entityType: string;
+    entityId: string;
+    definition: { key: string; name: string };
+    initiatedBy: { id: string; name: string };
+  };
+}
+
+interface ApprovalInboxProps {
+  /** Compact mode for dashboard embedding */
+  compact?: boolean;
+  /** Called after a successful decision to allow parent to refresh */
+  onDecisionMade?: () => void;
+}
+
+// ─── Decision dialog ──────────────────────────────────────────────────────────
+
+interface DecisionDialogProps {
+  step: PendingApprovalStep | null;
+  decision: 'APPROVE' | 'REJECT' | 'DELEGATE' | 'COMMENT' | null;
+  onClose: () => void;
+  onConfirm: (comment: string, delegateeId: string) => Promise<void>;
+  submitting: boolean;
+  users: { id: string; name: string }[];
+}
+
+function DecisionDialog({ step, decision, onClose, onConfirm, submitting, users }: DecisionDialogProps) {
+  const [comment, setComment] = useState('');
+  const [delegateeId, setDelegateeId] = useState('');
+
+  useEffect(() => {
+    setComment('');
+    setDelegateeId('');
+  }, [step, decision]);
+
+  if (!step || !decision) return null;
+
+  const requiresComment = decision === 'REJECT';
+  const requiresDelegatee = decision === 'DELEGATE';
+  const canSubmit = (!requiresComment || comment.trim().length > 0) && (!requiresDelegatee || delegateeId);
+
+  const labels: Record<string, string> = {
+    APPROVE: 'Approve',
+    REJECT: 'Reject',
+    DELEGATE: 'Delegate',
+    COMMENT: 'Add Comment',
+  };
+
+  const colors: Record<string, string> = {
+    APPROVE: 'bg-emerald-600 hover:bg-emerald-700',
+    REJECT: 'bg-rose-600 hover:bg-rose-700',
+    DELEGATE: 'bg-sky-600 hover:bg-sky-700',
+    COMMENT: 'bg-slate-600 hover:bg-slate-700',
+  };
+
+  return (
+    <Dialog open onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{labels[decision]} — {step.step.name}</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 py-2">
+          <p className="text-sm text-slate-500">
+            Workflow: <span className="font-medium text-slate-700">{step.instance.definition.name}</span>
+          </p>
+          {requiresDelegatee && (
+            <div className="space-y-1.5">
+              <label className="text-xs font-medium text-slate-600">Delegate to</label>
+              <Select value={delegateeId} onValueChange={setDelegateeId}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select a user…" />
+                </SelectTrigger>
+                <SelectContent>
+                  {users.map(u => (
+                    <SelectItem key={u.id} value={u.id}>{u.name}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-slate-600">
+              {requiresComment ? 'Reason (required)' : 'Comment (optional)'}
+            </label>
+            <Textarea
+              value={comment}
+              onChange={e => setComment(e.target.value)}
+              placeholder={requiresComment ? 'Enter rejection reason…' : 'Add a note…'}
+              rows={3}
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={submitting}>Cancel</Button>
+          <Button
+            className={`text-white ${colors[decision]}`}
+            disabled={!canSubmit || submitting}
+            onClick={() => onConfirm(comment, delegateeId)}
+          >
+            {submitting ? 'Submitting…' : labels[decision]}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ─── SLA badge ────────────────────────────────────────────────────────────────
+
+function SlaBadge({ activatedAt, slaHours }: { activatedAt: string | null; slaHours: number | null }) {
+  if (!slaHours || !activatedAt) return null;
+  const deadlineMs = new Date(activatedAt).getTime() + slaHours * 3_600_000;
+  const remainingHours = (deadlineMs - Date.now()) / 3_600_000;
+  const overdue = remainingHours < 0;
+  const urgent = !overdue && remainingHours < 4;
+
+  return (
+    <span className={`inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full border font-medium ${
+      overdue ? 'bg-rose-100 text-rose-700 border-rose-200' :
+      urgent  ? 'bg-amber-100 text-amber-700 border-amber-200' :
+               'bg-slate-100 text-slate-600 border-slate-200'
+    }`}>
+      <Clock className="h-3 w-3" />
+      {overdue
+        ? `${Math.abs(Math.round(remainingHours))}h overdue`
+        : `${Math.round(remainingHours)}h left`}
+    </span>
+  );
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export function ApprovalInbox({ compact = false, onDecisionMade }: ApprovalInboxProps) {
+  const [steps, setSteps] = useState<PendingApprovalStep[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [activeStep, setActiveStep] = useState<PendingApprovalStep | null>(null);
+  const [activeDecision, setActiveDecision] = useState<'APPROVE' | 'REJECT' | 'DELEGATE' | 'COMMENT' | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [users, setUsers] = useState<{ id: string; name: string }[]>([]);
+
+  const fetchApprovals = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/workflow/my-approvals');
+      if (res.ok) setSteps(await res.json());
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchApprovals();
+    // Prefetch users for delegation
+    fetch('/api/users?status=active').then(r => r.ok ? r.json() : []).then((data: { id: string; name: string }[]) => {
+      if (Array.isArray(data)) setUsers(data.map(u => ({ id: u.id, name: u.name })));
+    });
+  }, [fetchApprovals]);
+
+  const openDecision = (step: PendingApprovalStep, decision: typeof activeDecision) => {
+    setActiveStep(step);
+    setActiveDecision(decision);
+  };
+
+  const submitDecision = async (comment: string, delegateeId: string) => {
+    if (!activeStep || !activeDecision) return;
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/workflow/instances/${activeStep.instanceId}/decide`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          decision: activeDecision,
+          comment: comment || undefined,
+          delegatedToUserId: delegateeId || undefined,
+        }),
+      });
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.error ?? 'Failed to submit decision');
+      }
+      setActiveStep(null);
+      setActiveDecision(null);
+      await fetchApprovals();
+      onDecisionMade?.();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const entityLabel = (step: PendingApprovalStep) =>
+    `${step.instance.entityType.replace(/_/g, ' ')} · ${step.instance.entityId.slice(0, 8)}…`;
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12 text-slate-400 text-sm gap-2">
+        <RefreshCw className="h-4 w-4 animate-spin" />
+        Loading approvals…
+      </div>
+    );
+  }
+
+  if (!steps.length) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-slate-400 gap-2">
+        <Inbox className="h-8 w-8 opacity-40" />
+        <p className="text-sm">No pending approvals</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="space-y-3">
+        {!compact && (
+          <div className="flex items-center justify-between">
+            <p className="text-sm font-semibold text-slate-700">
+              {steps.length} pending approval{steps.length !== 1 ? 's' : ''}
+            </p>
+            <Button variant="ghost" size="sm" onClick={fetchApprovals}>
+              <RefreshCw className="h-3.5 w-3.5 mr-1.5" /> Refresh
+            </Button>
+          </div>
+        )}
+
+        {steps.map(step => (
+          <div
+            key={step.id}
+            className="rounded-xl border border-amber-200 bg-gradient-to-b from-amber-50 to-white p-4 shadow-sm"
+          >
+            <div className="flex items-start justify-between gap-3 mb-2">
+              <div className="min-w-0">
+                <p className="text-sm font-semibold text-slate-800 truncate">{step.step.name}</p>
+                <p className="text-xs text-slate-500 mt-0.5 truncate">{step.instance.definition.name}</p>
+                <p className="text-xs text-slate-400">{entityLabel(step)}</p>
+              </div>
+              <div className="flex flex-col items-end gap-1 shrink-0">
+                <Badge className="bg-amber-100 text-amber-700 border-amber-200 text-xs">
+                  Step {step.sequence}
+                </Badge>
+                <SlaBadge activatedAt={step.activatedAt} slaHours={step.step.slaHours} />
+              </div>
+            </div>
+
+            <div className="flex items-center gap-1.5 text-xs text-slate-400 mb-3">
+              <span>Initiated by <span className="text-slate-600 font-medium">{step.instance.initiatedBy.name}</span></span>
+              {step.requiredApprovals > 1 && (
+                <span>· {step.receivedApprovals}/{step.requiredApprovals} approvals</span>
+              )}
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              <Button
+                size="sm"
+                className="bg-emerald-600 hover:bg-emerald-700 text-white text-xs h-7"
+                onClick={() => openDecision(step, 'APPROVE')}
+              >
+                <CheckCircle className="h-3.5 w-3.5 mr-1" /> Approve
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                className="border-rose-300 text-rose-700 hover:bg-rose-50 text-xs h-7"
+                onClick={() => openDecision(step, 'REJECT')}
+              >
+                <XCircle className="h-3.5 w-3.5 mr-1" /> Reject
+              </Button>
+              {!compact && (
+                <>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="text-xs h-7"
+                    onClick={() => openDecision(step, 'DELEGATE')}
+                  >
+                    <UserCheck className="h-3.5 w-3.5 mr-1" /> Delegate
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="text-xs h-7 text-slate-500"
+                    onClick={() => openDecision(step, 'COMMENT')}
+                  >
+                    <MessageSquare className="h-3.5 w-3.5 mr-1" /> Comment
+                  </Button>
+                </>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <DecisionDialog
+        step={activeStep}
+        decision={activeDecision}
+        onClose={() => { setActiveStep(null); setActiveDecision(null); }}
+        onConfirm={submitDecision}
+        submitting={submitting}
+        users={users}
+      />
+    </>
+  );
+}

--- a/src/components/workflow/WorkflowTimeline.tsx
+++ b/src/components/workflow/WorkflowTimeline.tsx
@@ -1,0 +1,237 @@
+'use client';
+
+import { CheckCircle2, XCircle, Clock, SkipForward, Circle, ChevronRight } from 'lucide-react';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface Approval {
+  id: string;
+  decision: string;
+  comment: string | null;
+  user: { id: string; name: string; email: string };
+  createdAt: string;
+}
+
+interface StepInstance {
+  id: string;
+  sequence: number;
+  status: string;
+  resolvedApprovers: { userId: string; name: string; email: string }[] | null;
+  requiredApprovals: number;
+  receivedApprovals: number;
+  skipReason: string | null;
+  activatedAt: string | null;
+  completedAt: string | null;
+  step: {
+    name: string;
+    sequence: number;
+    slaHours: number | null;
+    onRejectBehavior: string;
+  };
+  approvals: Approval[];
+}
+
+interface WorkflowInstance {
+  id: string;
+  status: string;
+  entityType: string;
+  entityId: string;
+  definition: { key: string; name: string };
+  initiatedBy: { id: string; name: string };
+  createdAt: string;
+  completedAt: string | null;
+  stepInstances: StepInstance[];
+}
+
+interface WorkflowTimelineProps {
+  instance: WorkflowInstance;
+  /** Compact: hide approver lists and comments */
+  compact?: boolean;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function stepStatusConfig(status: string) {
+  switch (status) {
+    case 'APPROVED':
+      return {
+        icon: CheckCircle2,
+        ringColor: 'ring-emerald-400',
+        bgColor: 'bg-emerald-500',
+        textColor: 'text-emerald-700',
+        label: 'Approved',
+        labelClass: 'bg-emerald-100 text-emerald-700 border-emerald-200',
+      };
+    case 'REJECTED':
+      return {
+        icon: XCircle,
+        ringColor: 'ring-rose-400',
+        bgColor: 'bg-rose-500',
+        textColor: 'text-rose-700',
+        label: 'Rejected',
+        labelClass: 'bg-rose-100 text-rose-700 border-rose-200',
+      };
+    case 'ACTIVE':
+      return {
+        icon: Clock,
+        ringColor: 'ring-amber-400',
+        bgColor: 'bg-amber-400',
+        textColor: 'text-amber-700',
+        label: 'In Review',
+        labelClass: 'bg-amber-100 text-amber-700 border-amber-200',
+      };
+    case 'SKIPPED':
+      return {
+        icon: SkipForward,
+        ringColor: 'ring-slate-300',
+        bgColor: 'bg-slate-300',
+        textColor: 'text-slate-500',
+        label: 'Skipped',
+        labelClass: 'bg-slate-100 text-slate-500 border-slate-200',
+      };
+    default:
+      return {
+        icon: Circle,
+        ringColor: 'ring-slate-200',
+        bgColor: 'bg-slate-200',
+        textColor: 'text-slate-400',
+        label: 'Pending',
+        labelClass: 'bg-slate-100 text-slate-500 border-slate-200',
+      };
+  }
+}
+
+function instanceStatusConfig(status: string) {
+  switch (status) {
+    case 'APPROVED':   return { color: 'text-emerald-700', bg: 'bg-emerald-100 border-emerald-200', label: 'Approved' };
+    case 'REJECTED':   return { color: 'text-rose-700', bg: 'bg-rose-100 border-rose-200', label: 'Rejected' };
+    case 'IN_PROGRESS':return { color: 'text-amber-700', bg: 'bg-amber-100 border-amber-200', label: 'In Progress' };
+    case 'CANCELLED':  return { color: 'text-slate-600', bg: 'bg-slate-100 border-slate-200', label: 'Cancelled' };
+    default:           return { color: 'text-slate-500', bg: 'bg-slate-100 border-slate-200', label: status };
+  }
+}
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+function decisionIcon(decision: string) {
+  switch (decision) {
+    case 'APPROVE':  return <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500" />;
+    case 'REJECT':   return <XCircle className="h-3.5 w-3.5 text-rose-500" />;
+    case 'DELEGATE': return <ChevronRight className="h-3.5 w-3.5 text-sky-500" />;
+    default:         return <Circle className="h-3.5 w-3.5 text-slate-400" />;
+  }
+}
+
+// ─── Step node ────────────────────────────────────────────────────────────────
+
+function StepNode({ si, isLast, compact }: { si: StepInstance; isLast: boolean; compact: boolean }) {
+  const cfg = stepStatusConfig(si.status);
+  const Icon = cfg.icon;
+
+  return (
+    <div className="flex gap-3 min-w-0">
+      {/* Icon column */}
+      <div className="flex flex-col items-center">
+        <div className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-full ${cfg.bgColor} ring-2 ring-offset-2 ${cfg.ringColor} shadow-sm`}>
+          <Icon className="h-4 w-4 text-white" />
+        </div>
+        {!isLast && <div className="w-0.5 flex-1 mt-1 mb-1 bg-slate-200 min-h-[20px]" />}
+      </div>
+
+      {/* Content */}
+      <div className={`pb-4 min-w-0 ${isLast ? '' : ''}`}>
+        <div className="flex flex-wrap items-center gap-2 mb-1">
+          <span className="text-sm font-semibold text-slate-800">{si.step.name}</span>
+          <span className={`text-xs px-1.5 py-0.5 rounded border font-medium ${cfg.labelClass}`}>
+            {cfg.label}
+          </span>
+          {si.step.slaHours && (
+            <span className="text-xs text-slate-400">{si.step.slaHours}h SLA</span>
+          )}
+        </div>
+
+        {si.status === 'ACTIVE' && si.resolvedApprovers && !compact && (
+          <p className="text-xs text-slate-500 mb-1.5">
+            Awaiting: {si.resolvedApprovers.map(a => a.name).join(', ')}
+          </p>
+        )}
+
+        {si.status === 'ACTIVE' && si.requiredApprovals > 1 && (
+          <p className="text-xs text-amber-600 mb-1.5">
+            {si.receivedApprovals}/{si.requiredApprovals} approvals received
+          </p>
+        )}
+
+        {si.status === 'SKIPPED' && si.skipReason && (
+          <p className="text-xs text-slate-400 italic mb-1.5">{si.skipReason}</p>
+        )}
+
+        {si.completedAt && (
+          <p className="text-xs text-slate-400 mb-1.5">{formatDate(si.completedAt)}</p>
+        )}
+
+        {!compact && si.approvals.length > 0 && (
+          <div className="space-y-1 mt-1.5">
+            {si.approvals.map(a => (
+              <div key={a.id} className="flex items-start gap-1.5 text-xs text-slate-600">
+                {decisionIcon(a.decision)}
+                <span className="font-medium">{a.user.name}</span>
+                <span className="text-slate-400">— {a.decision.toLowerCase()}</span>
+                {a.comment && <span className="text-slate-500">"{a.comment}"</span>}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export function WorkflowTimeline({ instance, compact = false }: WorkflowTimelineProps) {
+  const statusCfg = instanceStatusConfig(instance.status);
+
+  return (
+    <div className="rounded-2xl border bg-white shadow-sm overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center justify-between px-5 py-3.5 border-b bg-slate-50">
+        <div className="min-w-0">
+          <p className="text-sm font-semibold text-slate-800 truncate">{instance.definition.name}</p>
+          <p className="text-xs text-slate-400 mt-0.5">
+            Started by {instance.initiatedBy.name} · {formatDate(instance.createdAt)}
+          </p>
+        </div>
+        <span className={`text-xs px-2 py-1 rounded-full border font-medium shrink-0 ${statusCfg.bg} ${statusCfg.color}`}>
+          {statusCfg.label}
+        </span>
+      </div>
+
+      {/* Steps */}
+      <div className="px-5 pt-4 pb-2">
+        {instance.stepInstances.length === 0 ? (
+          <p className="text-sm text-slate-400 py-2">No steps defined.</p>
+        ) : (
+          <div>
+            {instance.stepInstances.map((si, idx) => (
+              <StepNode
+                key={si.id}
+                si={si}
+                isLast={idx === instance.stepInstances.length - 1}
+                compact={compact}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {instance.completedAt && (
+        <div className="px-5 pb-3 text-xs text-slate-400">
+          Completed {formatDate(instance.completedAt)}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/navigation-permissions.ts
+++ b/src/lib/navigation-permissions.ts
@@ -223,6 +223,10 @@ export const NAVIGATION_PERMISSIONS: NavigationPermissionMap = {
 
   // Business Development (20.0.0)
   '/business-development': ['bd.companies.view', 'bd.companies.manage'],
+
+  // Workflow Engine (21.0.0)
+  '/workflow/definitions': ['workflow.definitions.view', 'workflow.definitions.manage'],
+  '/workflow/my-approvals': ['workflow.my-approvals.view'],
 };
 
 // Helper function to check if user has permission to access a route

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -424,6 +424,19 @@ export const PERMISSIONS: PermissionCategory[] = [
     ],
   },
   {
+  {
+    id: 'workflow',
+    name: 'Workflow Engine',
+    permissions: [
+      { id: 'workflow.definitions.view', name: 'View Workflow Definitions', description: 'View workflow definition templates and steps', category: 'workflow' },
+      { id: 'workflow.definitions.manage', name: 'Manage Workflow Definitions', description: 'Create, edit, and delete workflow definition templates', category: 'workflow' },
+      { id: 'workflow.instances.view', name: 'View Workflow Instances', description: 'View running and completed workflow instances', category: 'workflow' },
+      { id: 'workflow.instances.start', name: 'Start Workflows', description: 'Initiate new workflow instances for entities', category: 'workflow' },
+      { id: 'workflow.instances.cancel', name: 'Cancel Workflows', description: 'Cancel active workflow instances', category: 'workflow' },
+      { id: 'workflow.my-approvals.view', name: 'View My Approvals', description: 'View and act on pending approval steps assigned to the current user', category: 'workflow' },
+    ],
+  },
+  {
     name: 'Business Development',
     permissions: [
       { id: 'bd.companies.view', name: 'View BD Companies', description: 'View business development companies, their status, and related records', category: 'business_development' },
@@ -699,6 +712,13 @@ export const DEFAULT_ROLE_PERMISSIONS: Record<string, string[]> = {
     'bd.companies.view',
     'bd.documents.view',
     'bd.requests.view',
+    // 21.0.0 — Workflow Engine
+    'workflow.definitions.view',
+    'workflow.definitions.manage',
+    'workflow.instances.view',
+    'workflow.instances.start',
+    'workflow.instances.cancel',
+    'workflow.my-approvals.view',
   ],
   Engineer: [
     // Basic Access

--- a/src/lib/services/workflow.service.ts
+++ b/src/lib/services/workflow.service.ts
@@ -1,0 +1,646 @@
+/**
+ * Workflow Engine Service (21.0.0)
+ * Generic reusable approval workflow for IMS, Procurement, HR, and any module
+ * that needs multi-step, multi-approver flows.
+ */
+
+import prisma from '@/lib/db';
+import { logger } from '@/lib/logger';
+import { systemEventService } from '@/services/system-events.service';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type ApproverResolverConfig =
+  | { type: 'ROLE'; role: string }
+  | { type: 'PBAC_PERMISSION'; permission: string }
+  | { type: 'DEPARTMENT_HEAD' }
+  | { type: 'MANAGER_OF_INITIATOR' }
+  | { type: 'FIXED_USER'; userId: string }
+  | { type: 'AMOUNT_BAND'; field: string; bands: AmountBand[] };
+
+interface AmountBand {
+  min: number;
+  max?: number;
+  role?: string;
+  userId?: string;
+}
+
+export type ConditionOperator = 'eq' | 'ne' | 'gt' | 'gte' | 'lt' | 'lte' | 'in' | 'nin' | 'contains';
+
+export interface StepCondition {
+  field: string;
+  operator: ConditionOperator;
+  value: unknown;
+}
+
+interface ResolvedApprover {
+  userId: string;
+  name: string;
+  email: string;
+}
+
+// ─── Condition evaluator (no eval) ───────────────────────────────────────────
+
+function evaluateCondition(condition: StepCondition, metadata: Record<string, unknown>): boolean {
+  const fieldValue = metadata[condition.field];
+  const { operator, value } = condition;
+
+  switch (operator) {
+    case 'eq':   return fieldValue === value;
+    case 'ne':   return fieldValue !== value;
+    case 'gt':   return typeof fieldValue === 'number' && typeof value === 'number' && fieldValue > value;
+    case 'gte':  return typeof fieldValue === 'number' && typeof value === 'number' && fieldValue >= value;
+    case 'lt':   return typeof fieldValue === 'number' && typeof value === 'number' && fieldValue < value;
+    case 'lte':  return typeof fieldValue === 'number' && typeof value === 'number' && fieldValue <= value;
+    case 'in':   return Array.isArray(value) && value.includes(fieldValue);
+    case 'nin':  return Array.isArray(value) && !value.includes(fieldValue);
+    case 'contains':
+      return typeof fieldValue === 'string' && typeof value === 'string' && fieldValue.includes(value);
+    default:     return false;
+  }
+}
+
+function evaluateConditions(conditions: StepCondition[] | null | undefined, metadata: Record<string, unknown>): boolean {
+  if (!conditions || conditions.length === 0) return true;
+  return conditions.every(c => evaluateCondition(c, metadata));
+}
+
+// ─── Approver Resolver ────────────────────────────────────────────────────────
+
+async function resolveApprovers(
+  config: ApproverResolverConfig,
+  initiatorId: string,
+  metadata: Record<string, unknown>,
+): Promise<ResolvedApprover[]> {
+  switch (config.type) {
+    case 'ROLE': {
+      const users = await prisma.user.findMany({
+        where: {
+          role: { name: config.role },
+          status: 'active',
+        },
+        select: { id: true, name: true, email: true },
+      });
+      return users;
+    }
+
+    case 'PBAC_PERMISSION': {
+      const allUsers = await prisma.user.findMany({
+        where: { status: 'active' },
+        select: { id: true, name: true, email: true, role: { select: { permissions: true } }, customPermissions: true },
+      });
+      return allUsers
+        .filter(u => {
+          const perms = (u.customPermissions ?? u.role.permissions) as string[] | null;
+          return Array.isArray(perms) && perms.includes(config.permission);
+        })
+        .map(u => ({ userId: u.id, name: u.name, email: u.email }));
+    }
+
+    case 'DEPARTMENT_HEAD': {
+      const initiator = await prisma.user.findUnique({
+        where: { id: initiatorId },
+        select: { departmentId: true },
+      });
+      if (!initiator?.departmentId) return [];
+      const dept = await prisma.department.findUnique({
+        where: { id: initiator.departmentId },
+        select: { manager: { select: { id: true, name: true, email: true } } },
+      });
+      return dept?.manager ? [{ userId: dept.manager.id, name: dept.manager.name, email: dept.manager.email }] : [];
+    }
+
+    case 'MANAGER_OF_INITIATOR': {
+      const initiator = await prisma.user.findUnique({
+        where: { id: initiatorId },
+        select: { reportsTo: { select: { id: true, name: true, email: true } } },
+      });
+      return initiator?.reportsTo
+        ? [{ userId: initiator.reportsTo.id, name: initiator.reportsTo.name, email: initiator.reportsTo.email }]
+        : [];
+    }
+
+    case 'FIXED_USER': {
+      const user = await prisma.user.findUnique({
+        where: { id: config.userId, status: 'active' },
+        select: { id: true, name: true, email: true },
+      });
+      return user ? [{ userId: user.id, name: user.name, email: user.email }] : [];
+    }
+
+    case 'AMOUNT_BAND': {
+      const fieldVal = metadata[config.field];
+      if (typeof fieldVal !== 'number') return [];
+      const band = config.bands.find(b => fieldVal >= b.min && (b.max === undefined || fieldVal <= b.max));
+      if (!band) return [];
+      if (band.userId) {
+        const user = await prisma.user.findUnique({
+          where: { id: band.userId, status: 'active' },
+          select: { id: true, name: true, email: true },
+        });
+        return user ? [{ userId: user.id, name: user.name, email: user.email }] : [];
+      }
+      if (band.role) {
+        const users = await prisma.user.findMany({
+          where: { role: { name: band.role }, status: 'active' },
+          select: { id: true, name: true, email: true },
+        });
+        return users;
+      }
+      return [];
+    }
+
+    default:
+      return [];
+  }
+}
+
+// ─── Service ──────────────────────────────────────────────────────────────────
+
+class WorkflowService {
+
+  /**
+   * Start a new workflow instance for an entity.
+   * Finds the active definition by key, snapshots step instances, evaluates
+   * step-1 conditions, resolves approvers, and activates the first eligible step.
+   */
+  async startWorkflow(
+    key: string,
+    entityType: string,
+    entityId: string,
+    initiatedById: string,
+    siteId?: string,
+    metadata?: Record<string, unknown>,
+  ) {
+    const definition = await prisma.workflowDefinition.findFirst({
+      where: { key, isActive: true, deletedAt: null },
+      include: { steps: { orderBy: { sequence: 'asc' } } },
+    });
+    if (!definition) throw new Error(`No active workflow definition found for key: ${key}`);
+    if (!definition.steps.length) throw new Error(`Workflow definition "${key}" has no steps`);
+
+    const meta = metadata ?? {};
+
+    const instance = await prisma.workflowInstance.create({
+      data: {
+        definitionId: definition.id,
+        definitionVersion: definition.version,
+        entityType,
+        entityId,
+        status: 'IN_PROGRESS',
+        initiatedById,
+        metadata: meta,
+        siteId: siteId ?? null,
+      },
+    });
+
+    // Create all step instances in PENDING state
+    const stepInstances = await Promise.all(
+      definition.steps.map(step =>
+        prisma.workflowStepInstance.create({
+          data: {
+            instanceId: instance.id,
+            stepId: step.id,
+            sequence: step.sequence,
+            status: 'PENDING',
+            requiredApprovals: step.minApprovals,
+            receivedApprovals: 0,
+          },
+        })
+      )
+    );
+
+    // Activate the first eligible step
+    await this._activateNextStep(instance.id, initiatedById, meta, stepInstances, null);
+
+    await systemEventService.log({
+      eventType: 'WORKFLOW_STARTED',
+      eventCategory: 'BUSINESS',
+      severity: 'INFO',
+      userId: initiatedById,
+      entityType,
+      entityId,
+      summary: `Workflow "${definition.name}" started for ${entityType}:${entityId}`,
+      details: { definitionKey: key, instanceId: instance.id },
+    });
+
+    return instance;
+  }
+
+  /**
+   * Record an approval decision on the current active step.
+   * Handles APPROVE (advance/complete), REJECT (behavior), DELEGATE, COMMENT.
+   */
+  async recordDecision(
+    instanceId: string,
+    userId: string,
+    decision: 'APPROVE' | 'REJECT' | 'DELEGATE' | 'COMMENT',
+    comment?: string,
+    delegatedToUserId?: string,
+  ) {
+    const instance = await prisma.workflowInstance.findUnique({
+      where: { id: instanceId },
+      include: {
+        stepInstances: { orderBy: { sequence: 'asc' } },
+        definition: { include: { steps: { orderBy: { sequence: 'asc' } } } },
+      },
+    });
+    if (!instance) throw new Error('Workflow instance not found');
+    if (instance.status !== 'IN_PROGRESS') throw new Error(`Workflow is not in progress (status: ${instance.status})`);
+
+    const activeStepInstance = instance.stepInstances.find(si => si.status === 'ACTIVE');
+    if (!activeStepInstance) throw new Error('No active step found');
+
+    // Verify user is an authorized approver (in resolvedApprovers or delegated)
+    const resolvedApprovers = (activeStepInstance.resolvedApprovers ?? []) as ResolvedApprover[];
+    const isAuthorized = resolvedApprovers.some(a => a.userId === userId);
+    if (!isAuthorized) throw new Error('User is not an authorized approver for this step');
+
+    // Prevent duplicate approve/reject decisions from same user
+    const existingDecision = await prisma.workflowApproval.findFirst({
+      where: {
+        stepInstanceId: activeStepInstance.id,
+        userId,
+        decision: { in: ['APPROVE', 'REJECT'] },
+      },
+    });
+    if (existingDecision) throw new Error('User has already submitted a decision for this step');
+
+    // Record the approval
+    await prisma.workflowApproval.create({
+      data: {
+        stepInstanceId: activeStepInstance.id,
+        userId,
+        decision,
+        comment: comment ?? null,
+        delegatedToUserId: delegatedToUserId ?? null,
+      },
+    });
+
+    const meta = (instance.metadata ?? {}) as Record<string, unknown>;
+
+    if (decision === 'APPROVE') {
+      const newCount = activeStepInstance.receivedApprovals + 1;
+      await prisma.workflowStepInstance.update({
+        where: { id: activeStepInstance.id },
+        data: { receivedApprovals: newCount },
+      });
+
+      if (newCount >= activeStepInstance.requiredApprovals) {
+        // Mark step approved
+        await prisma.workflowStepInstance.update({
+          where: { id: activeStepInstance.id },
+          data: { status: 'APPROVED', completedAt: new Date() },
+        });
+        await systemEventService.log({
+          eventType: 'WORKFLOW_STEP_APPROVED',
+          eventCategory: 'BUSINESS',
+          severity: 'INFO',
+          userId,
+          entityType: instance.entityType,
+          entityId: instance.entityId,
+          summary: `Step "${activeStepInstance.sequence}" approved in workflow instance ${instanceId}`,
+          details: { instanceId, stepInstanceId: activeStepInstance.id, approverCount: newCount },
+        });
+        await this._activateNextStep(
+          instanceId,
+          instance.initiatedById,
+          meta,
+          instance.stepInstances,
+          activeStepInstance.id,
+        );
+      }
+    } else if (decision === 'REJECT') {
+      await prisma.workflowStepInstance.update({
+        where: { id: activeStepInstance.id },
+        data: { status: 'REJECTED', completedAt: new Date() },
+      });
+
+      const step = instance.definition.steps.find(s => s.id === activeStepInstance.stepId);
+      const behavior = (step?.onRejectBehavior ?? 'RETURN_PREVIOUS') as string;
+
+      await this._applyRejectBehavior(
+        instance,
+        activeStepInstance,
+        behavior,
+        userId,
+        meta,
+      );
+    } else if (decision === 'DELEGATE') {
+      if (!delegatedToUserId) throw new Error('delegatedToUserId required for DELEGATE decision');
+      const delegatee = await prisma.user.findUnique({
+        where: { id: delegatedToUserId },
+        select: { id: true, name: true, email: true },
+      });
+      if (!delegatee) throw new Error('Delegatee user not found');
+
+      // Add delegatee to resolvedApprovers if not already present
+      const alreadyIn = resolvedApprovers.some(a => a.userId === delegatedToUserId);
+      if (!alreadyIn) {
+        const updated = [...resolvedApprovers, { userId: delegatee.id, name: delegatee.name, email: delegatee.email }];
+        await prisma.workflowStepInstance.update({
+          where: { id: activeStepInstance.id },
+          data: { resolvedApprovers: updated },
+        });
+      }
+      await systemEventService.log({
+        eventType: 'WORKFLOW_DECISION_DELEGATED',
+        eventCategory: 'BUSINESS',
+        severity: 'INFO',
+        userId,
+        entityType: instance.entityType,
+        entityId: instance.entityId,
+        summary: `Step decision delegated to user ${delegatedToUserId} in workflow ${instanceId}`,
+        details: { instanceId, stepInstanceId: activeStepInstance.id, delegatedToUserId },
+      });
+    }
+    // COMMENT: already recorded — no state change needed
+
+    return prisma.workflowInstance.findUnique({
+      where: { id: instanceId },
+      include: { stepInstances: { include: { approvals: true }, orderBy: { sequence: 'asc' } } },
+    });
+  }
+
+  /** Cancel a workflow instance. */
+  async cancelWorkflow(instanceId: string, userId: string, reason?: string) {
+    const instance = await prisma.workflowInstance.findUnique({ where: { id: instanceId } });
+    if (!instance) throw new Error('Workflow instance not found');
+    if (['APPROVED', 'REJECTED', 'CANCELLED'].includes(instance.status)) {
+      throw new Error(`Cannot cancel workflow in status: ${instance.status}`);
+    }
+
+    // Mark active step as skipped
+    await prisma.workflowStepInstance.updateMany({
+      where: { instanceId, status: 'ACTIVE' },
+      data: { status: 'SKIPPED', skipReason: reason ?? 'Workflow cancelled', completedAt: new Date() },
+    });
+
+    await prisma.workflowInstance.update({
+      where: { id: instanceId },
+      data: {
+        status: 'CANCELLED',
+        cancelReason: reason ?? null,
+        cancelledById: userId,
+        cancelledAt: new Date(),
+      },
+    });
+
+    await systemEventService.log({
+      eventType: 'WORKFLOW_CANCELLED',
+      eventCategory: 'BUSINESS',
+      severity: 'WARNING',
+      userId,
+      entityType: instance.entityType,
+      entityId: instance.entityId,
+      summary: `Workflow instance ${instanceId} cancelled`,
+      details: { instanceId, reason },
+    });
+  }
+
+  /** Get the full workflow status for an entity (latest active instance). */
+  async getWorkflowStatus(entityType: string, entityId: string) {
+    return prisma.workflowInstance.findFirst({
+      where: { entityType, entityId },
+      orderBy: { createdAt: 'desc' },
+      include: {
+        definition: { select: { key: true, name: true, entityType: true } },
+        initiatedBy: { select: { id: true, name: true, email: true } },
+        cancelledBy: { select: { id: true, name: true } },
+        stepInstances: {
+          orderBy: { sequence: 'asc' },
+          include: {
+            step: { select: { name: true, sequence: true, slaHours: true, onRejectBehavior: true } },
+            approvals: {
+              include: { user: { select: { id: true, name: true, email: true } } },
+              orderBy: { createdAt: 'asc' },
+            },
+          },
+        },
+      },
+    });
+  }
+
+  /** Get all pending approval steps for a given user across all active workflows. */
+  async getPendingApprovalsForUser(userId: string, siteId?: string) {
+    const activeSteps = await prisma.workflowStepInstance.findMany({
+      where: { status: 'ACTIVE' },
+      include: {
+        instance: {
+          where: {
+            status: 'IN_PROGRESS',
+            ...(siteId ? { siteId } : {}),
+          },
+          include: {
+            definition: { select: { key: true, name: true } },
+            initiatedBy: { select: { id: true, name: true } },
+          },
+        },
+        step: { select: { name: true, sequence: true, slaHours: true } },
+        approvals: { where: { userId, decision: { in: ['APPROVE', 'REJECT'] } } },
+      },
+    });
+
+    // Filter to steps where user is in resolvedApprovers and hasn't decided yet
+    return activeSteps.filter(si => {
+      if (!si.instance) return false;
+      const approvers = (si.resolvedApprovers ?? []) as ResolvedApprover[];
+      const isApprover = approvers.some(a => a.userId === userId);
+      const hasDecided = si.approvals.length > 0;
+      return isApprover && !hasDecided;
+    });
+  }
+
+  // ─── Private helpers ────────────────────────────────────────────────────────
+
+  /** Activate the next eligible step after currentStepInstanceId (null = find first). */
+  private async _activateNextStep(
+    instanceId: string,
+    initiatorId: string,
+    meta: Record<string, unknown>,
+    stepInstances: { id: string; sequence: number; stepId: string; status: string }[],
+    completedStepInstanceId: string | null,
+  ) {
+    const completedSeq = completedStepInstanceId
+      ? stepInstances.find(si => si.id === completedStepInstanceId)?.sequence ?? -1
+      : -1;
+
+    const candidates = stepInstances
+      .filter(si => si.sequence > completedSeq && si.status === 'PENDING')
+      .sort((a, b) => a.sequence - b.sequence);
+
+    for (const candidate of candidates) {
+      const stepDef = await prisma.workflowStep.findUnique({ where: { id: candidate.stepId } });
+      if (!stepDef) continue;
+
+      const conditions = stepDef.conditions as StepCondition[] | null;
+      const conditionsMet = evaluateConditions(conditions, meta);
+
+      if (!conditionsMet) {
+        // Skip this step
+        await prisma.workflowStepInstance.update({
+          where: { id: candidate.id },
+          data: { status: 'SKIPPED', skipReason: 'Step conditions not met', completedAt: new Date() },
+        });
+        continue;
+      }
+
+      // Resolve approvers and activate
+      const resolverConfig = stepDef.approverResolver as ApproverResolverConfig;
+      const resolvedApprovers = await resolveApprovers(resolverConfig, initiatorId, meta);
+
+      await prisma.workflowStepInstance.update({
+        where: { id: candidate.id },
+        data: {
+          status: 'ACTIVE',
+          resolvedApprovers,
+          requiredApprovals: stepDef.minApprovals,
+          activatedAt: new Date(),
+        },
+      });
+
+      await prisma.workflowInstance.update({
+        where: { id: instanceId },
+        data: { currentStepId: candidate.id },
+      });
+
+      return; // activated a step — done
+    }
+
+    // No more eligible steps — workflow complete
+    await prisma.workflowInstance.update({
+      where: { id: instanceId },
+      data: { status: 'APPROVED', currentStepId: null, completedAt: new Date() },
+    });
+
+    const instance = await prisma.workflowInstance.findUnique({ where: { id: instanceId } });
+    await systemEventService.log({
+      eventType: 'WORKFLOW_COMPLETED',
+      eventCategory: 'BUSINESS',
+      severity: 'INFO',
+      entityType: instance?.entityType,
+      entityId: instance?.entityId,
+      summary: `Workflow instance ${instanceId} completed (all steps approved)`,
+      details: { instanceId },
+    });
+  }
+
+  /** Apply the onRejectBehavior of a rejected step. */
+  private async _applyRejectBehavior(
+    instance: {
+      id: string;
+      entityType: string;
+      entityId: string;
+      initiatedById: string;
+      metadata: unknown;
+      definition: { steps: { id: string; sequence: number }[] };
+    },
+    rejectedStepInstance: { id: string; sequence: number; stepId: string },
+    behavior: string,
+    rejectorId: string,
+    meta: Record<string, unknown>,
+  ) {
+    const instanceId = instance.id;
+
+    await systemEventService.log({
+      eventType: 'WORKFLOW_STEP_REJECTED',
+      eventCategory: 'BUSINESS',
+      severity: 'WARNING',
+      userId: rejectorId,
+      entityType: instance.entityType,
+      entityId: instance.entityId,
+      summary: `Step ${rejectedStepInstance.sequence} rejected (behavior: ${behavior}) in workflow ${instanceId}`,
+      details: { instanceId, stepInstanceId: rejectedStepInstance.id, behavior },
+    });
+
+    if (behavior === 'TERMINATE') {
+      await prisma.workflowInstance.update({
+        where: { id: instanceId },
+        data: { status: 'REJECTED', currentStepId: null, completedAt: new Date() },
+      });
+      return;
+    }
+
+    if (behavior === 'RETURN_PREVIOUS') {
+      // Find the most recent non-skipped approved step before the rejected one
+      const allSteps = await prisma.workflowStepInstance.findMany({
+        where: { instanceId },
+        orderBy: { sequence: 'asc' },
+      });
+      const previousApproved = allSteps
+        .filter(si => si.sequence < rejectedStepInstance.sequence && si.status === 'APPROVED')
+        .sort((a, b) => b.sequence - a.sequence)[0];
+
+      if (!previousApproved) {
+        // No previous step — treat as RESTART
+        await this._restartWorkflow(instance, meta);
+        return;
+      }
+
+      // Reactivate previous step
+      const stepDef = await prisma.workflowStep.findUnique({ where: { id: previousApproved.stepId } });
+      if (!stepDef) return;
+      const resolverConfig = stepDef.approverResolver as ApproverResolverConfig;
+      const resolvedApprovers = await resolveApprovers(resolverConfig, instance.initiatedById, meta);
+
+      await prisma.workflowStepInstance.update({
+        where: { id: previousApproved.id },
+        data: {
+          status: 'ACTIVE',
+          resolvedApprovers,
+          receivedApprovals: 0,
+          activatedAt: new Date(),
+          completedAt: null,
+        },
+      });
+      await prisma.workflowInstance.update({
+        where: { id: instanceId },
+        data: { currentStepId: previousApproved.id },
+      });
+      return;
+    }
+
+    if (behavior === 'RESTART') {
+      await this._restartWorkflow(instance, meta);
+    }
+  }
+
+  /** Reset all step instances and activate step 1 fresh. */
+  private async _restartWorkflow(
+    instance: {
+      id: string;
+      entityType: string;
+      entityId: string;
+      initiatedById: string;
+      definition: { steps: { id: string; sequence: number }[] };
+    },
+    meta: Record<string, unknown>,
+  ) {
+    const instanceId = instance.id;
+
+    // Reset all step instances to PENDING
+    await prisma.workflowStepInstance.updateMany({
+      where: { instanceId },
+      data: { status: 'PENDING', receivedApprovals: 0, resolvedApprovers: undefined, activatedAt: null, completedAt: null, skipReason: null },
+    });
+
+    const stepInstances = await prisma.workflowStepInstance.findMany({
+      where: { instanceId },
+      orderBy: { sequence: 'asc' },
+    });
+
+    await systemEventService.log({
+      eventType: 'WORKFLOW_RESTARTED',
+      eventCategory: 'BUSINESS',
+      severity: 'WARNING',
+      entityType: instance.entityType,
+      entityId: instance.entityId,
+      summary: `Workflow instance ${instanceId} restarted from step 1`,
+      details: { instanceId },
+    });
+
+    await this._activateNextStep(instanceId, instance.initiatedById, meta, stepInstances, null);
+  }
+}
+
+export const workflowService = new WorkflowService();

--- a/src/lib/startup-migrations.ts
+++ b/src/lib/startup-migrations.ts
@@ -97,6 +97,9 @@ const STARTUP_MIGRATIONS = [
 
   // ── Payroll entitlements: annual leave allowance, ticket, visa (20.1.0) ──
   'add_payroll_entitlements.sql',
+
+  // ── Workflow Engine (21.0.0) ──────────────────────────────────────────────
+  'add_workflow_engine.sql',
 ];
 
 /**

--- a/src/types/system-events.ts
+++ b/src/types/system-events.ts
@@ -326,6 +326,16 @@ export type OpsAgentEventType =
   | 'OPS_AGENT_TASK_CREATED'
   | 'OPS_AGENT_ESCALATION_TRIGGERED';
 
+// Workflow Engine Events (21.0.0)
+export type WorkflowEventType =
+  | 'WORKFLOW_STARTED'
+  | 'WORKFLOW_STEP_APPROVED'
+  | 'WORKFLOW_STEP_REJECTED'
+  | 'WORKFLOW_COMPLETED'
+  | 'WORKFLOW_CANCELLED'
+  | 'WORKFLOW_RESTARTED'
+  | 'WORKFLOW_DECISION_DELEGATED';
+
 // Combined Event Type
 export type EventType =
   | AuthEventType
@@ -344,7 +354,8 @@ export type EventType =
   | RiskEventType
   | KnowledgeEventType
   | ExportEventType
-  | OpsAgentEventType;
+  | OpsAgentEventType
+  | WorkflowEventType;
 
 // ============================================================================
 // SEVERITY LEVELS


### PR DESCRIPTION
Introduces a reusable multi-step, multi-approver workflow engine for use
by IMS, Procurement, HR, and any future module that needs approval flows.

Schema: WorkflowDefinition (versioned blueprint), WorkflowStep (ordered
steps with approver resolver + SLA + conditions), WorkflowInstance (per-
entity running flow), WorkflowStepInstance (step snapshot with resolved
approvers), WorkflowApproval (individual decisions).

Service (workflow.service.ts): startWorkflow, recordDecision (APPROVE /
REJECT / DELEGATE / COMMENT), cancelWorkflow, getWorkflowStatus,
getPendingApprovalsForUser. Full state machine — automatic step
advancement, conditional step skipping, RETURN_PREVIOUS / RESTART /
TERMINATE reject behaviors.

Six approver resolver types: ROLE, PBAC_PERMISSION, DEPARTMENT_HEAD,
MANAGER_OF_INITIATOR, FIXED_USER, AMOUNT_BAND. Safe condition evaluator
(no eval) supporting eq/ne/gt/gte/lt/lte/in/nin/contains operators.

API routes under /api/workflow/: definitions CRUD, start, instances,
decide, cancel, my-approvals, entity status. Six new PBAC permissions.

UI: ApprovalInbox (embeddable inbox with SLA badge, approve/reject/
delegate/comment), WorkflowTimeline (color-coded step progression).
Admin page at /workflow/definitions. My Approvals page at
/workflow/my-approvals. Workflow sidebar section added.

All state transitions logged via SystemEventService.

https://claude.ai/code/session_013A7g4KRNFVWSncyuiXzt6n