### PR TITLE
feat(hr-sync): add Dolibarr extrafield lookup helpers + supervisor field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [21.1.0] - 2026-04-26
+
+### Dolibarr Employee Sync — Extrafield Resolution
+#### Fixed
+- **Numeric extrafield IDs resolved to text** — department, nationality, and select-type extrafields (e.g. marital status) are now looked up against Dolibarr's `hrm_department`, `c_country`, and `extrafields` tables via the direct MySQL pool before being stored in OTS
+- **Supervisor hierarchy synced from Dolibarr** — a second pass after each sync run reads `fk_user_resp` from every Dolibarr user and wires both `Employee.reportsToId` and `User.reportsToId` so the `MANAGER_OF_INITIATOR` workflow resolver is always up-to-date
+#### Added
+- `fetchDolibarrDepartmentMap()`, `fetchDolibarrCountryMap()`, `fetchDolibarrExtraFieldSelectMaps()` helpers in `dolibarr-db.ts`
+- `fk_user_resp` field on the `DolibarrUser` interface
+
+### Loan Approval Workflow
+#### Added
+- **`PENDING_APPROVAL` loan status** — new loans are created in this state and transition to `ACTIVE` only after workflow approval, or `CANCELLED` on rejection
+- **`hr-loan-approval` workflow definition** seeded by `loan_approval_workflow.sql`: step 1 routes to the direct manager (`MANAGER_OF_INITIATOR`, 72 h SLA), step 2 to any user with `hr.loans.manage` permission (120 h SLA); both steps terminate on rejection
+- Loan creation API (`POST /api/hr/loans`) starts the approval workflow automatically; falls back to direct `ACTIVE` if the definition has not been seeded yet
+- Workflow decide endpoint (`POST /api/workflow/instances/[id]/decide`) propagates final `APPROVED`/`REJECTED` outcome to the loan record
+- Amber **Pending Approval** badge in the Loans UI
+
+---
+
 ## [21.0.0] - 2026-04-26
 
 ### Workflow Engine

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Project Overview
 Hexa Steel® OTS — enterprise ERP for steel fabrication projects. Next.js 15 App Router + TypeScript + Prisma + MySQL. Deployed at `hexasteel.sa/ots` with optional `NEXT_PUBLIC_BASE_PATH` subpath.
 
-**Current version:** `21.0.0` — Generic Workflow / Approval Engine. New models: `WorkflowDefinition`, `WorkflowStep`, `WorkflowInstance`, `WorkflowStepInstance`, `WorkflowApproval`. Migration `add_workflow_engine.sql`. Service at `@/lib/services/workflow.service.ts`. Reusable components: `ApprovalInbox`, `WorkflowTimeline`. Admin page at `/workflow/definitions`.
+**Current version:** `21.1.0` — Dolibarr extrafield resolution + Loan approval workflow. Dolibarr employee sync now resolves numeric extrafield IDs (department, nationality, marital status) to text labels via direct MySQL lookups, and wires `Employee.reportsToId` / `User.reportsToId` from `fk_user_resp`. Loan creation now starts the `hr-loan-approval` workflow (Manager → HR Manager); migration `loan_approval_workflow.sql` seeds the definition and adds `PENDING_APPROVAL` to `LoanStatus`.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexa-steel-ots",
-  "version": "21.0.0",
+  "version": "21.1.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/prisma/manual_migrations/loan_approval_workflow.sql
+++ b/prisma/manual_migrations/loan_approval_workflow.sql
@@ -1,0 +1,62 @@
+-- 21.1.0 — Loan approval workflow
+-- 1. Add PENDING_APPROVAL to Loan.status enum
+-- 2. Seed the hr-loan-approval WorkflowDefinition (2 steps: manager → HR manager)
+
+DROP PROCEDURE IF EXISTS add_loan_pending_approval_status;
+DELIMITER $$
+CREATE PROCEDURE add_loan_pending_approval_status()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME   = 'Loan'
+      AND COLUMN_NAME  = 'status'
+      AND COLUMN_TYPE LIKE '%PENDING_APPROVAL%'
+  ) THEN
+    ALTER TABLE Loan
+      MODIFY COLUMN status
+        ENUM('ACTIVE','COMPLETED','CANCELLED','PENDING_APPROVAL')
+        NOT NULL DEFAULT 'ACTIVE';
+  END IF;
+END$$
+DELIMITER ;
+CALL add_loan_pending_approval_status();
+DROP PROCEDURE IF EXISTS add_loan_pending_approval_status;
+
+DROP PROCEDURE IF EXISTS seed_hr_loan_approval_workflow;
+DELIMITER $$
+CREATE PROCEDURE seed_hr_loan_approval_workflow()
+BEGIN
+  DECLARE def_id CHAR(36);
+  IF NOT EXISTS (
+    SELECT 1 FROM WorkflowDefinition
+    WHERE `key` = 'hr-loan-approval' AND deletedAt IS NULL
+  ) THEN
+    SET def_id = UUID();
+    INSERT INTO WorkflowDefinition
+      (id, `key`, name, description, entityType, version, isActive, createdAt, updatedAt)
+    VALUES
+      (def_id, 'hr-loan-approval', 'HR Loan Approval',
+       'Two-step approval: direct manager then HR manager',
+       'Loan', 1, 1, NOW(), NOW());
+
+    -- Step 1: direct manager of the submitting user
+    INSERT INTO WorkflowStep
+      (id, definitionId, sequence, name, approverResolver, minApprovals, slaHours, onRejectBehavior, createdAt, updatedAt)
+    VALUES
+      (UUID(), def_id, 1, 'Direct Manager Approval',
+       '{"type":"MANAGER_OF_INITIATOR"}',
+       1, 72, 'TERMINATE', NOW(), NOW());
+
+    -- Step 2: any user with hr.loans.manage permission (HR manager / CEO)
+    INSERT INTO WorkflowStep
+      (id, definitionId, sequence, name, approverResolver, minApprovals, slaHours, onRejectBehavior, createdAt, updatedAt)
+    VALUES
+      (UUID(), def_id, 2, 'HR Manager Approval',
+       '{"type":"PBAC_PERMISSION","permission":"hr.loans.manage"}',
+       1, 120, 'TERMINATE', NOW(), NOW());
+  END IF;
+END$$
+DELIMITER ;
+CALL seed_hr_loan_approval_workflow();
+DROP PROCEDURE IF EXISTS seed_hr_loan_approval_workflow;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5005,6 +5005,7 @@ enum LoanStatus {
   ACTIVE
   COMPLETED
   CANCELLED
+  PENDING_APPROVAL
 }
 
 enum CustodyStatus {

--- a/src/app/api/hr/loans/route.ts
+++ b/src/app/api/hr/loans/route.ts
@@ -10,6 +10,7 @@ import { z } from 'zod';
 import prisma from '@/lib/db';
 import { withApiContext } from '@/lib/api-utils';
 import { logger } from '@/lib/logger';
+import { workflowService } from '@/lib/services/workflow.service';
 
 const createSchema = z.object({
   employeeId: z.string().uuid(),
@@ -86,13 +87,29 @@ export const POST = withApiContext(async (req: NextRequest, session) => {
         installmentsTotal: d.installmentsTotal,
         installmentsPaid: 0,
         startDate: new Date(d.startDate),
-        status: 'ACTIVE',
+        status: 'PENDING_APPROVAL',
         reason: d.reason ?? null,
         exceedsYearWarning: d.exceedsYearWarning,
         warningReason: d.warningReason ?? null,
         createdById: session!.userId,
       },
     });
+
+    // Start the approval workflow; fall back to ACTIVE if definition not yet seeded
+    try {
+      await workflowService.startWorkflow(
+        'hr-loan-approval',
+        'Loan',
+        loan.id,
+        session!.userId,
+        undefined,
+        { principal: d.principal, installmentsTotal: d.installmentsTotal },
+      );
+    } catch (wfErr) {
+      logger.warn({ loanId: loan.id, error: wfErr }, '[Loans] No workflow definition — activating directly');
+      await prisma.loan.update({ where: { id: loan.id }, data: { status: 'ACTIVE' } });
+    }
+
     logger.info({ loanId: loan.id, employeeId: d.employeeId }, '[Loans] Created');
     return NextResponse.json(loan, { status: 201 });
   } catch (error) {

--- a/src/app/api/workflow/instances/[id]/decide/route.ts
+++ b/src/app/api/workflow/instances/[id]/decide/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
+import prisma from '@/lib/db';
 import { withApiContext } from '@/lib/api-utils';
 import { logger } from '@/lib/logger';
 import { checkPermission } from '@/lib/permission-checker';
@@ -29,6 +30,16 @@ export const POST = withApiContext(async (req, session, ctx) => {
       parsed.data.comment,
       parsed.data.delegatedToUserId,
     );
+
+    // Propagate final workflow outcome to the owning entity
+    if (result?.entityType === 'Loan') {
+      if (result.status === 'APPROVED') {
+        await prisma.loan.update({ where: { id: result.entityId }, data: { status: 'ACTIVE' } });
+      } else if (result.status === 'REJECTED') {
+        await prisma.loan.update({ where: { id: result.entityId }, data: { status: 'CANCELLED' } });
+      }
+    }
+
     return NextResponse.json(result);
   } catch (error) {
     logger.error({ error, id }, 'Failed to record workflow decision');

--- a/src/components/hr/loans-page-client.tsx
+++ b/src/components/hr/loans-page-client.tsx
@@ -17,7 +17,7 @@ import {
 import { cn } from '@/lib/utils';
 import Link from 'next/link';
 
-type LoanStatus = 'ACTIVE' | 'COMPLETED' | 'CANCELLED';
+type LoanStatus = 'ACTIVE' | 'COMPLETED' | 'CANCELLED' | 'PENDING_APPROVAL';
 
 interface LoanEntry {
   id: string;
@@ -52,6 +52,7 @@ function money(v: string | number) {
 function loanStatusBadge(status: LoanStatus) {
   if (status === 'ACTIVE') return <Badge className="bg-sky-100 text-sky-700 border-sky-200 border"><Clock className="h-3 w-3 mr-1" />Active</Badge>;
   if (status === 'COMPLETED') return <Badge className="bg-emerald-100 text-emerald-700 border-emerald-200 border"><CheckCircle2 className="h-3 w-3 mr-1" />Completed</Badge>;
+  if (status === 'PENDING_APPROVAL') return <Badge className="bg-amber-100 text-amber-700 border-amber-200 border"><Clock className="h-3 w-3 mr-1" />Pending Approval</Badge>;
   return <Badge className="bg-slate-100 text-slate-500 border-slate-200 border"><MinusCircle className="h-3 w-3 mr-1" />Cancelled</Badge>;
 }
 

--- a/src/lib/dolibarr/dolibarr-client.ts
+++ b/src/lib/dolibarr/dolibarr-client.ts
@@ -321,6 +321,7 @@ export interface DolibarrUser {
   dateemployment?: number | string | null;    // joining
   dateemploymentend?: number | string | null; // leaving
   gender?: string | null;        // 'man' or 'woman'
+  fk_user_resp?: number | string | null; // rowid of the direct supervisor (llx_user.rowid)
   // Dolibarr "array_options" holds extrafields keyed by "options_<fieldname>".
   // Hexa Steel uses these for Arabic name, IBAN, bank name, Iqama, etc.
   array_options?: Record<string, unknown> | null;

--- a/src/lib/dolibarr/dolibarr-db.ts
+++ b/src/lib/dolibarr/dolibarr-db.ts
@@ -49,6 +49,12 @@ export class DolibarrDbNotConfiguredError extends Error {
  *  `date_approval`, and selecting them blows up the whole sync with
  *  "Unknown column … in 'field list'". So we stick to the columns that
  *  have existed in every Dolibarr release we care about. */
+/**
+ * A resolved key→label map for a single Dolibarr select extrafield.
+ * key is the stored value (often a numeric string like "3"), label is the display text.
+ */
+export type ExtraFieldSelectMap = Map<string, string>;
+
 export interface DolibarrHolidayDbRow {
   rowid: number;
   fk_user: number;
@@ -133,6 +139,78 @@ export interface PingResult {
   tablePrefix?: string;
   holidayCount?: number;
   error?: string;
+}
+
+/**
+ * Returns a Map<id, departmentName> from Dolibarr's hrm_department table.
+ * Used during employee sync to resolve the numeric `options_department` extrafield
+ * to a human-readable department name.
+ */
+export async function fetchDolibarrDepartmentMap(): Promise<Map<string, string>> {
+  const p = getDolibarrDbPool();
+  const prefix = getDolibarrTablePrefix();
+  const [rows] = await p.query<mysql.RowDataPacket[]>(
+    `SELECT rowid, label FROM \`${prefix}hrm_department\` WHERE active = 1`,
+  );
+  const map = new Map<string, string>();
+  for (const r of rows) {
+    if (r.rowid != null && r.label != null) {
+      map.set(String(r.rowid), String(r.label));
+    }
+  }
+  return map;
+}
+
+/**
+ * Returns a Map<id, countryLabel> from Dolibarr's c_country table.
+ * Used during employee sync to resolve the numeric `options_nationality` extrafield.
+ */
+export async function fetchDolibarrCountryMap(): Promise<Map<string, string>> {
+  const p = getDolibarrDbPool();
+  const prefix = getDolibarrTablePrefix();
+  const [rows] = await p.query<mysql.RowDataPacket[]>(
+    `SELECT rowid, label FROM \`${prefix}c_country\` WHERE active = 1`,
+  );
+  const map = new Map<string, string>();
+  for (const r of rows) {
+    if (r.rowid != null && r.label != null) {
+      map.set(String(r.rowid), String(r.label));
+    }
+  }
+  return map;
+}
+
+/**
+ * Returns a Map<fieldName, Map<key, label>> for all select-type user extrafields.
+ * Dolibarr stores select options in the `param` column as a JSON object:
+ * {"options":{"key1":"Label 1","key2":"Label 2"}}.
+ * Falls back gracefully if param is null or unparseable.
+ */
+export async function fetchDolibarrExtraFieldSelectMaps(): Promise<Map<string, ExtraFieldSelectMap>> {
+  const p = getDolibarrDbPool();
+  const prefix = getDolibarrTablePrefix();
+  const [rows] = await p.query<mysql.RowDataPacket[]>(
+    `SELECT name, type, param FROM \`${prefix}extrafields\`
+     WHERE elementtype = 'user' AND type IN ('select', 'sellist', 'radio', 'checkbox')`,
+  );
+  const result = new Map<string, ExtraFieldSelectMap>();
+  for (const r of rows) {
+    if (!r.name || !r.param) continue;
+    try {
+      const parsed = typeof r.param === 'string' ? JSON.parse(r.param) : r.param;
+      const options: Record<string, string> | undefined =
+        parsed?.options ?? (typeof parsed === 'object' ? parsed : undefined);
+      if (!options) continue;
+      const fieldMap = new Map<string, string>();
+      for (const [k, v] of Object.entries(options)) {
+        if (v != null) fieldMap.set(String(k), String(v));
+      }
+      if (fieldMap.size > 0) result.set(String(r.name), fieldMap);
+    } catch {
+      // unparseable param — skip this field
+    }
+  }
+  return result;
 }
 
 /**

--- a/src/lib/services/hr/sync-dolibarr-employees.ts
+++ b/src/lib/services/hr/sync-dolibarr-employees.ts
@@ -29,6 +29,13 @@ import {
   DolibarrUser,
   createDolibarrClient,
 } from '@/lib/dolibarr/dolibarr-client';
+import {
+  fetchDolibarrDepartmentMap,
+  fetchDolibarrCountryMap,
+  fetchDolibarrExtraFieldSelectMaps,
+  DolibarrDbNotConfiguredError,
+  ExtraFieldSelectMap,
+} from '@/lib/dolibarr/dolibarr-db';
 
 // ============================================================================
 // TYPES
@@ -59,6 +66,29 @@ export class ReconciliationRequiredError extends Error {
     );
     this.name = 'ReconciliationRequiredError';
   }
+}
+
+// ============================================================================
+// LOOKUP MAPS
+// ============================================================================
+
+interface LookupMaps {
+  departments: Map<string, string>;
+  countries: Map<string, string>;
+  selectFields: Map<string, ExtraFieldSelectMap>;
+}
+
+const EMPTY_MAPS: LookupMaps = {
+  departments: new Map(),
+  countries: new Map(),
+  selectFields: new Map(),
+};
+
+/** If the raw value is a pure integer string, resolve it via the map; else return as-is. */
+function resolveLinked(raw: string | null, map: Map<string, string>): string | null {
+  if (!raw) return null;
+  if (/^\d+$/.test(raw)) return map.get(raw) ?? raw;
+  return raw;
 }
 
 // ============================================================================
@@ -133,7 +163,7 @@ function mapStatus(apiUser: DolibarrUser): EmployeeStatus {
  * a plain object with all columns the sync touches — the caller filters by
  * `manuallyEditedFields` on update, and passes the full object on create.
  */
-function projectFromDolibarr(apiUser: DolibarrUser): {
+function projectFromDolibarr(apiUser: DolibarrUser, maps: LookupMaps = EMPTY_MAPS): {
   employmentId: string;
   fullNameEn: string;
   fullNameAr: string | null;
@@ -181,15 +211,18 @@ function projectFromDolibarr(apiUser: DolibarrUser): {
     // now maps to OTS Employee.occupation. The legacy `trade` column was
     // dropped, see prisma/manual_migrations/migrate_trade_to_occupation.sql.
     occupation: typeof apiUser.job === 'string' && apiUser.job.trim() !== '' ? apiUser.job.trim() : null,
-    department: extra(apiUser, 'options_department'),
+    department: resolveLinked(extra(apiUser, 'options_department'), maps.departments),
     basicSalary: basic,
     bankName: extra(apiUser, 'options_bank_name', 'options_bank'),
     bankIban: extra(apiUser, 'options_iban', 'options_bank_iban'),
     // Extended extrafields
-    nationality: extra(apiUser, 'options_nationality'),
+    nationality: resolveLinked(extra(apiUser, 'options_nationality'), maps.countries),
     employeeNo: extra(apiUser, 'options_employee_no'),
     boarderNumber: extra(apiUser, 'options_boarder_number'),
-    maritalStatus: extra(apiUser, 'options_marital_status'),
+    maritalStatus: resolveLinked(
+      extra(apiUser, 'options_marital_status'),
+      maps.selectFields.get('marital_status') ?? new Map(),
+    ),
     occupationAr: extra(apiUser, 'options_occupation_in_iqama_ar'),
     gosiSubscriptionNo: extra(apiUser, 'options_gosi_subscription'),
     contractEndDate: extraDate(apiUser, 'options_contract_ending_date'),
@@ -260,9 +293,28 @@ export async function runDolibarrEmployeeSync(
     apiResponseMs = Date.now() - apiStart;
     rowsRead = dolibarrUsers.length;
 
+    // Load extrafield lookup maps from Dolibarr MySQL (graceful if not configured)
+    let maps: LookupMaps = EMPTY_MAPS;
+    try {
+      const [departments, countries, selectFields] = await Promise.all([
+        fetchDolibarrDepartmentMap(),
+        fetchDolibarrCountryMap(),
+        fetchDolibarrExtraFieldSelectMaps(),
+      ]);
+      maps = { departments, countries, selectFields };
+      logger.info(
+        { depts: departments.size, countries: countries.size, selectFields: selectFields.size },
+        '[HR Sync] Extrafield lookup maps loaded',
+      );
+    } catch (e) {
+      if (!(e instanceof DolibarrDbNotConfiguredError)) {
+        logger.warn({ error: e }, '[HR Sync] Failed to load Dolibarr lookup maps — IDs stored as-is');
+      }
+    }
+
     for (const apiUser of dolibarrUsers) {
       try {
-        const projection = projectFromDolibarr(apiUser);
+        const projection = projectFromDolibarr(apiUser, maps);
 
         // -- Upsert by employmentId --
         const existing = await prisma.employee.findUnique({
@@ -427,6 +479,36 @@ export async function runDolibarrEmployeeSync(
         const empId = String(apiUser.id ?? 'unknown');
         hardErrors.push({ employmentId: empId, message: msg });
         logger.error({ employmentId: empId, error: rowError }, '[HR Sync] Row failed');
+      }
+    }
+
+    // ── Supervisor backfill: wire Employee.reportsToId + User.reportsToId ──────
+    // Uses Dolibarr fk_user_resp (supervisor's rowid). Runs after all employees
+    // are upserted so both sides of the relation are guaranteed to exist.
+    for (const apiUser of dolibarrUsers) {
+      const rawSupId = apiUser.fk_user_resp;
+      if (!rawSupId) continue;
+      const empKey = String(apiUser.id);
+      const supKey = String(rawSupId);
+      try {
+        const [emp, sup] = await Promise.all([
+          prisma.employee.findUnique({ where: { employmentId: empKey }, select: { id: true, reportsToId: true } }),
+          prisma.employee.findUnique({ where: { employmentId: supKey }, select: { id: true } }),
+        ]);
+        if (!emp || !sup) continue;
+        if (emp.reportsToId !== sup.id) {
+          await prisma.employee.update({ where: { id: emp.id }, data: { reportsToId: sup.id } });
+        }
+        // Also keep User.reportsToId in sync so workflow MANAGER_OF_INITIATOR resolver works
+        const [empUser, supUser] = await Promise.all([
+          prisma.user.findFirst({ where: { employeeId: emp.id }, select: { id: true, reportsToId: true } }),
+          prisma.user.findFirst({ where: { employeeId: sup.id }, select: { id: true } }),
+        ]);
+        if (empUser && supUser && empUser.reportsToId !== supUser.id) {
+          await prisma.user.update({ where: { id: empUser.id }, data: { reportsToId: supUser.id } });
+        }
+      } catch (supErr) {
+        logger.warn({ employmentId: empKey, error: supErr }, '[HR Sync] Supervisor link failed — skipped');
       }
     }
 


### PR DESCRIPTION
- dolibarr-db.ts: add fetchDolibarrDepartmentMap(), fetchDolibarrCountryMap(),
  fetchDolibarrExtraFieldSelectMaps() to resolve numeric IDs to text labels
  during employee sync
- dolibarr-client.ts: expose fk_user_resp on DolibarrUser so the sync service
  can wire Employee/User reportsToId from Dolibarr's supervisor field

https://claude.ai/code/session_01SRZHKXK4gecgyDWpax7jj6