### PR TITLE
feat(ims): add IMS module foundation — schema, migrations, permissions, navigation, document APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [22.0.0] - 2026-04-27
+
+### IMS — Integrated Management System Module
+
+#### Added
+- **IMS module** — full Integrated Management System covering ISO 9001:2015, ISO 14001:2015, and ISO 45001:2018 standards
+- **Document Control** — document registry with versioned revisions, controlled distribution, acknowledgement tracking, and document categories (QM, POL, SOP, PLN, WI, FRM, EXT, REC) with Arabic names
+- **Document Change Requests (DCR)** — full lifecycle management from draft through review, approval, and implementation with auto-numbered DCR codes
+- **Clause Matrix** — interactive coverage map across all three ISO standards; toggle document-to-clause mappings with Excel export via XLSX
+- **Review Calendar** — monthly timeline of upcoming document reviews grouped by month with overdue highlighting
+- **Risk Register** — full risk and opportunity register with 5×5 likelihood × severity scoring; supports RISK and OPPORTUNITY types
+- **Risk Assessments** — versioned assessment records per risk with inherent and residual rating calculation
+- **Risk Treatments** — treatment action tracking (mitigate, transfer, accept, eliminate, exploit, share, enhance) with responsible person, target dates, effectiveness ratings
+- **Hazard Identification** — OHS hazard log linked to risks with control measures and hierarchy of controls
+- **Risk Matrix** — interactive 5×5 heat map colour-coded by risk rating with filterable ISO standard views and drill-down cell detail
+- **Treatments Tracker** — cross-register treatment view with overdue detection, status filtering, and effectiveness summary
+- **IMS Dashboard** — aggregated KPIs across documents, risks, DCRs, and upcoming reviews
+- **Workflow definitions** — `IMS_REVISION_APPROVAL` (3-step: DC → Manager → CEO) and `IMS_CHANGE_REQUEST` (2-step: DC → Manager) seeded into the workflow engine
+- **ISO clause seed data** — all clauses §4–10 for ISO 9001, ISO 14001, and ISO 45001 seeded with proper parent-child hierarchy
+- **Sidebar navigation** — IMS section added with 8 navigation items (Dashboard, Documents, DCR, Clause Matrix, Review Calendar, Risk Register, Risk Matrix, Treatments)
+- **RBAC permissions** — 15 IMS permissions added across Admin, CEO, Manager, Engineer, and Document Controller roles
+- **Prisma schema** — 12 new models: `ImsCategory`, `ImsDocument`, `ImsRevision`, `ImsDistribution`, `ImsDistributionRecipient`, `ImsChangeRequest`, `ImsClause`, `ImsClauseMapping`, `ImsRisk`, `ImsRiskAssessment`, `ImsRiskTreatment`, `ImsHazardIdentification`
+
+#### Changed
+- Version bumped to **22.0.0**
+
+---
+
 ## [21.3.0] - 2026-04-27
 
 ### Business Development & Workflow UX Improvements

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexa-steel-ots",
-  "version": "21.3.0",
+  "version": "22.0.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/prisma/manual_migrations/add_ims_module.sql
+++ b/prisma/manual_migrations/add_ims_module.sql
@@ -1,0 +1,443 @@
+-- 22.0.0 — IMS (Integrated Management System) Module
+-- Document Control + Risk & Opportunity Register
+-- ISO 9001:2015 / ISO 14001:2015 / ISO 45001:2018
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- ImsCategory
+-- ──────────────────────────────────────────────────────────────────────────────
+DROP PROCEDURE IF EXISTS create_ims_category;
+DELIMITER $$
+CREATE PROCEDURE create_ims_category()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'ImsCategory'
+  ) THEN
+    CREATE TABLE ImsCategory (
+      id          CHAR(36)     NOT NULL PRIMARY KEY,
+      code        VARCHAR(10)  NOT NULL UNIQUE,
+      name        VARCHAR(100) NOT NULL,
+      nameAr      VARCHAR(100),
+      level       INT          NOT NULL DEFAULT 1,
+      description TEXT,
+      isActive    TINYINT(1)   NOT NULL DEFAULT 1,
+      createdAt   DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+      updatedAt   DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+      INDEX idx_ims_cat_code (code),
+      INDEX idx_ims_cat_active (isActive)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+  END IF;
+END$$
+DELIMITER ;
+CALL create_ims_category();
+DROP PROCEDURE IF EXISTS create_ims_category;
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- ImsDocument
+-- ──────────────────────────────────────────────────────────────────────────────
+DROP PROCEDURE IF EXISTS create_ims_document;
+DELIMITER $$
+CREATE PROCEDURE create_ims_document()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'ImsDocument'
+  ) THEN
+    CREATE TABLE ImsDocument (
+      id                  CHAR(36)     NOT NULL PRIMARY KEY,
+      documentNumber      VARCHAR(50)  NOT NULL UNIQUE,
+      title               VARCHAR(255) NOT NULL,
+      titleAr             VARCHAR(255),
+      categoryId          CHAR(36)     NOT NULL,
+      departmentId        CHAR(36),
+      status              VARCHAR(30)  NOT NULL DEFAULT 'DRAFT',
+      currentVersion      VARCHAR(20)  NOT NULL DEFAULT '1.0',
+      ownerId             CHAR(36),
+      reviewerId          CHAR(36),
+      applicableStandards JSON,
+      scope               TEXT,
+      purpose             TEXT,
+      site                VARCHAR(100),
+      confidentiality     VARCHAR(20)  NOT NULL DEFAULT 'INTERNAL',
+      reviewFrequencyDays INT          NOT NULL DEFAULT 365,
+      lastReviewDate      DATETIME(3),
+      nextReviewDate      DATETIME(3),
+      fileUrl             VARCHAR(512),
+      issuedAt            DATETIME(3),
+      deletedAt           DATETIME(3),
+      deletedById         CHAR(36),
+      createdAt           DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+      updatedAt           DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+      createdById         CHAR(36),
+      updatedById         CHAR(36),
+      INDEX idx_ims_doc_status       (status),
+      INDEX idx_ims_doc_category     (categoryId),
+      INDEX idx_ims_doc_department   (departmentId),
+      INDEX idx_ims_doc_owner        (ownerId),
+      INDEX idx_ims_doc_next_review  (nextReviewDate),
+      INDEX idx_ims_doc_deleted      (deletedAt),
+      CONSTRAINT fk_ims_doc_category   FOREIGN KEY (categoryId)   REFERENCES ImsCategory(id),
+      CONSTRAINT fk_ims_doc_dept       FOREIGN KEY (departmentId) REFERENCES Department(id),
+      CONSTRAINT fk_ims_doc_owner      FOREIGN KEY (ownerId)      REFERENCES User(id),
+      CONSTRAINT fk_ims_doc_reviewer   FOREIGN KEY (reviewerId)   REFERENCES User(id)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+  END IF;
+END$$
+DELIMITER ;
+CALL create_ims_document();
+DROP PROCEDURE IF EXISTS create_ims_document;
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- ImsRevision
+-- ──────────────────────────────────────────────────────────────────────────────
+DROP PROCEDURE IF EXISTS create_ims_revision;
+DELIMITER $$
+CREATE PROCEDURE create_ims_revision()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'ImsRevision'
+  ) THEN
+    CREATE TABLE ImsRevision (
+      id                 CHAR(36)     NOT NULL PRIMARY KEY,
+      documentId         CHAR(36)     NOT NULL,
+      version            VARCHAR(20)  NOT NULL,
+      changeDescription  TEXT,
+      changeType         VARCHAR(20)  NOT NULL DEFAULT 'MINOR',
+      status             VARCHAR(30)  NOT NULL DEFAULT 'DRAFT',
+      fileUrl            VARCHAR(512),
+      preparedById       CHAR(36),
+      reviewedById       CHAR(36),
+      approvedById       CHAR(36),
+      effectiveDate      DATETIME(3),
+      workflowInstanceId CHAR(36),
+      createdAt          DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+      updatedAt          DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+      INDEX idx_ims_rev_doc    (documentId),
+      INDEX idx_ims_rev_status (status),
+      CONSTRAINT fk_ims_rev_doc      FOREIGN KEY (documentId)   REFERENCES ImsDocument(id) ON DELETE CASCADE,
+      CONSTRAINT fk_ims_rev_prepared FOREIGN KEY (preparedById) REFERENCES User(id),
+      CONSTRAINT fk_ims_rev_reviewed FOREIGN KEY (reviewedById) REFERENCES User(id),
+      CONSTRAINT fk_ims_rev_approved FOREIGN KEY (approvedById) REFERENCES User(id)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+  END IF;
+END$$
+DELIMITER ;
+CALL create_ims_revision();
+DROP PROCEDURE IF EXISTS create_ims_revision;
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- ImsDistribution
+-- ──────────────────────────────────────────────────────────────────────────────
+DROP PROCEDURE IF EXISTS create_ims_distribution;
+DELIMITER $$
+CREATE PROCEDURE create_ims_distribution()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'ImsDistribution'
+  ) THEN
+    CREATE TABLE ImsDistribution (
+      id         CHAR(36)    NOT NULL PRIMARY KEY,
+      documentId CHAR(36)    NOT NULL,
+      revisionId CHAR(36),
+      issuedAt   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+      issuedById CHAR(36),
+      notes      TEXT,
+      createdAt  DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+      updatedAt  DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+      INDEX idx_ims_dist_doc (documentId),
+      CONSTRAINT fk_ims_dist_doc FOREIGN KEY (documentId) REFERENCES ImsDocument(id) ON DELETE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+  END IF;
+END$$
+DELIMITER ;
+CALL create_ims_distribution();
+DROP PROCEDURE IF EXISTS create_ims_distribution;
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- ImsDistributionRecipient
+-- ──────────────────────────────────────────────────────────────────────────────
+DROP PROCEDURE IF EXISTS create_ims_dist_recipient;
+DELIMITER $$
+CREATE PROCEDURE create_ims_dist_recipient()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'ImsDistributionRecipient'
+  ) THEN
+    CREATE TABLE ImsDistributionRecipient (
+      id                CHAR(36)    NOT NULL PRIMARY KEY,
+      distributionId    CHAR(36)    NOT NULL,
+      userId            CHAR(36)    NOT NULL,
+      acknowledgedAt    DATETIME(3),
+      acknowledgeMethod VARCHAR(50),
+      createdAt         DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+      updatedAt         DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+      UNIQUE KEY uq_ims_dist_user (distributionId, userId),
+      INDEX idx_ims_dr_dist (distributionId),
+      INDEX idx_ims_dr_user (userId),
+      CONSTRAINT fk_ims_dr_dist FOREIGN KEY (distributionId) REFERENCES ImsDistribution(id) ON DELETE CASCADE,
+      CONSTRAINT fk_ims_dr_user FOREIGN KEY (userId)         REFERENCES User(id)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+  END IF;
+END$$
+DELIMITER ;
+CALL create_ims_dist_recipient();
+DROP PROCEDURE IF EXISTS create_ims_dist_recipient;
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- ImsChangeRequest (DCR)
+-- ──────────────────────────────────────────────────────────────────────────────
+DROP PROCEDURE IF EXISTS create_ims_change_request;
+DELIMITER $$
+CREATE PROCEDURE create_ims_change_request()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'ImsChangeRequest'
+  ) THEN
+    CREATE TABLE ImsChangeRequest (
+      id                 CHAR(36)     NOT NULL PRIMARY KEY,
+      dcrNumber          VARCHAR(50)  NOT NULL UNIQUE,
+      title              VARCHAR(255) NOT NULL,
+      description        TEXT,
+      reason             TEXT,
+      documentId         CHAR(36),
+      requestedById      CHAR(36)     NOT NULL,
+      status             VARCHAR(30)  NOT NULL DEFAULT 'SUBMITTED',
+      priority           VARCHAR(20)  NOT NULL DEFAULT 'MEDIUM',
+      workflowInstanceId CHAR(36),
+      deletedAt          DATETIME(3),
+      createdAt          DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+      updatedAt          DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+      INDEX idx_ims_dcr_status    (status),
+      INDEX idx_ims_dcr_doc       (documentId),
+      INDEX idx_ims_dcr_requester (requestedById),
+      INDEX idx_ims_dcr_deleted   (deletedAt),
+      CONSTRAINT fk_ims_dcr_doc       FOREIGN KEY (documentId)    REFERENCES ImsDocument(id),
+      CONSTRAINT fk_ims_dcr_requester FOREIGN KEY (requestedById) REFERENCES User(id)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+  END IF;
+END$$
+DELIMITER ;
+CALL create_ims_change_request();
+DROP PROCEDURE IF EXISTS create_ims_change_request;
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- ImsClause
+-- ──────────────────────────────────────────────────────────────────────────────
+DROP PROCEDURE IF EXISTS create_ims_clause;
+DELIMITER $$
+CREATE PROCEDURE create_ims_clause()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'ImsClause'
+  ) THEN
+    CREATE TABLE ImsClause (
+      id        CHAR(36)     NOT NULL PRIMARY KEY,
+      standard  VARCHAR(20)  NOT NULL,
+      clause    VARCHAR(20)  NOT NULL,
+      title     VARCHAR(255) NOT NULL,
+      titleAr   VARCHAR(255),
+      parentId  CHAR(36),
+      level     INT          NOT NULL DEFAULT 1,
+      isActive  TINYINT(1)   NOT NULL DEFAULT 1,
+      createdAt DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+      updatedAt DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+      UNIQUE KEY uq_ims_clause_std_num (standard, clause),
+      INDEX idx_ims_clause_standard (standard),
+      INDEX idx_ims_clause_parent   (parentId),
+      CONSTRAINT fk_ims_clause_parent FOREIGN KEY (parentId) REFERENCES ImsClause(id)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+  END IF;
+END$$
+DELIMITER ;
+CALL create_ims_clause();
+DROP PROCEDURE IF EXISTS create_ims_clause;
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- ImsClauseMapping
+-- ──────────────────────────────────────────────────────────────────────────────
+DROP PROCEDURE IF EXISTS create_ims_clause_mapping;
+DELIMITER $$
+CREATE PROCEDURE create_ims_clause_mapping()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'ImsClauseMapping'
+  ) THEN
+    CREATE TABLE ImsClauseMapping (
+      id         CHAR(36)    NOT NULL PRIMARY KEY,
+      clauseId   CHAR(36)    NOT NULL,
+      documentId CHAR(36)    NOT NULL,
+      notes      TEXT,
+      createdAt  DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+      updatedAt  DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+      UNIQUE KEY uq_ims_mapping (clauseId, documentId),
+      INDEX idx_ims_mapping_clause (clauseId),
+      INDEX idx_ims_mapping_doc    (documentId),
+      CONSTRAINT fk_ims_mapping_clause FOREIGN KEY (clauseId)   REFERENCES ImsClause(id)   ON DELETE CASCADE,
+      CONSTRAINT fk_ims_mapping_doc    FOREIGN KEY (documentId) REFERENCES ImsDocument(id) ON DELETE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+  END IF;
+END$$
+DELIMITER ;
+CALL create_ims_clause_mapping();
+DROP PROCEDURE IF EXISTS create_ims_clause_mapping;
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- ImsRisk
+-- ──────────────────────────────────────────────────────────────────────────────
+DROP PROCEDURE IF EXISTS create_ims_risk;
+DELIMITER $$
+CREATE PROCEDURE create_ims_risk()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'ImsRisk'
+  ) THEN
+    CREATE TABLE ImsRisk (
+      id                  CHAR(36)     NOT NULL PRIMARY KEY,
+      riskNumber          VARCHAR(50)  NOT NULL UNIQUE,
+      type                VARCHAR(20)  NOT NULL DEFAULT 'RISK',
+      title               VARCHAR(255) NOT NULL,
+      titleAr             VARCHAR(255),
+      description         TEXT,
+      source              VARCHAR(255),
+      applicableStandards JSON,
+      category            VARCHAR(50)  NOT NULL,
+      status              VARCHAR(30)  NOT NULL DEFAULT 'OPEN',
+      ownerId             CHAR(36),
+      departmentId        CHAR(36),
+      currentLikelihood   INT          NOT NULL DEFAULT 1,
+      currentSeverity     INT          NOT NULL DEFAULT 1,
+      currentRiskLevel    INT          NOT NULL DEFAULT 1,
+      currentRiskRating   VARCHAR(20)  NOT NULL DEFAULT 'LOW',
+      reviewFrequencyDays INT          NOT NULL DEFAULT 90,
+      nextReviewDate      DATETIME(3),
+      lastReviewDate      DATETIME(3),
+      deletedAt           DATETIME(3),
+      deletedById         CHAR(36),
+      createdAt           DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+      updatedAt           DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+      createdById         CHAR(36),
+      updatedById         CHAR(36),
+      INDEX idx_ims_risk_type       (type),
+      INDEX idx_ims_risk_status     (status),
+      INDEX idx_ims_risk_category   (category),
+      INDEX idx_ims_risk_rating     (currentRiskRating),
+      INDEX idx_ims_risk_owner      (ownerId),
+      INDEX idx_ims_risk_dept       (departmentId),
+      INDEX idx_ims_risk_review     (nextReviewDate),
+      INDEX idx_ims_risk_deleted    (deletedAt),
+      CONSTRAINT fk_ims_risk_owner  FOREIGN KEY (ownerId)      REFERENCES User(id),
+      CONSTRAINT fk_ims_risk_dept   FOREIGN KEY (departmentId) REFERENCES Department(id)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+  END IF;
+END$$
+DELIMITER ;
+CALL create_ims_risk();
+DROP PROCEDURE IF EXISTS create_ims_risk;
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- ImsRiskAssessment
+-- ──────────────────────────────────────────────────────────────────────────────
+DROP PROCEDURE IF EXISTS create_ims_risk_assessment;
+DELIMITER $$
+CREATE PROCEDURE create_ims_risk_assessment()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'ImsRiskAssessment'
+  ) THEN
+    CREATE TABLE ImsRiskAssessment (
+      id               CHAR(36)    NOT NULL PRIMARY KEY,
+      riskId           CHAR(36)    NOT NULL,
+      likelihood       INT         NOT NULL,
+      severity         INT         NOT NULL,
+      riskLevel        INT         NOT NULL,
+      riskRating       VARCHAR(20) NOT NULL,
+      assessmentType   VARCHAR(30) NOT NULL DEFAULT 'PERIODIC',
+      existingControls TEXT,
+      recommendations  TEXT,
+      assessedById     CHAR(36),
+      createdAt        DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+      updatedAt        DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+      INDEX idx_ims_ra_risk (riskId),
+      CONSTRAINT fk_ims_ra_risk     FOREIGN KEY (riskId)      REFERENCES ImsRisk(id) ON DELETE CASCADE,
+      CONSTRAINT fk_ims_ra_assessor FOREIGN KEY (assessedById) REFERENCES User(id)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+  END IF;
+END$$
+DELIMITER ;
+CALL create_ims_risk_assessment();
+DROP PROCEDURE IF EXISTS create_ims_risk_assessment;
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- ImsRiskTreatment
+-- ──────────────────────────────────────────────────────────────────────────────
+DROP PROCEDURE IF EXISTS create_ims_risk_treatment;
+DELIMITER $$
+CREATE PROCEDURE create_ims_risk_treatment()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'ImsRiskTreatment'
+  ) THEN
+    CREATE TABLE ImsRiskTreatment (
+      id            CHAR(36)    NOT NULL PRIMARY KEY,
+      riskId        CHAR(36)    NOT NULL,
+      treatmentType VARCHAR(30) NOT NULL,
+      description   TEXT,
+      responsibleId CHAR(36),
+      targetDate    DATETIME(3),
+      completedDate DATETIME(3),
+      status        VARCHAR(20) NOT NULL DEFAULT 'PLANNED',
+      effectiveness VARCHAR(20),
+      notes         TEXT,
+      createdAt     DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+      updatedAt     DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+      INDEX idx_ims_rt_risk        (riskId),
+      INDEX idx_ims_rt_status      (status),
+      INDEX idx_ims_rt_responsible (responsibleId),
+      CONSTRAINT fk_ims_rt_risk        FOREIGN KEY (riskId)        REFERENCES ImsRisk(id) ON DELETE CASCADE,
+      CONSTRAINT fk_ims_rt_responsible FOREIGN KEY (responsibleId) REFERENCES User(id)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+  END IF;
+END$$
+DELIMITER ;
+CALL create_ims_risk_treatment();
+DROP PROCEDURE IF EXISTS create_ims_risk_treatment;
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- ImsHazardIdentification
+-- ──────────────────────────────────────────────────────────────────────────────
+DROP PROCEDURE IF EXISTS create_ims_hazard;
+DELIMITER $$
+CREATE PROCEDURE create_ims_hazard()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'ImsHazardIdentification'
+  ) THEN
+    CREATE TABLE ImsHazardIdentification (
+      id                CHAR(36)     NOT NULL PRIMARY KEY,
+      riskId            CHAR(36)     NOT NULL,
+      hazardType        VARCHAR(30)  NOT NULL,
+      hazardDescription TEXT,
+      location          VARCHAR(255),
+      affectedPersonnel VARCHAR(255),
+      controlHierarchy  VARCHAR(30)  NOT NULL,
+      controlMeasures   TEXT,
+      createdAt         DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+      updatedAt         DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+      INDEX idx_ims_hazard_risk (riskId),
+      CONSTRAINT fk_ims_hazard_risk FOREIGN KEY (riskId) REFERENCES ImsRisk(id) ON DELETE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+  END IF;
+END$$
+DELIMITER ;
+CALL create_ims_hazard();
+DROP PROCEDURE IF EXISTS create_ims_hazard;

--- a/prisma/manual_migrations/seed_ims_data.sql
+++ b/prisma/manual_migrations/seed_ims_data.sql
@@ -1,0 +1,611 @@
+-- 22.0.0 — IMS Seed Data
+-- Section 1: Document Categories
+-- Section 2: ISO Clauses (9001, 14001, 45001)
+-- Section 3: Workflow Definitions
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- SECTION 1: Document Categories
+-- ──────────────────────────────────────────────────────────────────────────────
+DROP PROCEDURE IF EXISTS seed_ims_categories;
+DELIMITER $$
+CREATE PROCEDURE seed_ims_categories()
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM ImsCategory WHERE code = 'QM') THEN
+    INSERT INTO ImsCategory (id, code, name, nameAr, level, isActive, createdAt, updatedAt)
+    VALUES (UUID(), 'QM', 'Quality Manual', 'دليل الجودة', 1, 1, NOW(), NOW());
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsCategory WHERE code = 'POL') THEN
+    INSERT INTO ImsCategory (id, code, name, nameAr, level, isActive, createdAt, updatedAt)
+    VALUES (UUID(), 'POL', 'Policy', 'السياسة', 1, 1, NOW(), NOW());
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsCategory WHERE code = 'SOP') THEN
+    INSERT INTO ImsCategory (id, code, name, nameAr, level, isActive, createdAt, updatedAt)
+    VALUES (UUID(), 'SOP', 'Standard Operating Procedure', 'إجراء تشغيل موحد', 2, 1, NOW(), NOW());
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsCategory WHERE code = 'PLN') THEN
+    INSERT INTO ImsCategory (id, code, name, nameAr, level, isActive, createdAt, updatedAt)
+    VALUES (UUID(), 'PLN', 'Plan', 'خطة', 2, 1, NOW(), NOW());
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsCategory WHERE code = 'WI') THEN
+    INSERT INTO ImsCategory (id, code, name, nameAr, level, isActive, createdAt, updatedAt)
+    VALUES (UUID(), 'WI', 'Work Instruction', 'تعليمات عمل', 3, 1, NOW(), NOW());
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsCategory WHERE code = 'FRM') THEN
+    INSERT INTO ImsCategory (id, code, name, nameAr, level, isActive, createdAt, updatedAt)
+    VALUES (UUID(), 'FRM', 'Form', 'نموذج', 4, 1, NOW(), NOW());
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsCategory WHERE code = 'EXT') THEN
+    INSERT INTO ImsCategory (id, code, name, nameAr, level, isActive, createdAt, updatedAt)
+    VALUES (UUID(), 'EXT', 'External Document', 'وثيقة خارجية', 5, 1, NOW(), NOW());
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsCategory WHERE code = 'REC') THEN
+    INSERT INTO ImsCategory (id, code, name, nameAr, level, isActive, createdAt, updatedAt)
+    VALUES (UUID(), 'REC', 'Record', 'سجل', 6, 1, NOW(), NOW());
+  END IF;
+END$$
+DELIMITER ;
+CALL seed_ims_categories();
+DROP PROCEDURE IF EXISTS seed_ims_categories;
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- SECTION 2a: ISO 9001:2015 Clauses
+-- ──────────────────────────────────────────────────────────────────────────────
+DROP PROCEDURE IF EXISTS seed_iso9001_clauses;
+DELIMITER $$
+CREATE PROCEDURE seed_iso9001_clauses()
+BEGIN
+  DECLARE v4 CHAR(36); DECLARE v5 CHAR(36); DECLARE v6 CHAR(36);
+  DECLARE v7 CHAR(36); DECLARE v8 CHAR(36); DECLARE v9 CHAR(36); DECLARE v10 CHAR(36);
+  DECLARE v51 CHAR(36); DECLARE v52 CHAR(36); DECLARE v53 CHAR(36);
+  DECLARE v61 CHAR(36); DECLARE v62 CHAR(36);
+  DECLARE v71 CHAR(36); DECLARE v72 CHAR(36); DECLARE v73 CHAR(36); DECLARE v74 CHAR(36); DECLARE v75 CHAR(36);
+  DECLARE v81 CHAR(36); DECLARE v82 CHAR(36); DECLARE v83 CHAR(36); DECLARE v84 CHAR(36); DECLARE v85 CHAR(36);
+  DECLARE v91 CHAR(36); DECLARE v92 CHAR(36); DECLARE v93 CHAR(36);
+  DECLARE v101 CHAR(36); DECLARE v102 CHAR(36);
+
+  -- Clause 4
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='4') THEN
+    SET v4 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v4,'ISO_9001','4','Context of the organization',NULL,1,1,NOW(),NOW());
+  ELSE SELECT id INTO v4 FROM ImsClause WHERE standard='ISO_9001' AND clause='4'; END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='4.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','4.1','Understanding the organization and its context',v4,2,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='4.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','4.2','Understanding the needs and expectations of interested parties',v4,2,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='4.3') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','4.3','Determining the scope of the quality management system',v4,2,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='4.4') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','4.4','Quality management system and its processes',v4,2,1,NOW(),NOW()); END IF;
+
+  -- Clause 5
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='5') THEN
+    SET v5 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v5,'ISO_9001','5','Leadership',NULL,1,1,NOW(),NOW());
+  ELSE SELECT id INTO v5 FROM ImsClause WHERE standard='ISO_9001' AND clause='5'; END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='5.1') THEN
+    SET v51 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v51,'ISO_9001','5.1','Leadership and commitment',v5,2,1,NOW(),NOW());
+  ELSE SELECT id INTO v51 FROM ImsClause WHERE standard='ISO_9001' AND clause='5.1'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='5.1.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','5.1.1','General',v51,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='5.1.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','5.1.2','Customer focus',v51,3,1,NOW(),NOW()); END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='5.2') THEN
+    SET v52 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v52,'ISO_9001','5.2','Policy',v5,2,1,NOW(),NOW());
+  ELSE SELECT id INTO v52 FROM ImsClause WHERE standard='ISO_9001' AND clause='5.2'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='5.2.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','5.2.1','Establishing the quality policy',v52,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='5.2.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','5.2.2','Communicating the quality policy',v52,3,1,NOW(),NOW()); END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='5.3') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','5.3','Organizational roles, responsibilities and authorities',v5,2,1,NOW(),NOW()); END IF;
+
+  -- Clause 6
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='6') THEN
+    SET v6 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v6,'ISO_9001','6','Planning',NULL,1,1,NOW(),NOW());
+  ELSE SELECT id INTO v6 FROM ImsClause WHERE standard='ISO_9001' AND clause='6'; END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='6.1') THEN
+    SET v61 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v61,'ISO_9001','6.1','Actions to address risks and opportunities',v6,2,1,NOW(),NOW());
+  ELSE SELECT id INTO v61 FROM ImsClause WHERE standard='ISO_9001' AND clause='6.1'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='6.1.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','6.1.1','General',v61,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='6.1.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','6.1.2','Actions to address risks and opportunities',v61,3,1,NOW(),NOW()); END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='6.2') THEN
+    SET v62 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v62,'ISO_9001','6.2','Quality objectives and planning to achieve them',v6,2,1,NOW(),NOW());
+  ELSE SELECT id INTO v62 FROM ImsClause WHERE standard='ISO_9001' AND clause='6.2'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='6.2.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','6.2.1','Quality objectives',v62,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='6.2.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','6.2.2','Planning to achieve quality objectives',v62,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='6.3') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','6.3','Planning of changes',v6,2,1,NOW(),NOW()); END IF;
+
+  -- Clause 7
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='7') THEN
+    SET v7 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v7,'ISO_9001','7','Support',NULL,1,1,NOW(),NOW());
+  ELSE SELECT id INTO v7 FROM ImsClause WHERE standard='ISO_9001' AND clause='7'; END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='7.1') THEN
+    SET v71 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v71,'ISO_9001','7.1','Resources',v7,2,1,NOW(),NOW());
+  ELSE SELECT id INTO v71 FROM ImsClause WHERE standard='ISO_9001' AND clause='7.1'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='7.1.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','7.1.1','General',v71,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='7.1.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','7.1.2','People',v71,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='7.1.3') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','7.1.3','Infrastructure',v71,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='7.1.4') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','7.1.4','Environment for the operation of processes',v71,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='7.1.5') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','7.1.5','Monitoring and measuring resources',v71,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='7.1.6') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','7.1.6','Organizational knowledge',v71,3,1,NOW(),NOW()); END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='7.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','7.2','Competence',v7,2,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='7.3') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','7.3','Awareness',v7,2,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='7.4') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','7.4','Communication',v7,2,1,NOW(),NOW()); END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='7.5') THEN
+    SET v75 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v75,'ISO_9001','7.5','Documented information',v7,2,1,NOW(),NOW());
+  ELSE SELECT id INTO v75 FROM ImsClause WHERE standard='ISO_9001' AND clause='7.5'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='7.5.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','7.5.1','General',v75,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='7.5.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','7.5.2','Creating and updating',v75,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='7.5.3') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','7.5.3','Control of documented information',v75,3,1,NOW(),NOW()); END IF;
+
+  -- Clause 8
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='8') THEN
+    SET v8 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v8,'ISO_9001','8','Operation',NULL,1,1,NOW(),NOW());
+  ELSE SELECT id INTO v8 FROM ImsClause WHERE standard='ISO_9001' AND clause='8'; END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='8.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','8.1','Operational planning and control',v8,2,1,NOW(),NOW()); END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='8.2') THEN
+    SET v82 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v82,'ISO_9001','8.2','Requirements for products and services',v8,2,1,NOW(),NOW());
+  ELSE SELECT id INTO v82 FROM ImsClause WHERE standard='ISO_9001' AND clause='8.2'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='8.2.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','8.2.1','Customer communication',v82,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='8.2.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','8.2.2','Determining the requirements for products and services',v82,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='8.2.3') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','8.2.3','Review of the requirements',v82,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='8.2.4') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','8.2.4','Changes to requirements',v82,3,1,NOW(),NOW()); END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='8.3') THEN
+    SET v83 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v83,'ISO_9001','8.3','Design and development of products and services',v8,2,1,NOW(),NOW());
+  ELSE SELECT id INTO v83 FROM ImsClause WHERE standard='ISO_9001' AND clause='8.3'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='8.3.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','8.3.1','General',v83,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='8.3.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','8.3.2','Design and development planning',v83,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='8.3.3') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','8.3.3','Design and development inputs',v83,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='8.3.4') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','8.3.4','Design and development controls',v83,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='8.3.5') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','8.3.5','Design and development outputs',v83,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='8.3.6') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','8.3.6','Design and development changes',v83,3,1,NOW(),NOW()); END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='8.4') THEN
+    SET v84 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v84,'ISO_9001','8.4','Control of externally provided processes, products and services',v8,2,1,NOW(),NOW());
+  ELSE SELECT id INTO v84 FROM ImsClause WHERE standard='ISO_9001' AND clause='8.4'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='8.4.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','8.4.1','General',v84,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='8.4.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','8.4.2','Type and extent of control',v84,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='8.4.3') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','8.4.3','Information for external providers',v84,3,1,NOW(),NOW()); END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='8.5') THEN
+    SET v85 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v85,'ISO_9001','8.5','Production and service provision',v8,2,1,NOW(),NOW());
+  ELSE SELECT id INTO v85 FROM ImsClause WHERE standard='ISO_9001' AND clause='8.5'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='8.5.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','8.5.1','Control of production and service provision',v85,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='8.5.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','8.5.2','Identification and traceability',v85,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='8.5.3') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','8.5.3','Property belonging to customers or external providers',v85,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='8.5.4') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','8.5.4','Preservation',v85,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='8.5.5') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','8.5.5','Post-delivery activities',v85,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='8.5.6') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','8.5.6','Control of changes',v85,3,1,NOW(),NOW()); END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='8.6') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','8.6','Release of products and services',v8,2,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='8.7') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','8.7','Control of nonconforming outputs',v8,2,1,NOW(),NOW()); END IF;
+
+  -- Clause 9
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='9') THEN
+    SET v9 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v9,'ISO_9001','9','Performance evaluation',NULL,1,1,NOW(),NOW());
+  ELSE SELECT id INTO v9 FROM ImsClause WHERE standard='ISO_9001' AND clause='9'; END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='9.1') THEN
+    SET v91 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v91,'ISO_9001','9.1','Monitoring, measurement, analysis and evaluation',v9,2,1,NOW(),NOW());
+  ELSE SELECT id INTO v91 FROM ImsClause WHERE standard='ISO_9001' AND clause='9.1'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='9.1.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','9.1.1','General',v91,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='9.1.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','9.1.2','Customer satisfaction',v91,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='9.1.3') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','9.1.3','Analysis and evaluation',v91,3,1,NOW(),NOW()); END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='9.2') THEN
+    SET v92 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v92,'ISO_9001','9.2','Internal audit',v9,2,1,NOW(),NOW());
+  ELSE SELECT id INTO v92 FROM ImsClause WHERE standard='ISO_9001' AND clause='9.2'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='9.2.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','9.2.1','General',v92,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='9.2.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','9.2.2','Internal audit programme',v92,3,1,NOW(),NOW()); END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='9.3') THEN
+    SET v93 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v93,'ISO_9001','9.3','Management review',v9,2,1,NOW(),NOW());
+  ELSE SELECT id INTO v93 FROM ImsClause WHERE standard='ISO_9001' AND clause='9.3'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='9.3.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','9.3.1','General',v93,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='9.3.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','9.3.2','Management review inputs',v93,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='9.3.3') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','9.3.3','Management review outputs',v93,3,1,NOW(),NOW()); END IF;
+
+  -- Clause 10
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='10') THEN
+    SET v10 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v10,'ISO_9001','10','Improvement',NULL,1,1,NOW(),NOW());
+  ELSE SELECT id INTO v10 FROM ImsClause WHERE standard='ISO_9001' AND clause='10'; END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='10.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','10.1','General',v10,2,1,NOW(),NOW()); END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='10.2') THEN
+    SET v102 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v102,'ISO_9001','10.2','Nonconformity and corrective action',v10,2,1,NOW(),NOW());
+  ELSE SELECT id INTO v102 FROM ImsClause WHERE standard='ISO_9001' AND clause='10.2'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='10.2.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','10.2.1','Reaction to nonconformity',v102,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='10.2.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','10.2.2','Evaluation of need for corrective action',v102,3,1,NOW(),NOW()); END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_9001' AND clause='10.3') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_9001','10.3','Continual improvement',v10,2,1,NOW(),NOW()); END IF;
+END$$
+DELIMITER ;
+CALL seed_iso9001_clauses();
+DROP PROCEDURE IF EXISTS seed_iso9001_clauses;
+
+-- =============================================================================
+-- Section 2b: ISO 14001:2015 Clauses
+-- =============================================================================
+DROP PROCEDURE IF EXISTS seed_iso14001_clauses;
+DELIMITER $$
+CREATE PROCEDURE seed_iso14001_clauses()
+BEGIN
+  DECLARE v4 VARCHAR(36) DEFAULT NULL;
+  DECLARE v41 VARCHAR(36) DEFAULT NULL;
+  DECLARE v42 VARCHAR(36) DEFAULT NULL;
+  DECLARE v43 VARCHAR(36) DEFAULT NULL;
+  DECLARE v44 VARCHAR(36) DEFAULT NULL;
+  DECLARE v5 VARCHAR(36) DEFAULT NULL;
+  DECLARE v51 VARCHAR(36) DEFAULT NULL;
+  DECLARE v52 VARCHAR(36) DEFAULT NULL;
+  DECLARE v53 VARCHAR(36) DEFAULT NULL;
+  DECLARE v6 VARCHAR(36) DEFAULT NULL;
+  DECLARE v61 VARCHAR(36) DEFAULT NULL;
+  DECLARE v62 VARCHAR(36) DEFAULT NULL;
+  DECLARE v63 VARCHAR(36) DEFAULT NULL;
+  DECLARE v7 VARCHAR(36) DEFAULT NULL;
+  DECLARE v71 VARCHAR(36) DEFAULT NULL;
+  DECLARE v72 VARCHAR(36) DEFAULT NULL;
+  DECLARE v73 VARCHAR(36) DEFAULT NULL;
+  DECLARE v74 VARCHAR(36) DEFAULT NULL;
+  DECLARE v8 VARCHAR(36) DEFAULT NULL;
+  DECLARE v81 VARCHAR(36) DEFAULT NULL;
+  DECLARE v82 VARCHAR(36) DEFAULT NULL;
+  DECLARE v9 VARCHAR(36) DEFAULT NULL;
+  DECLARE v91 VARCHAR(36) DEFAULT NULL;
+  DECLARE v92 VARCHAR(36) DEFAULT NULL;
+  DECLARE v93 VARCHAR(36) DEFAULT NULL;
+  DECLARE v10 VARCHAR(36) DEFAULT NULL;
+  DECLARE v101 VARCHAR(36) DEFAULT NULL;
+  DECLARE v102 VARCHAR(36) DEFAULT NULL;
+
+  -- Clause 4
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='4') THEN
+    SET v4 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v4,'ISO_14001','4','Context of the organisation',NULL,1,1,NOW(),NOW());
+  ELSE SELECT id INTO v4 FROM ImsClause WHERE standard='ISO_14001' AND clause='4'; END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='4.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_14001','4.1','Understanding the organisation and its context',v4,2,1,NOW(),NOW()); END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='4.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_14001','4.2','Understanding the needs and expectations of interested parties',v4,2,1,NOW(),NOW()); END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='4.3') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_14001','4.3','Determining the scope of the EMS',v4,2,1,NOW(),NOW()); END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='4.4') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_14001','4.4','Environmental management system',v4,2,1,NOW(),NOW()); END IF;
+
+  -- Clause 5
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='5') THEN
+    SET v5 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v5,'ISO_14001','5','Leadership',NULL,1,1,NOW(),NOW());
+  ELSE SELECT id INTO v5 FROM ImsClause WHERE standard='ISO_14001' AND clause='5'; END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='5.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_14001','5.1','Leadership and commitment',v5,2,1,NOW(),NOW()); END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='5.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_14001','5.2','Environmental policy',v5,2,1,NOW(),NOW()); END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='5.3') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_14001','5.3','Organisational roles, responsibilities and authorities',v5,2,1,NOW(),NOW()); END IF;
+
+  -- Clause 6
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='6') THEN
+    SET v6 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v6,'ISO_14001','6','Planning',NULL,1,1,NOW(),NOW());
+  ELSE SELECT id INTO v6 FROM ImsClause WHERE standard='ISO_14001' AND clause='6'; END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='6.1') THEN
+    SET v61 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v61,'ISO_14001','6.1','Actions to address risks and opportunities',v6,2,1,NOW(),NOW());
+  ELSE SELECT id INTO v61 FROM ImsClause WHERE standard='ISO_14001' AND clause='6.1'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='6.1.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_14001','6.1.1','General',v61,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='6.1.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_14001','6.1.2','Environmental aspects',v61,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='6.1.3') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_14001','6.1.3','Compliance obligations',v61,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='6.1.4') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_14001','6.1.4','Planning action',v61,3,1,NOW(),NOW()); END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='6.2') THEN
+    SET v62 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v62,'ISO_14001','6.2','Environmental objectives and planning to achieve them',v6,2,1,NOW(),NOW());
+  ELSE SELECT id INTO v62 FROM ImsClause WHERE standard='ISO_14001' AND clause='6.2'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='6.2.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_14001','6.2.1','Establish environmental objectives',v62,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='6.2.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_14001','6.2.2','Planning actions to achieve objectives',v62,3,1,NOW(),NOW()); END IF;
+
+  -- Clause 7
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='7') THEN
+    SET v7 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v7,'ISO_14001','7','Support',NULL,1,1,NOW(),NOW());
+  ELSE SELECT id INTO v7 FROM ImsClause WHERE standard='ISO_14001' AND clause='7'; END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='7.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_14001','7.1','Resources',v7,2,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='7.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_14001','7.2','Competence',v7,2,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='7.3') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_14001','7.3','Awareness',v7,2,1,NOW(),NOW()); END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='7.4') THEN
+    SET v74 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v74,'ISO_14001','7.4','Communication',v7,2,1,NOW(),NOW());
+  ELSE SELECT id INTO v74 FROM ImsClause WHERE standard='ISO_14001' AND clause='7.4'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='7.4.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_14001','7.4.1','General',v74,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='7.4.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_14001','7.4.2','Internal communication',v74,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='7.4.3') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_14001','7.4.3','External communication',v74,3,1,NOW(),NOW()); END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='7.5') THEN
+    SET v72 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v72,'ISO_14001','7.5','Documented information',v7,2,1,NOW(),NOW());
+  ELSE SELECT id INTO v72 FROM ImsClause WHERE standard='ISO_14001' AND clause='7.5'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='7.5.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_14001','7.5.1','General',v72,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='7.5.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_14001','7.5.2','Creating and updating',v72,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='7.5.3') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_14001','7.5.3','Control of documented information',v72,3,1,NOW(),NOW()); END IF;
+
+  -- Clause 8
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='8') THEN
+    SET v8 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v8,'ISO_14001','8','Operation',NULL,1,1,NOW(),NOW());
+  ELSE SELECT id INTO v8 FROM ImsClause WHERE standard='ISO_14001' AND clause='8'; END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='8.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_14001','8.1','Operational planning and control',v8,2,1,NOW(),NOW()); END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='8.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_14001','8.2','Emergency preparedness and response',v8,2,1,NOW(),NOW()); END IF;
+
+  -- Clause 9
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='9') THEN
+    SET v9 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v9,'ISO_14001','9','Performance evaluation',NULL,1,1,NOW(),NOW());
+  ELSE SELECT id INTO v9 FROM ImsClause WHERE standard='ISO_14001' AND clause='9'; END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='9.1') THEN
+    SET v91 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v91,'ISO_14001','9.1','Monitoring, measurement, analysis and evaluation',v9,2,1,NOW(),NOW());
+  ELSE SELECT id INTO v91 FROM ImsClause WHERE standard='ISO_14001' AND clause='9.1'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='9.1.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_14001','9.1.1','General',v91,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='9.1.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_14001','9.1.2','Evaluation of compliance',v91,3,1,NOW(),NOW()); END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='9.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_14001','9.2','Internal audit',v9,2,1,NOW(),NOW()); END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='9.3') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_14001','9.3','Management review',v9,2,1,NOW(),NOW()); END IF;
+
+  -- Clause 10
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='10') THEN
+    SET v10 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v10,'ISO_14001','10','Improvement',NULL,1,1,NOW(),NOW());
+  ELSE SELECT id INTO v10 FROM ImsClause WHERE standard='ISO_14001' AND clause='10'; END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='10.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_14001','10.1','General',v10,2,1,NOW(),NOW()); END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='10.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_14001','10.2','Nonconformity and corrective action',v10,2,1,NOW(),NOW()); END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_14001' AND clause='10.3') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_14001','10.3','Continual improvement',v10,2,1,NOW(),NOW()); END IF;
+
+END$$
+DELIMITER ;
+CALL seed_iso14001_clauses();
+DROP PROCEDURE IF EXISTS seed_iso14001_clauses;
+
+-- =============================================================================
+-- Section 2c: ISO 45001:2018 Clauses
+-- =============================================================================
+DROP PROCEDURE IF EXISTS seed_iso45001_clauses;
+DELIMITER $$
+CREATE PROCEDURE seed_iso45001_clauses()
+BEGIN
+  DECLARE v4 VARCHAR(36) DEFAULT NULL;
+  DECLARE v5 VARCHAR(36) DEFAULT NULL;
+  DECLARE v51 VARCHAR(36) DEFAULT NULL;
+  DECLARE v52 VARCHAR(36) DEFAULT NULL;
+  DECLARE v6 VARCHAR(36) DEFAULT NULL;
+  DECLARE v61 VARCHAR(36) DEFAULT NULL;
+  DECLARE v62 VARCHAR(36) DEFAULT NULL;
+  DECLARE v7 VARCHAR(36) DEFAULT NULL;
+  DECLARE v74 VARCHAR(36) DEFAULT NULL;
+  DECLARE v75 VARCHAR(36) DEFAULT NULL;
+  DECLARE v8 VARCHAR(36) DEFAULT NULL;
+  DECLARE v81 VARCHAR(36) DEFAULT NULL;
+  DECLARE v82 VARCHAR(36) DEFAULT NULL;
+  DECLARE v83 VARCHAR(36) DEFAULT NULL;
+  DECLARE v9 VARCHAR(36) DEFAULT NULL;
+  DECLARE v91 VARCHAR(36) DEFAULT NULL;
+  DECLARE v92 VARCHAR(36) DEFAULT NULL;
+  DECLARE v93 VARCHAR(36) DEFAULT NULL;
+  DECLARE v10 VARCHAR(36) DEFAULT NULL;
+  DECLARE v102 VARCHAR(36) DEFAULT NULL;
+
+  -- Clause 4
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='4') THEN
+    SET v4 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v4,'ISO_45001','4','Context of the organisation',NULL,1,1,NOW(),NOW());
+  ELSE SELECT id INTO v4 FROM ImsClause WHERE standard='ISO_45001' AND clause='4'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='4.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','4.1','Understanding the organisation and its context',v4,2,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='4.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','4.2','Understanding needs and expectations of workers and other interested parties',v4,2,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='4.3') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','4.3','Determining the scope of the OH&S MS',v4,2,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='4.4') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','4.4','OH&S management system',v4,2,1,NOW(),NOW()); END IF;
+
+  -- Clause 5
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='5') THEN
+    SET v5 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v5,'ISO_45001','5','Leadership and worker participation',NULL,1,1,NOW(),NOW());
+  ELSE SELECT id INTO v5 FROM ImsClause WHERE standard='ISO_45001' AND clause='5'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='5.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','5.1','Leadership and commitment',v5,2,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='5.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','5.2','OH&S policy',v5,2,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='5.3') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','5.3','Organisational roles, responsibilities and authorities',v5,2,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='5.4') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','5.4','Consultation and participation of workers',v5,2,1,NOW(),NOW()); END IF;
+
+  -- Clause 6
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='6') THEN
+    SET v6 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v6,'ISO_45001','6','Planning',NULL,1,1,NOW(),NOW());
+  ELSE SELECT id INTO v6 FROM ImsClause WHERE standard='ISO_45001' AND clause='6'; END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='6.1') THEN
+    SET v61 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v61,'ISO_45001','6.1','Actions to address risks and opportunities',v6,2,1,NOW(),NOW());
+  ELSE SELECT id INTO v61 FROM ImsClause WHERE standard='ISO_45001' AND clause='6.1'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='6.1.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','6.1.1','General',v61,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='6.1.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','6.1.2','Hazard identification and assessment of risks and opportunities',v61,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='6.1.3') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','6.1.3','Determination of legal and other requirements',v61,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='6.1.4') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','6.1.4','Planning action',v61,3,1,NOW(),NOW()); END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='6.2') THEN
+    SET v62 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v62,'ISO_45001','6.2','OH&S objectives and planning to achieve them',v6,2,1,NOW(),NOW());
+  ELSE SELECT id INTO v62 FROM ImsClause WHERE standard='ISO_45001' AND clause='6.2'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='6.2.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','6.2.1','Establish OH&S objectives',v62,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='6.2.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','6.2.2','Planning actions to achieve objectives',v62,3,1,NOW(),NOW()); END IF;
+
+  -- Clause 7
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='7') THEN
+    SET v74 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v74,'ISO_45001','7','Support',NULL,1,1,NOW(),NOW());
+  ELSE SELECT id INTO v74 FROM ImsClause WHERE standard='ISO_45001' AND clause='7'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='7.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','7.1','Resources',v74,2,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='7.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','7.2','Competence',v74,2,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='7.3') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','7.3','Awareness',v74,2,1,NOW(),NOW()); END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='7.4') THEN
+    SET v75 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v75,'ISO_45001','7.4','Communication',v74,2,1,NOW(),NOW());
+  ELSE SELECT id INTO v75 FROM ImsClause WHERE standard='ISO_45001' AND clause='7.4'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='7.4.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','7.4.1','General',v75,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='7.4.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','7.4.2','Internal communication',v75,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='7.4.3') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','7.4.3','External communication',v75,3,1,NOW(),NOW()); END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='7.5') THEN
+    SET v7 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v7,'ISO_45001','7.5','Documented information',v74,2,1,NOW(),NOW());
+  ELSE SELECT id INTO v7 FROM ImsClause WHERE standard='ISO_45001' AND clause='7.5'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='7.5.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','7.5.1','General',v7,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='7.5.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','7.5.2','Creating and updating',v7,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='7.5.3') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','7.5.3','Control of documented information',v7,3,1,NOW(),NOW()); END IF;
+
+  -- Clause 8
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='8') THEN
+    SET v8 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v8,'ISO_45001','8','Operation',NULL,1,1,NOW(),NOW());
+  ELSE SELECT id INTO v8 FROM ImsClause WHERE standard='ISO_45001' AND clause='8'; END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='8.1') THEN
+    SET v81 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v81,'ISO_45001','8.1','Operational planning and control',v8,2,1,NOW(),NOW());
+  ELSE SELECT id INTO v81 FROM ImsClause WHERE standard='ISO_45001' AND clause='8.1'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='8.1.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','8.1.1','General',v81,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='8.1.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','8.1.2','Eliminating hazards and reducing OH&S risks',v81,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='8.1.3') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','8.1.3','Management of change',v81,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='8.1.4') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','8.1.4','Procurement',v81,3,1,NOW(),NOW()); END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='8.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','8.2','Emergency preparedness and response',v8,2,1,NOW(),NOW()); END IF;
+
+  -- Clause 9
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='9') THEN
+    SET v9 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v9,'ISO_45001','9','Performance evaluation',NULL,1,1,NOW(),NOW());
+  ELSE SELECT id INTO v9 FROM ImsClause WHERE standard='ISO_45001' AND clause='9'; END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='9.1') THEN
+    SET v91 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v91,'ISO_45001','9.1','Monitoring, measurement, analysis and performance evaluation',v9,2,1,NOW(),NOW());
+  ELSE SELECT id INTO v91 FROM ImsClause WHERE standard='ISO_45001' AND clause='9.1'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='9.1.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','9.1.1','General',v91,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='9.1.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','9.1.2','Evaluation of compliance',v91,3,1,NOW(),NOW()); END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='9.2') THEN
+    SET v92 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v92,'ISO_45001','9.2','Internal audit',v9,2,1,NOW(),NOW());
+  ELSE SELECT id INTO v92 FROM ImsClause WHERE standard='ISO_45001' AND clause='9.2'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='9.2.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','9.2.1','General',v92,3,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='9.2.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','9.2.2','Internal audit programme',v92,3,1,NOW(),NOW()); END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='9.3') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','9.3','Management review',v9,2,1,NOW(),NOW()); END IF;
+
+  -- Clause 10
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='10') THEN
+    SET v10 = UUID();
+    INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (v10,'ISO_45001','10','Improvement',NULL,1,1,NOW(),NOW());
+  ELSE SELECT id INTO v10 FROM ImsClause WHERE standard='ISO_45001' AND clause='10'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='10.1') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','10.1','General',v10,2,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='10.2') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','10.2','Incident, nonconformity and corrective action',v10,2,1,NOW(),NOW()); END IF;
+  IF NOT EXISTS (SELECT 1 FROM ImsClause WHERE standard='ISO_45001' AND clause='10.3') THEN INSERT INTO ImsClause (id,standard,clause,title,parentId,level,isActive,createdAt,updatedAt) VALUES (UUID(),'ISO_45001','10.3','Continual improvement',v10,2,1,NOW(),NOW()); END IF;
+
+END$$
+DELIMITER ;
+CALL seed_iso45001_clauses();
+DROP PROCEDURE IF EXISTS seed_iso45001_clauses;
+
+-- =============================================================================
+-- Section 3: Workflow Definitions
+-- =============================================================================
+DROP PROCEDURE IF EXISTS seed_ims_workflows;
+DELIMITER $$
+CREATE PROCEDURE seed_ims_workflows()
+BEGIN
+  DECLARE wf1 VARCHAR(36) DEFAULT NULL;
+  DECLARE wf2 VARCHAR(36) DEFAULT NULL;
+  DECLARE st1 VARCHAR(36) DEFAULT NULL;
+  DECLARE st2 VARCHAR(36) DEFAULT NULL;
+  DECLARE st3 VARCHAR(36) DEFAULT NULL;
+
+  -- IMS_REVISION_APPROVAL workflow
+  IF NOT EXISTS (SELECT 1 FROM WorkflowDefinition WHERE code='IMS_REVISION_APPROVAL') THEN
+    SET wf1 = UUID();
+    INSERT INTO WorkflowDefinition (id,code,name,description,isActive,createdAt,updatedAt)
+    VALUES (wf1,'IMS_REVISION_APPROVAL','IMS Document Revision Approval',
+      'Approval workflow for IMS document revisions — Preparer → Reviewer → Approver',
+      1,NOW(),NOW());
+
+    SET st1 = UUID();
+    INSERT INTO WorkflowStep (id,definitionId,stepOrder,name,description,approverRole,requiredApprovals,isParallel,isFinal,createdAt,updatedAt)
+    VALUES (st1,wf1,1,'Document Review','Document Controller or Technical SME reviews the revised document','DOCUMENT_CONTROLLER',1,0,0,NOW(),NOW());
+
+    SET st2 = UUID();
+    INSERT INTO WorkflowStep (id,definitionId,stepOrder,name,description,approverRole,requiredApprovals,isParallel,isFinal,createdAt,updatedAt)
+    VALUES (st2,wf1,2,'Management Approval','Department Manager or Management Representative approves the document','MANAGER',1,0,0,NOW(),NOW());
+
+    SET st3 = UUID();
+    INSERT INTO WorkflowStep (id,definitionId,stepOrder,name,description,approverRole,requiredApprovals,isParallel,isFinal,createdAt,updatedAt)
+    VALUES (st3,wf1,3,'Top Management Sign-off','CEO or designated top management provides final approval','CEO',1,0,1,NOW(),NOW());
+  END IF;
+
+  -- IMS_CHANGE_REQUEST workflow
+  IF NOT EXISTS (SELECT 1 FROM WorkflowDefinition WHERE code='IMS_CHANGE_REQUEST') THEN
+    SET wf2 = UUID();
+    INSERT INTO WorkflowDefinition (id,code,name,description,isActive,createdAt,updatedAt)
+    VALUES (wf2,'IMS_CHANGE_REQUEST','IMS Document Change Request',
+      'Review and approval workflow for IMS document change requests (DCR)',
+      1,NOW(),NOW());
+
+    SET st1 = UUID();
+    INSERT INTO WorkflowStep (id,definitionId,stepOrder,name,description,approverRole,requiredApprovals,isParallel,isFinal,createdAt,updatedAt)
+    VALUES (st1,wf2,1,'Change Impact Review','Document Controller assesses impact and feasibility of proposed change','DOCUMENT_CONTROLLER',1,0,0,NOW(),NOW());
+
+    SET st2 = UUID();
+    INSERT INTO WorkflowStep (id,definitionId,stepOrder,name,description,approverRole,requiredApprovals,isParallel,isFinal,createdAt,updatedAt)
+    VALUES (st2,wf2,2,'Manager Approval','Responsible manager reviews and approves the change request','MANAGER',1,0,1,NOW(),NOW());
+  END IF;
+END$$
+DELIMITER ;
+CALL seed_ims_workflows();
+DROP PROCEDURE IF EXISTS seed_ims_workflows;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -42,8 +42,10 @@ model Department {
   annualInitiatives AnnualInitiative[] @relation("AnnualInitiativeDepartment")
   weeklyIssues      WeeklyIssue[]      @relation("WeeklyIssueDept")
   circulationRecipients HrCirculationRecipient[] @relation("DepartmentCirculationRecipients")
-  createdAt         DateTime           @default(now())
-  updatedAt         DateTime           @updatedAt
+  imsDocuments          ImsDocument[]            @relation("ImsDepartmentDocuments")
+  imsRisks              ImsRisk[]                @relation("ImsRiskDepartment")
+  createdAt             DateTime                 @default(now())
+  updatedAt             DateTime                 @updatedAt
 }
 
 model HrSection {
@@ -339,6 +341,18 @@ model User {
   cancelledWorkflows  WorkflowInstance[] @relation("WorkflowCancelledBy")
   workflowApprovals   WorkflowApproval[] @relation("WorkflowApprovalUser")
   delegatedApprovals  WorkflowApproval[] @relation("WorkflowApprovalDelegatedTo")
+
+  // IMS back-relations (22.0.0)
+  ownedImsDocuments              ImsDocument[]              @relation("ImsDocumentOwner")
+  reviewedImsDocuments           ImsDocument[]              @relation("ImsDocumentReviewer")
+  preparedImsRevisions           ImsRevision[]              @relation("ImsRevisionPreparedBy")
+  reviewedImsRevisions           ImsRevision[]              @relation("ImsRevisionReviewedBy")
+  approvedImsRevisions           ImsRevision[]              @relation("ImsRevisionApprovedBy")
+  imsDistributionRecipients      ImsDistributionRecipient[] @relation("ImsDistributionRecipient")
+  imsChangeRequests              ImsChangeRequest[]         @relation("ImsChangeRequestBy")
+  ownedImsRisks                  ImsRisk[]                  @relation("ImsRiskOwner")
+  imsRiskAssessments             ImsRiskAssessment[]        @relation("ImsRiskAssessor")
+  imsRiskTreatments              ImsRiskTreatment[]         @relation("ImsRiskTreatmentResponsible")
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -6020,4 +6034,313 @@ model WorkflowApproval {
   @@index([stepInstanceId])
   @@index([userId])
   @@map("WorkflowApproval")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// IMS — Integrated Management System (22.0.0)
+// Document Control, Risk Register, ISO 9001/14001/45001
+// ─────────────────────────────────────────────────────────────────────────────
+
+model ImsCategory {
+  id          String  @id @default(uuid()) @db.Char(36)
+  code        String  @unique @db.VarChar(10)
+  name        String  @db.VarChar(100)
+  nameAr      String? @db.VarChar(100)
+  level       Int     @default(1)
+  description String? @db.Text
+  isActive    Boolean @default(true)
+
+  documents ImsDocument[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([code])
+  @@index([isActive])
+  @@map("ImsCategory")
+}
+
+model ImsDocument {
+  id                  String       @id @default(uuid()) @db.Char(36)
+  documentNumber      String       @unique @db.VarChar(50)
+  title               String       @db.VarChar(255)
+  titleAr             String?      @db.VarChar(255)
+  categoryId          String       @db.Char(36)
+  category            ImsCategory  @relation(fields: [categoryId], references: [id])
+  departmentId        String?      @db.Char(36)
+  department          Department?  @relation("ImsDepartmentDocuments", fields: [departmentId], references: [id])
+  status              String       @default("DRAFT") @db.VarChar(30)
+  currentVersion      String       @default("1.0") @db.VarChar(20)
+  ownerId             String?      @db.Char(36)
+  owner               User?        @relation("ImsDocumentOwner", fields: [ownerId], references: [id])
+  reviewerId          String?      @db.Char(36)
+  reviewer            User?        @relation("ImsDocumentReviewer", fields: [reviewerId], references: [id])
+  applicableStandards Json?
+  scope               String?      @db.Text
+  purpose             String?      @db.Text
+  site                String?      @db.VarChar(100)
+  confidentiality     String       @default("INTERNAL") @db.VarChar(20)
+  reviewFrequencyDays Int          @default(365)
+  lastReviewDate      DateTime?
+  nextReviewDate      DateTime?
+  fileUrl             String?      @db.VarChar(512)
+  issuedAt            DateTime?
+
+  revisions      ImsRevision[]
+  distributions  ImsDistribution[]
+  changeRequests ImsChangeRequest[]
+  clauseMappings ImsClauseMapping[]
+
+  deletedAt   DateTime?
+  deletedById String?   @db.Char(36)
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+  createdById String?   @db.Char(36)
+  updatedById String?   @db.Char(36)
+
+  @@index([status])
+  @@index([categoryId])
+  @@index([departmentId])
+  @@index([ownerId])
+  @@index([nextReviewDate])
+  @@index([deletedAt])
+  @@map("ImsDocument")
+}
+
+model ImsRevision {
+  id                String      @id @default(uuid()) @db.Char(36)
+  documentId        String      @db.Char(36)
+  document          ImsDocument @relation(fields: [documentId], references: [id], onDelete: Cascade)
+  version           String      @db.VarChar(20)
+  changeDescription String?     @db.Text
+  changeType        String      @default("MINOR") @db.VarChar(20)
+  status            String      @default("DRAFT") @db.VarChar(30)
+  fileUrl           String?     @db.VarChar(512)
+  preparedById      String?     @db.Char(36)
+  preparedBy        User?       @relation("ImsRevisionPreparedBy", fields: [preparedById], references: [id])
+  reviewedById      String?     @db.Char(36)
+  reviewedBy        User?       @relation("ImsRevisionReviewedBy", fields: [reviewedById], references: [id])
+  approvedById      String?     @db.Char(36)
+  approvedBy        User?       @relation("ImsRevisionApprovedBy", fields: [approvedById], references: [id])
+  effectiveDate     DateTime?
+  workflowInstanceId String?    @db.Char(36)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([documentId])
+  @@index([status])
+  @@map("ImsRevision")
+}
+
+model ImsDistribution {
+  id         String      @id @default(uuid()) @db.Char(36)
+  documentId String      @db.Char(36)
+  document   ImsDocument @relation(fields: [documentId], references: [id], onDelete: Cascade)
+  revisionId String?     @db.Char(36)
+  issuedAt   DateTime    @default(now())
+  issuedById String?     @db.Char(36)
+  notes      String?     @db.Text
+
+  recipients ImsDistributionRecipient[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([documentId])
+  @@map("ImsDistribution")
+}
+
+model ImsDistributionRecipient {
+  id                String          @id @default(uuid()) @db.Char(36)
+  distributionId    String          @db.Char(36)
+  distribution      ImsDistribution @relation(fields: [distributionId], references: [id], onDelete: Cascade)
+  userId            String          @db.Char(36)
+  user              User            @relation("ImsDistributionRecipient", fields: [userId], references: [id])
+  acknowledgedAt    DateTime?
+  acknowledgeMethod String?         @db.VarChar(50)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([distributionId, userId])
+  @@index([distributionId])
+  @@index([userId])
+  @@map("ImsDistributionRecipient")
+}
+
+model ImsChangeRequest {
+  id            String       @id @default(uuid()) @db.Char(36)
+  dcrNumber     String       @unique @db.VarChar(50)
+  title         String       @db.VarChar(255)
+  description   String?      @db.Text
+  reason        String?      @db.Text
+  documentId    String?      @db.Char(36)
+  document      ImsDocument? @relation(fields: [documentId], references: [id])
+  requestedById String       @db.Char(36)
+  requestedBy   User         @relation("ImsChangeRequestBy", fields: [requestedById], references: [id])
+  status        String       @default("SUBMITTED") @db.VarChar(30)
+  priority      String       @default("MEDIUM") @db.VarChar(20)
+  workflowInstanceId String? @db.Char(36)
+
+  deletedAt DateTime?
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+
+  @@index([status])
+  @@index([documentId])
+  @@index([requestedById])
+  @@index([deletedAt])
+  @@map("ImsChangeRequest")
+}
+
+model ImsClause {
+  id       String     @id @default(uuid()) @db.Char(36)
+  standard String     @db.VarChar(20)
+  clause   String     @db.VarChar(20)
+  title    String     @db.VarChar(255)
+  titleAr  String?    @db.VarChar(255)
+  parentId String?    @db.Char(36)
+  parent   ImsClause? @relation("ImsClauseParent", fields: [parentId], references: [id])
+  children ImsClause[] @relation("ImsClauseParent")
+  level    Int        @default(1)
+  isActive Boolean    @default(true)
+
+  mappings ImsClauseMapping[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([standard, clause])
+  @@index([standard])
+  @@index([parentId])
+  @@map("ImsClause")
+}
+
+model ImsClauseMapping {
+  id         String      @id @default(uuid()) @db.Char(36)
+  clauseId   String      @db.Char(36)
+  clause     ImsClause   @relation(fields: [clauseId], references: [id], onDelete: Cascade)
+  documentId String      @db.Char(36)
+  document   ImsDocument @relation(fields: [documentId], references: [id], onDelete: Cascade)
+  notes      String?     @db.Text
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([clauseId, documentId])
+  @@index([clauseId])
+  @@index([documentId])
+  @@map("ImsClauseMapping")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// IMS Risk & Opportunity Register (22.0.0) — ISO 9001/14001/45001 Clause 6.1
+// ─────────────────────────────────────────────────────────────────────────────
+
+model ImsRisk {
+  id                  String      @id @default(uuid()) @db.Char(36)
+  riskNumber          String      @unique @db.VarChar(50)
+  type                String      @default("RISK") @db.VarChar(20)
+  title               String      @db.VarChar(255)
+  titleAr             String?     @db.VarChar(255)
+  description         String?     @db.Text
+  source              String?     @db.VarChar(255)
+  applicableStandards Json?
+  category            String      @db.VarChar(50)
+  status              String      @default("OPEN") @db.VarChar(30)
+  ownerId             String?     @db.Char(36)
+  owner               User?       @relation("ImsRiskOwner", fields: [ownerId], references: [id])
+  departmentId        String?     @db.Char(36)
+  department          Department? @relation("ImsRiskDepartment", fields: [departmentId], references: [id])
+  currentLikelihood   Int         @default(1)
+  currentSeverity     Int         @default(1)
+  currentRiskLevel    Int         @default(1)
+  currentRiskRating   String      @default("LOW") @db.VarChar(20)
+  reviewFrequencyDays Int         @default(90)
+  nextReviewDate      DateTime?
+  lastReviewDate      DateTime?
+
+  assessments ImsRiskAssessment[]
+  treatments  ImsRiskTreatment[]
+  hazards     ImsHazardIdentification[]
+
+  deletedAt   DateTime?
+  deletedById String?   @db.Char(36)
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+  createdById String?   @db.Char(36)
+  updatedById String?   @db.Char(36)
+
+  @@index([type])
+  @@index([status])
+  @@index([category])
+  @@index([currentRiskRating])
+  @@index([ownerId])
+  @@index([departmentId])
+  @@index([nextReviewDate])
+  @@index([deletedAt])
+  @@map("ImsRisk")
+}
+
+model ImsRiskAssessment {
+  id               String  @id @default(uuid()) @db.Char(36)
+  riskId           String  @db.Char(36)
+  risk             ImsRisk @relation(fields: [riskId], references: [id], onDelete: Cascade)
+  likelihood       Int
+  severity         Int
+  riskLevel        Int
+  riskRating       String  @db.VarChar(20)
+  assessmentType   String  @default("PERIODIC") @db.VarChar(30)
+  existingControls String? @db.Text
+  recommendations  String? @db.Text
+  assessedById     String? @db.Char(36)
+  assessedBy       User?   @relation("ImsRiskAssessor", fields: [assessedById], references: [id])
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([riskId])
+  @@map("ImsRiskAssessment")
+}
+
+model ImsRiskTreatment {
+  id            String   @id @default(uuid()) @db.Char(36)
+  riskId        String   @db.Char(36)
+  risk          ImsRisk  @relation(fields: [riskId], references: [id], onDelete: Cascade)
+  treatmentType String   @db.VarChar(30)
+  description   String?  @db.Text
+  responsibleId String?  @db.Char(36)
+  responsible   User?    @relation("ImsRiskTreatmentResponsible", fields: [responsibleId], references: [id])
+  targetDate    DateTime?
+  completedDate DateTime?
+  status        String   @default("PLANNED") @db.VarChar(20)
+  effectiveness String?  @db.VarChar(20)
+  notes         String?  @db.Text
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([riskId])
+  @@index([status])
+  @@index([responsibleId])
+  @@map("ImsRiskTreatment")
+}
+
+model ImsHazardIdentification {
+  id                String  @id @default(uuid()) @db.Char(36)
+  riskId            String  @db.Char(36)
+  risk              ImsRisk @relation(fields: [riskId], references: [id], onDelete: Cascade)
+  hazardType        String  @db.VarChar(30)
+  hazardDescription String? @db.Text
+  location          String? @db.VarChar(255)
+  affectedPersonnel String? @db.VarChar(255)
+  controlHierarchy  String  @db.VarChar(30)
+  controlMeasures   String? @db.Text
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([riskId])
+  @@map("ImsHazardIdentification")
 }

--- a/src/app/api/ims/categories/route.ts
+++ b/src/app/api/ims/categories/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/db';
+import { logger } from '@/lib/logger';
+
+export async function GET() {
+  try {
+    const categories = await prisma.imsCategory.findMany({
+      where: { isActive: true },
+      select: {
+        id: true,
+        code: true,
+        name: true,
+        nameAr: true,
+        level: true,
+        description: true,
+        _count: { select: { documents: true } },
+      },
+      orderBy: [{ level: 'asc' }, { code: 'asc' }],
+    });
+
+    return NextResponse.json(categories);
+  } catch (error) {
+    logger.error({ error }, 'Failed to fetch IMS categories');
+    return NextResponse.json({ error: 'Failed to fetch categories' }, { status: 500 });
+  }
+}

--- a/src/app/api/ims/change-requests/[id]/route.ts
+++ b/src/app/api/ims/change-requests/[id]/route.ts
@@ -1,0 +1,153 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/db';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import { logger } from '@/lib/logger';
+import { systemEventService } from '@/services/system-events.service';
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id } = await params;
+
+    const changeRequest = await prisma.imsChangeRequest.findFirst({
+      where: { id, deletedAt: null },
+      include: {
+        document: { select: { id: true, documentNumber: true, title: true } },
+        requestedBy: { select: { id: true, name: true } },
+      },
+    });
+
+    if (!changeRequest) {
+      return NextResponse.json({ error: 'Change request not found' }, { status: 404 });
+    }
+
+    return NextResponse.json(changeRequest);
+  } catch (error) {
+    logger.error({ error }, 'Failed to fetch IMS change request');
+    return NextResponse.json({ error: 'Failed to fetch change request' }, { status: 500 });
+  }
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id } = await params;
+
+    const existing = await prisma.imsChangeRequest.findFirst({
+      where: { id, deletedAt: null },
+      select: { id: true, dcrNumber: true },
+    });
+
+    if (!existing) {
+      return NextResponse.json({ error: 'Change request not found' }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const { title, description, reason, status, priority, documentId, workflowInstanceId } = body;
+
+    const updateData: Record<string, unknown> = {};
+
+    if (title !== undefined) updateData.title = title;
+    if (description !== undefined) updateData.description = description;
+    if (reason !== undefined) updateData.reason = reason;
+    if (status !== undefined) updateData.status = status;
+    if (priority !== undefined) updateData.priority = priority;
+    if (documentId !== undefined) updateData.documentId = documentId;
+    if (workflowInstanceId !== undefined) updateData.workflowInstanceId = workflowInstanceId;
+
+    const changeRequest = await prisma.imsChangeRequest.update({
+      where: { id },
+      data: updateData,
+      include: {
+        document: { select: { id: true, documentNumber: true, title: true } },
+        requestedBy: { select: { id: true, name: true } },
+      },
+    });
+
+    systemEventService.log({
+      eventType: 'KC_ENTRY_UPDATED',
+      eventCategory: 'KNOWLEDGE',
+      userId: session.sub,
+      userName: session.name,
+      entityType: 'ImsChangeRequest',
+      entityId: changeRequest.id,
+      entityName: changeRequest.dcrNumber,
+      summary: `DCR ${changeRequest.dcrNumber} updated`,
+      details: { updatedFields: Object.keys(updateData) },
+    });
+
+    return NextResponse.json(changeRequest);
+  } catch (error) {
+    logger.error({ error }, 'Failed to update IMS change request');
+    return NextResponse.json({ error: 'Failed to update change request' }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id } = await params;
+
+    const existing = await prisma.imsChangeRequest.findFirst({
+      where: { id, deletedAt: null },
+      select: { id: true, dcrNumber: true, title: true },
+    });
+
+    if (!existing) {
+      return NextResponse.json({ error: 'Change request not found' }, { status: 404 });
+    }
+
+    await prisma.imsChangeRequest.update({
+      where: { id },
+      data: { deletedAt: new Date() },
+    });
+
+    systemEventService.log({
+      eventType: 'KC_ENTRY_DELETED',
+      eventCategory: 'KNOWLEDGE',
+      userId: session.sub,
+      userName: session.name,
+      entityType: 'ImsChangeRequest',
+      entityId: id,
+      entityName: existing.dcrNumber,
+      summary: `DCR ${existing.dcrNumber} deleted`,
+      details: { dcrNumber: existing.dcrNumber, title: existing.title },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    logger.error({ error }, 'Failed to delete IMS change request');
+    return NextResponse.json({ error: 'Failed to delete change request' }, { status: 500 });
+  }
+}

--- a/src/app/api/ims/change-requests/route.ts
+++ b/src/app/api/ims/change-requests/route.ts
@@ -1,0 +1,141 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/db';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import { logger } from '@/lib/logger';
+import { systemEventService } from '@/services/system-events.service';
+
+async function generateDcrNumber(): Promise<string> {
+  const year = new Date().getFullYear();
+  const yearStart = new Date(`${year}-01-01T00:00:00.000Z`);
+  const yearEnd = new Date(`${year + 1}-01-01T00:00:00.000Z`);
+
+  const count = await prisma.imsChangeRequest.count({
+    where: {
+      createdAt: { gte: yearStart, lt: yearEnd },
+    },
+  });
+
+  const sequence = (count + 1).toString().padStart(4, '0');
+  return `DCR-${year}-${sequence}`;
+}
+
+export async function GET(request: Request) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const status = searchParams.get('status');
+    const priority = searchParams.get('priority');
+    const documentId = searchParams.get('documentId');
+    const search = searchParams.get('search');
+
+    const where: Record<string, unknown> = { deletedAt: null };
+
+    if (status) where.status = status;
+    if (priority) where.priority = priority;
+    if (documentId) where.documentId = documentId;
+
+    if (search) {
+      where.OR = [
+        { title: { contains: search } },
+        { dcrNumber: { contains: search } },
+      ];
+    }
+
+    const changeRequests = await prisma.imsChangeRequest.findMany({
+      where,
+      select: {
+        id: true,
+        dcrNumber: true,
+        title: true,
+        description: true,
+        reason: true,
+        status: true,
+        priority: true,
+        workflowInstanceId: true,
+        createdAt: true,
+        updatedAt: true,
+        document: {
+          select: { id: true, documentNumber: true, title: true },
+        },
+        requestedBy: {
+          select: { id: true, name: true },
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    return NextResponse.json(changeRequests);
+  } catch (error) {
+    logger.error({ error }, 'Failed to fetch IMS change requests');
+    return NextResponse.json({ error: 'Failed to fetch change requests' }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const {
+      title,
+      description,
+      reason,
+      documentId,
+      priority,
+    } = body;
+
+    if (!title) {
+      return NextResponse.json({ error: 'Missing required field: title' }, { status: 400 });
+    }
+
+    const dcrNumber = await generateDcrNumber();
+
+    const changeRequest = await prisma.imsChangeRequest.create({
+      data: {
+        dcrNumber,
+        title,
+        description: description ?? null,
+        reason: reason ?? null,
+        documentId: documentId ?? null,
+        requestedById: session.sub,
+        priority: priority ?? 'MEDIUM',
+        status: 'SUBMITTED',
+      },
+      include: {
+        document: { select: { id: true, documentNumber: true, title: true } },
+        requestedBy: { select: { id: true, name: true } },
+      },
+    });
+
+    systemEventService.log({
+      eventType: 'KC_ENTRY_CREATED',
+      eventCategory: 'KNOWLEDGE',
+      userId: session.sub,
+      userName: session.name,
+      entityType: 'ImsChangeRequest',
+      entityId: changeRequest.id,
+      entityName: changeRequest.dcrNumber,
+      summary: `DCR ${changeRequest.dcrNumber} created: ${changeRequest.title}`,
+      details: { dcrNumber: changeRequest.dcrNumber, documentId, priority: changeRequest.priority },
+    });
+
+    return NextResponse.json(changeRequest, { status: 201 });
+  } catch (error) {
+    logger.error({ error }, 'Failed to create IMS change request');
+    return NextResponse.json({ error: 'Failed to create change request' }, { status: 500 });
+  }
+}

--- a/src/app/api/ims/clause-matrix/[documentId]/[clauseId]/route.ts
+++ b/src/app/api/ims/clause-matrix/[documentId]/[clauseId]/route.ts
@@ -1,0 +1,133 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/db';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import { logger } from '@/lib/logger';
+import { systemEventService } from '@/services/system-events.service';
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ documentId: string; clauseId: string }> }
+) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { documentId, clauseId } = await params;
+
+    const [document, clause] = await Promise.all([
+      prisma.imsDocument.findFirst({
+        where: { id: documentId, deletedAt: null },
+        select: { id: true, documentNumber: true },
+      }),
+      prisma.imsClause.findFirst({
+        where: { id: clauseId, isActive: true },
+        select: { id: true, standard: true, clause: true, title: true },
+      }),
+    ]);
+
+    if (!document) {
+      return NextResponse.json({ error: 'Document not found' }, { status: 404 });
+    }
+
+    if (!clause) {
+      return NextResponse.json({ error: 'Clause not found' }, { status: 404 });
+    }
+
+    const body = await request.json().catch(() => ({}));
+    const notes = (body as { notes?: string }).notes ?? null;
+
+    const mapping = await prisma.imsClauseMapping.create({
+      data: {
+        clauseId,
+        documentId,
+        notes,
+      },
+      include: {
+        clause: {
+          select: { id: true, standard: true, clause: true, title: true, level: true },
+        },
+        document: {
+          select: { id: true, documentNumber: true, title: true },
+        },
+      },
+    });
+
+    systemEventService.log({
+      eventType: 'KC_ENTRY_CREATED',
+      eventCategory: 'KNOWLEDGE',
+      userId: session.sub,
+      userName: session.name,
+      entityType: 'ImsClauseMapping',
+      entityId: mapping.id,
+      entityName: `${document.documentNumber} → ${clause.standard} ${clause.clause}`,
+      summary: `Clause mapping added: ${document.documentNumber} mapped to ${clause.standard} ${clause.clause}`,
+      details: { documentId, clauseId, standard: clause.standard, clause: clause.clause },
+    });
+
+    return NextResponse.json(mapping, { status: 201 });
+  } catch (error) {
+    const prismaError = error as { code?: string };
+    if (prismaError.code === 'P2002') {
+      return NextResponse.json({ error: 'Mapping already exists' }, { status: 409 });
+    }
+    logger.error({ error }, 'Failed to create IMS clause mapping');
+    return NextResponse.json({ error: 'Failed to create clause mapping' }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ documentId: string; clauseId: string }> }
+) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { documentId, clauseId } = await params;
+
+    const mapping = await prisma.imsClauseMapping.findFirst({
+      where: { documentId, clauseId },
+      select: {
+        id: true,
+        clause: { select: { standard: true, clause: true } },
+        document: { select: { documentNumber: true } },
+      },
+    });
+
+    if (!mapping) {
+      return NextResponse.json({ error: 'Clause mapping not found' }, { status: 404 });
+    }
+
+    await prisma.imsClauseMapping.delete({
+      where: { id: mapping.id },
+    });
+
+    systemEventService.log({
+      eventType: 'KC_ENTRY_DELETED',
+      eventCategory: 'KNOWLEDGE',
+      userId: session.sub,
+      userName: session.name,
+      entityType: 'ImsClauseMapping',
+      entityId: mapping.id,
+      entityName: `${mapping.document.documentNumber} → ${mapping.clause.standard} ${mapping.clause.clause}`,
+      summary: `Clause mapping removed: ${mapping.document.documentNumber} from ${mapping.clause.standard} ${mapping.clause.clause}`,
+      details: { documentId, clauseId },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    logger.error({ error }, 'Failed to delete IMS clause mapping');
+    return NextResponse.json({ error: 'Failed to delete clause mapping' }, { status: 500 });
+  }
+}

--- a/src/app/api/ims/clause-matrix/route.ts
+++ b/src/app/api/ims/clause-matrix/route.ts
@@ -1,0 +1,97 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/db';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import { logger } from '@/lib/logger';
+
+const STANDARDS = ['ISO_9001', 'ISO_14001', 'ISO_45001'] as const;
+
+export async function GET(request: Request) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const [allClauses, activeDocuments] = await Promise.all([
+      prisma.imsClause.findMany({
+        where: { isActive: true },
+        select: {
+          id: true,
+          standard: true,
+          clause: true,
+          title: true,
+          level: true,
+          parentId: true,
+        },
+        orderBy: [{ standard: 'asc' }, { clause: 'asc' }],
+      }),
+      prisma.imsDocument.findMany({
+        where: { deletedAt: null, status: { not: 'OBSOLETE' } },
+        select: {
+          id: true,
+          documentNumber: true,
+          title: true,
+          status: true,
+          clauseMappings: {
+            select: { clauseId: true },
+          },
+        },
+        orderBy: { documentNumber: 'asc' },
+      }),
+    ]);
+
+    // Group clauses by standard
+    const clausesByStandard: Record<string, typeof allClauses> = {};
+    for (const clause of allClauses) {
+      if (!clausesByStandard[clause.standard]) {
+        clausesByStandard[clause.standard] = [];
+      }
+      clausesByStandard[clause.standard].push(clause);
+    }
+
+    // Build documents with flat clauseId array
+    type ActiveDoc = (typeof activeDocuments)[number];
+    type ClauseRow = (typeof allClauses)[number];
+    const documents = activeDocuments.map((doc: ActiveDoc) => ({
+      id: doc.id,
+      documentNumber: doc.documentNumber,
+      title: doc.title,
+      status: doc.status,
+      clauseIds: doc.clauseMappings.map((m: { clauseId: string }) => m.clauseId),
+    }));
+
+    // Calculate coverage per standard
+    const coverage = STANDARDS.map((standard) => {
+      const standardClauses: ClauseRow[] = clausesByStandard[standard] ?? [];
+      const totalClauses = standardClauses.length;
+      const clauseIdSet = new Set(standardClauses.map((c: ClauseRow) => c.id));
+
+      const mappedClauseIds = new Set<string>();
+      for (const doc of documents) {
+        for (const clauseId of doc.clauseIds) {
+          if (clauseIdSet.has(clauseId)) {
+            mappedClauseIds.add(clauseId);
+          }
+        }
+      }
+
+      const mappedClauses = mappedClauseIds.size;
+      const percentage = totalClauses > 0 ? Math.round((mappedClauses / totalClauses) * 100) : 0;
+
+      return { standard, totalClauses, mappedClauses, percentage };
+    });
+
+    return NextResponse.json({
+      clauses: clausesByStandard,
+      documents,
+      coverage,
+    });
+  } catch (error) {
+    logger.error({ error }, 'Failed to fetch IMS clause matrix');
+    return NextResponse.json({ error: 'Failed to fetch clause matrix' }, { status: 500 });
+  }
+}

--- a/src/app/api/ims/clauses/route.ts
+++ b/src/app/api/ims/clauses/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/db';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import { logger } from '@/lib/logger';
+
+interface RawClause {
+  id: string;
+  standard: string;
+  clause: string;
+  title: string;
+  titleAr: string | null;
+  level: number;
+  isActive: boolean;
+  parentId: string | null;
+}
+
+interface ClauseNode extends RawClause {
+  children: ClauseNode[];
+}
+
+function buildHierarchy(clauses: ClauseNode[], parentId: string | null = null): ClauseNode[] {
+  return clauses
+    .filter((c: ClauseNode) => (c.parentId ?? null) === parentId)
+    .map((c: ClauseNode) => ({
+      ...c,
+      children: buildHierarchy(clauses, c.id),
+    }));
+}
+
+export async function GET(request: Request) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const standard = searchParams.get('standard');
+
+    const where: Record<string, unknown> = { isActive: true };
+    if (standard) where.standard = standard;
+
+    const rawClauses: RawClause[] = await prisma.imsClause.findMany({
+      where,
+      select: {
+        id: true,
+        standard: true,
+        clause: true,
+        title: true,
+        titleAr: true,
+        level: true,
+        isActive: true,
+        parentId: true,
+      },
+      orderBy: [{ standard: 'asc' }, { clause: 'asc' }],
+    });
+
+    const clausesWithChildren: ClauseNode[] = rawClauses.map((c: RawClause) => ({
+      ...c,
+      children: [],
+    }));
+
+    const hierarchy = buildHierarchy(clausesWithChildren);
+
+    return NextResponse.json(hierarchy);
+  } catch (error) {
+    logger.error({ error }, 'Failed to fetch IMS clauses');
+    return NextResponse.json({ error: 'Failed to fetch clauses' }, { status: 500 });
+  }
+}

--- a/src/app/api/ims/dashboard/route.ts
+++ b/src/app/api/ims/dashboard/route.ts
@@ -1,0 +1,141 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/db';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import { logger } from '@/lib/logger';
+
+const STANDARDS = ['ISO_9001', 'ISO_14001', 'ISO_45001'] as const;
+
+export async function GET(request: Request) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const now = new Date();
+
+    const [
+      totalDocuments,
+      byStatusRaw,
+      overdueReviews,
+      pendingDCRs,
+      unacknowledgedDistributions,
+      allClauses,
+      mappedClausesRaw,
+      recentActivity,
+    ] = await Promise.all([
+      // Total active documents
+      prisma.imsDocument.count({ where: { deletedAt: null } }),
+
+      // Count by status
+      prisma.imsDocument.groupBy({
+        by: ['status'],
+        where: { deletedAt: null },
+        _count: true,
+      }),
+
+      // Overdue reviews: APPROVED docs with nextReviewDate < now
+      prisma.imsDocument.count({
+        where: {
+          deletedAt: null,
+          status: 'APPROVED',
+          nextReviewDate: { lt: now },
+        },
+      }),
+
+      // Pending DCRs: SUBMITTED or UNDER_REVIEW
+      prisma.imsChangeRequest.count({
+        where: {
+          deletedAt: null,
+          status: { in: ['SUBMITTED', 'UNDER_REVIEW'] },
+        },
+      }),
+
+      // Unacknowledged distribution recipients
+      prisma.imsDistributionRecipient.count({
+        where: { acknowledgedAt: null },
+      }),
+
+      // All active clauses grouped by standard
+      prisma.imsClause.groupBy({
+        by: ['standard'],
+        where: { isActive: true },
+        _count: true,
+      }),
+
+      // Distinct clauseIds mapped to at least one document
+      prisma.imsClauseMapping.findMany({
+        select: {
+          clauseId: true,
+          clause: { select: { standard: true } },
+        },
+        distinct: ['clauseId'],
+      }),
+
+      // Recent activity: last 10 created/updated documents
+      prisma.imsDocument.findMany({
+        where: { deletedAt: null },
+        select: {
+          id: true,
+          documentNumber: true,
+          title: true,
+          status: true,
+          updatedAt: true,
+          createdAt: true,
+        },
+        orderBy: { updatedAt: 'desc' },
+        take: 10,
+      }),
+    ]);
+
+    // Build byStatus map
+    const byStatus: Record<string, number> = {
+      DRAFT: 0,
+      UNDER_REVIEW: 0,
+      APPROVED: 0,
+      OBSOLETE: 0,
+    };
+    for (const row of byStatusRaw) {
+      byStatus[row.status] = row._count;
+    }
+
+    // Build clause coverage per standard
+    const totalClausesByStandard: Record<string, number> = {};
+    for (const row of allClauses) {
+      totalClausesByStandard[row.standard] = row._count;
+    }
+
+    const mappedClausesByStandard: Record<string, Set<string>> = {};
+    for (const row of mappedClausesRaw) {
+      const std = row.clause.standard;
+      if (!mappedClausesByStandard[std]) {
+        mappedClausesByStandard[std] = new Set();
+      }
+      mappedClausesByStandard[std].add(row.clauseId);
+    }
+
+    const clauseCoverage = STANDARDS.map((standard) => {
+      const totalClauses = totalClausesByStandard[standard] ?? 0;
+      const mappedClauses = mappedClausesByStandard[standard]?.size ?? 0;
+      const percentage = totalClauses > 0 ? Math.round((mappedClauses / totalClauses) * 100) : 0;
+      return { standard, totalClauses, mappedClauses, percentage };
+    });
+
+    return NextResponse.json({
+      totalDocuments,
+      byStatus,
+      overdueReviews,
+      pendingDCRs,
+      unacknowledgedDistributions,
+      clauseCoverage,
+      recentActivity,
+    });
+  } catch (error) {
+    logger.error({ error }, 'Failed to fetch IMS dashboard');
+    return NextResponse.json({ error: 'Failed to fetch dashboard' }, { status: 500 });
+  }
+}

--- a/src/app/api/ims/documents/[id]/distributions/[distId]/acknowledge/route.ts
+++ b/src/app/api/ims/documents/[id]/distributions/[distId]/acknowledge/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/db';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import { logger } from '@/lib/logger';
+import { systemEventService } from '@/services/system-events.service';
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string; distId: string }> }
+) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id, distId } = await params;
+
+    const document = await prisma.imsDocument.findFirst({
+      where: { id, deletedAt: null },
+      select: { id: true, documentNumber: true },
+    });
+
+    if (!document) {
+      return NextResponse.json({ error: 'Document not found' }, { status: 404 });
+    }
+
+    const distribution = await prisma.imsDistribution.findFirst({
+      where: { id: distId, documentId: id },
+      select: { id: true },
+    });
+
+    if (!distribution) {
+      return NextResponse.json({ error: 'Distribution not found' }, { status: 404 });
+    }
+
+    const recipient = await prisma.imsDistributionRecipient.findFirst({
+      where: { distributionId: distId, userId: session.sub },
+      select: { id: true, acknowledgedAt: true },
+    });
+
+    if (!recipient) {
+      return NextResponse.json({ error: 'Recipient record not found for current user' }, { status: 404 });
+    }
+
+    if (recipient.acknowledgedAt) {
+      return NextResponse.json({ error: 'Already acknowledged' }, { status: 409 });
+    }
+
+    const updated = await prisma.imsDistributionRecipient.update({
+      where: { id: recipient.id },
+      data: {
+        acknowledgedAt: new Date(),
+        acknowledgeMethod: 'SYSTEM',
+      },
+      include: {
+        user: { select: { id: true, name: true, email: true } },
+      },
+    });
+
+    systemEventService.log({
+      eventType: 'KC_ENTRY_UPDATED',
+      eventCategory: 'KNOWLEDGE',
+      userId: session.sub,
+      userName: session.name,
+      entityType: 'ImsDistributionRecipient',
+      entityId: updated.id,
+      entityName: document.documentNumber,
+      summary: `Distribution acknowledged for document ${document.documentNumber}`,
+      details: { documentId: id, distributionId: distId, acknowledgeMethod: 'SYSTEM' },
+    });
+
+    return NextResponse.json(updated);
+  } catch (error) {
+    logger.error({ error }, 'Failed to acknowledge IMS distribution');
+    return NextResponse.json({ error: 'Failed to acknowledge distribution' }, { status: 500 });
+  }
+}

--- a/src/app/api/ims/documents/[id]/distributions/route.ts
+++ b/src/app/api/ims/documents/[id]/distributions/route.ts
@@ -1,0 +1,118 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/db';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import { logger } from '@/lib/logger';
+import { systemEventService } from '@/services/system-events.service';
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id } = await params;
+
+    const document = await prisma.imsDocument.findFirst({
+      where: { id, deletedAt: null },
+      select: { id: true },
+    });
+
+    if (!document) {
+      return NextResponse.json({ error: 'Document not found' }, { status: 404 });
+    }
+
+    const distributions = await prisma.imsDistribution.findMany({
+      where: { documentId: id },
+      include: {
+        recipients: {
+          include: {
+            user: { select: { id: true, name: true, email: true } },
+          },
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    return NextResponse.json(distributions);
+  } catch (error) {
+    logger.error({ error }, 'Failed to fetch IMS distributions');
+    return NextResponse.json({ error: 'Failed to fetch distributions' }, { status: 500 });
+  }
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id } = await params;
+
+    const document = await prisma.imsDocument.findFirst({
+      where: { id, deletedAt: null },
+      select: { id: true, documentNumber: true },
+    });
+
+    if (!document) {
+      return NextResponse.json({ error: 'Document not found' }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const { userIds, notes, revisionId } = body;
+
+    if (!Array.isArray(userIds) || userIds.length === 0) {
+      return NextResponse.json({ error: 'Missing required field: userIds (non-empty array)' }, { status: 400 });
+    }
+
+    const distribution = await prisma.imsDistribution.create({
+      data: {
+        documentId: id,
+        revisionId: revisionId ?? null,
+        issuedById: session.sub,
+        notes: notes ?? null,
+        recipients: {
+          create: userIds.map((userId: string) => ({ userId })),
+        },
+      },
+      include: {
+        recipients: {
+          include: {
+            user: { select: { id: true, name: true, email: true } },
+          },
+        },
+      },
+    });
+
+    systemEventService.log({
+      eventType: 'KC_ENTRY_CREATED',
+      eventCategory: 'KNOWLEDGE',
+      userId: session.sub,
+      userName: session.name,
+      entityType: 'ImsDistribution',
+      entityId: distribution.id,
+      entityName: document.documentNumber,
+      summary: `Document ${document.documentNumber} distributed to ${userIds.length} recipient(s)`,
+      details: { documentId: id, recipientCount: userIds.length },
+    });
+
+    return NextResponse.json(distribution, { status: 201 });
+  } catch (error) {
+    logger.error({ error }, 'Failed to create IMS distribution');
+    return NextResponse.json({ error: 'Failed to create distribution' }, { status: 500 });
+  }
+}

--- a/src/app/api/ims/documents/[id]/revisions/route.ts
+++ b/src/app/api/ims/documents/[id]/revisions/route.ts
@@ -1,0 +1,129 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/db';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import { logger } from '@/lib/logger';
+import { systemEventService } from '@/services/system-events.service';
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id } = await params;
+
+    const document = await prisma.imsDocument.findFirst({
+      where: { id, deletedAt: null },
+      select: { id: true },
+    });
+
+    if (!document) {
+      return NextResponse.json({ error: 'Document not found' }, { status: 404 });
+    }
+
+    const revisions = await prisma.imsRevision.findMany({
+      where: { documentId: id },
+      include: {
+        preparedBy: { select: { id: true, name: true } },
+        reviewedBy: { select: { id: true, name: true } },
+        approvedBy: { select: { id: true, name: true } },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    return NextResponse.json(revisions);
+  } catch (error) {
+    logger.error({ error }, 'Failed to fetch IMS revisions');
+    return NextResponse.json({ error: 'Failed to fetch revisions' }, { status: 500 });
+  }
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id } = await params;
+
+    const document = await prisma.imsDocument.findFirst({
+      where: { id, deletedAt: null },
+      select: { id: true, documentNumber: true },
+    });
+
+    if (!document) {
+      return NextResponse.json({ error: 'Document not found' }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const {
+      version,
+      changeDescription,
+      changeType,
+      status,
+      fileUrl,
+      preparedById,
+      reviewedById,
+      approvedById,
+      effectiveDate,
+      workflowInstanceId,
+    } = body;
+
+    if (!version) {
+      return NextResponse.json({ error: 'Missing required field: version' }, { status: 400 });
+    }
+
+    const revision = await prisma.imsRevision.create({
+      data: {
+        documentId: id,
+        version,
+        changeDescription: changeDescription ?? null,
+        changeType: changeType ?? 'MINOR',
+        status: status ?? 'DRAFT',
+        fileUrl: fileUrl ?? null,
+        preparedById: preparedById ?? session.sub,
+        reviewedById: reviewedById ?? null,
+        approvedById: approvedById ?? null,
+        effectiveDate: effectiveDate ? new Date(effectiveDate) : null,
+        workflowInstanceId: workflowInstanceId ?? null,
+      },
+      include: {
+        preparedBy: { select: { id: true, name: true } },
+        reviewedBy: { select: { id: true, name: true } },
+        approvedBy: { select: { id: true, name: true } },
+      },
+    });
+
+    systemEventService.log({
+      eventType: 'KC_ENTRY_CREATED',
+      eventCategory: 'KNOWLEDGE',
+      userId: session.sub,
+      userName: session.name,
+      entityType: 'ImsRevision',
+      entityId: revision.id,
+      entityName: `${document.documentNumber} v${version}`,
+      summary: `Revision ${version} created for document ${document.documentNumber}`,
+      details: { documentId: id, version, changeType: revision.changeType },
+    });
+
+    return NextResponse.json(revision, { status: 201 });
+  } catch (error) {
+    logger.error({ error }, 'Failed to create IMS revision');
+    return NextResponse.json({ error: 'Failed to create revision' }, { status: 500 });
+  }
+}

--- a/src/app/api/ims/documents/[id]/route.ts
+++ b/src/app/api/ims/documents/[id]/route.ts
@@ -1,0 +1,232 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/db';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import { logger } from '@/lib/logger';
+import { systemEventService } from '@/services/system-events.service';
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id } = await params;
+
+    const document = await prisma.imsDocument.findFirst({
+      where: { id, deletedAt: null },
+      include: {
+        category: { select: { id: true, code: true, name: true, nameAr: true } },
+        department: { select: { id: true, name: true } },
+        owner: { select: { id: true, name: true } },
+        reviewer: { select: { id: true, name: true } },
+        revisions: {
+          include: {
+            preparedBy: { select: { id: true, name: true } },
+            approvedBy: { select: { id: true, name: true } },
+          },
+          orderBy: { createdAt: 'desc' },
+        },
+        distributions: {
+          include: {
+            recipients: {
+              include: {
+                user: { select: { id: true, name: true, email: true } },
+              },
+            },
+          },
+          orderBy: { createdAt: 'desc' },
+        },
+        clauseMappings: {
+          include: {
+            clause: {
+              select: {
+                id: true,
+                standard: true,
+                clause: true,
+                title: true,
+                level: true,
+              },
+            },
+          },
+        },
+        _count: {
+          select: {
+            revisions: true,
+            distributions: true,
+            changeRequests: true,
+            clauseMappings: true,
+          },
+        },
+      },
+    });
+
+    if (!document) {
+      return NextResponse.json({ error: 'Document not found' }, { status: 404 });
+    }
+
+    return NextResponse.json(document);
+  } catch (error) {
+    logger.error({ error }, 'Failed to fetch IMS document');
+    return NextResponse.json({ error: 'Failed to fetch document' }, { status: 500 });
+  }
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id } = await params;
+
+    const existing = await prisma.imsDocument.findFirst({
+      where: { id, deletedAt: null },
+      select: { id: true, reviewFrequencyDays: true, nextReviewDate: true },
+    });
+
+    if (!existing) {
+      return NextResponse.json({ error: 'Document not found' }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const {
+      title,
+      titleAr,
+      categoryId,
+      departmentId,
+      ownerId,
+      reviewerId,
+      applicableStandards,
+      scope,
+      purpose,
+      site,
+      confidentiality,
+      reviewFrequencyDays,
+      fileUrl,
+      status,
+      currentVersion,
+      lastReviewDate,
+      issuedAt,
+    } = body;
+
+    const updateData: Record<string, unknown> = { updatedById: session.sub };
+
+    if (title !== undefined) updateData.title = title;
+    if (titleAr !== undefined) updateData.titleAr = titleAr;
+    if (categoryId !== undefined) updateData.categoryId = categoryId;
+    if (departmentId !== undefined) updateData.departmentId = departmentId;
+    if (ownerId !== undefined) updateData.ownerId = ownerId;
+    if (reviewerId !== undefined) updateData.reviewerId = reviewerId;
+    if (applicableStandards !== undefined) updateData.applicableStandards = applicableStandards;
+    if (scope !== undefined) updateData.scope = scope;
+    if (purpose !== undefined) updateData.purpose = purpose;
+    if (site !== undefined) updateData.site = site;
+    if (confidentiality !== undefined) updateData.confidentiality = confidentiality;
+    if (fileUrl !== undefined) updateData.fileUrl = fileUrl;
+    if (status !== undefined) updateData.status = status;
+    if (currentVersion !== undefined) updateData.currentVersion = currentVersion;
+    if (lastReviewDate !== undefined) updateData.lastReviewDate = new Date(lastReviewDate);
+    if (issuedAt !== undefined) updateData.issuedAt = new Date(issuedAt);
+
+    if (reviewFrequencyDays !== undefined) {
+      updateData.reviewFrequencyDays = reviewFrequencyDays;
+      const nextReviewDate = new Date();
+      nextReviewDate.setDate(nextReviewDate.getDate() + reviewFrequencyDays);
+      updateData.nextReviewDate = nextReviewDate;
+    }
+
+    const document = await prisma.imsDocument.update({
+      where: { id },
+      data: updateData,
+      include: {
+        category: { select: { id: true, code: true, name: true } },
+        department: { select: { id: true, name: true } },
+        owner: { select: { id: true, name: true } },
+        reviewer: { select: { id: true, name: true } },
+      },
+    });
+
+    systemEventService.log({
+      eventType: 'KC_ENTRY_UPDATED',
+      eventCategory: 'KNOWLEDGE',
+      userId: session.sub,
+      userName: session.name,
+      entityType: 'ImsDocument',
+      entityId: document.id,
+      entityName: document.documentNumber,
+      summary: `IMS document ${document.documentNumber} updated`,
+      details: { updatedFields: Object.keys(updateData) },
+    });
+
+    return NextResponse.json(document);
+  } catch (error) {
+    logger.error({ error }, 'Failed to update IMS document');
+    return NextResponse.json({ error: 'Failed to update document' }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id } = await params;
+
+    const existing = await prisma.imsDocument.findFirst({
+      where: { id, deletedAt: null },
+      select: { id: true, documentNumber: true, title: true },
+    });
+
+    if (!existing) {
+      return NextResponse.json({ error: 'Document not found' }, { status: 404 });
+    }
+
+    await prisma.imsDocument.update({
+      where: { id },
+      data: {
+        deletedAt: new Date(),
+        deletedById: session.sub,
+      },
+    });
+
+    systemEventService.log({
+      eventType: 'KC_ENTRY_DELETED',
+      eventCategory: 'KNOWLEDGE',
+      userId: session.sub,
+      userName: session.name,
+      entityType: 'ImsDocument',
+      entityId: id,
+      entityName: existing.documentNumber,
+      summary: `IMS document ${existing.documentNumber} deleted`,
+      details: { documentNumber: existing.documentNumber, title: existing.title },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    logger.error({ error }, 'Failed to delete IMS document');
+    return NextResponse.json({ error: 'Failed to delete document' }, { status: 500 });
+  }
+}

--- a/src/app/api/ims/documents/route.ts
+++ b/src/app/api/ims/documents/route.ts
@@ -1,0 +1,217 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/db';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import { logger } from '@/lib/logger';
+import { systemEventService } from '@/services/system-events.service';
+
+// Generate document number: "{category.code}-{YYYY}-{NNN:4}"
+async function generateDocumentNumber(categoryId: string): Promise<string> {
+  const category = await prisma.imsCategory.findUnique({
+    where: { id: categoryId },
+    select: { code: true },
+  });
+
+  if (!category) {
+    throw new Error('Category not found');
+  }
+
+  const year = new Date().getFullYear();
+  const yearStart = new Date(`${year}-01-01T00:00:00.000Z`);
+  const yearEnd = new Date(`${year + 1}-01-01T00:00:00.000Z`);
+
+  const count = await prisma.imsDocument.count({
+    where: {
+      categoryId,
+      createdAt: { gte: yearStart, lt: yearEnd },
+    },
+  });
+
+  const sequence = (count + 1).toString().padStart(4, '0');
+  return `${category.code}-${year}-${sequence}`;
+}
+
+export async function GET(request: Request) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const categoryId = searchParams.get('categoryId');
+    const status = searchParams.get('status');
+    const departmentId = searchParams.get('departmentId');
+    const site = searchParams.get('site');
+    const search = searchParams.get('search');
+    const overdue = searchParams.get('overdue');
+
+    const where: Record<string, unknown> = { deletedAt: null };
+
+    if (categoryId) where.categoryId = categoryId;
+    if (status) where.status = status;
+    if (departmentId) where.departmentId = departmentId;
+    if (site) where.site = site;
+
+    if (search) {
+      where.OR = [
+        { title: { contains: search } },
+        { documentNumber: { contains: search } },
+      ];
+    }
+
+    if (overdue === 'true') {
+      where.nextReviewDate = { lt: new Date() };
+      where.status = 'APPROVED';
+    }
+
+    const documents = await prisma.imsDocument.findMany({
+      where,
+      select: {
+        id: true,
+        documentNumber: true,
+        title: true,
+        titleAr: true,
+        status: true,
+        currentVersion: true,
+        site: true,
+        confidentiality: true,
+        reviewFrequencyDays: true,
+        lastReviewDate: true,
+        nextReviewDate: true,
+        fileUrl: true,
+        issuedAt: true,
+        applicableStandards: true,
+        scope: true,
+        purpose: true,
+        createdAt: true,
+        updatedAt: true,
+        category: {
+          select: { id: true, code: true, name: true, nameAr: true },
+        },
+        department: {
+          select: { id: true, name: true },
+        },
+        owner: {
+          select: { id: true, name: true },
+        },
+        reviewer: {
+          select: { id: true, name: true },
+        },
+        _count: {
+          select: {
+            revisions: true,
+            distributions: true,
+            changeRequests: true,
+            clauseMappings: true,
+          },
+        },
+      },
+      orderBy: { updatedAt: 'desc' },
+    });
+
+    const now = new Date();
+    const result = documents.map((doc) => {
+      let overdueDays: number | null = null;
+      if (doc.nextReviewDate && doc.nextReviewDate < now && doc.status === 'APPROVED') {
+        overdueDays = Math.floor(
+          (now.getTime() - doc.nextReviewDate.getTime()) / (1000 * 60 * 60 * 24)
+        );
+      }
+      return { ...doc, overdueDays };
+    });
+
+    return NextResponse.json(result);
+  } catch (error) {
+    logger.error({ error }, 'Failed to fetch IMS documents');
+    return NextResponse.json({ error: 'Failed to fetch documents' }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const {
+      title,
+      titleAr,
+      categoryId,
+      departmentId,
+      ownerId,
+      reviewerId,
+      applicableStandards,
+      scope,
+      purpose,
+      site,
+      confidentiality,
+      reviewFrequencyDays,
+      fileUrl,
+    } = body;
+
+    if (!title || !categoryId) {
+      return NextResponse.json({ error: 'Missing required fields: title, categoryId' }, { status: 400 });
+    }
+
+    const documentNumber = await generateDocumentNumber(categoryId);
+
+    const days = typeof reviewFrequencyDays === 'number' ? reviewFrequencyDays : 365;
+    const nextReviewDate = new Date();
+    nextReviewDate.setDate(nextReviewDate.getDate() + days);
+
+    const document = await prisma.imsDocument.create({
+      data: {
+        documentNumber,
+        title,
+        titleAr: titleAr ?? null,
+        categoryId,
+        departmentId: departmentId ?? null,
+        ownerId: ownerId ?? null,
+        reviewerId: reviewerId ?? null,
+        applicableStandards: applicableStandards ?? null,
+        scope: scope ?? null,
+        purpose: purpose ?? null,
+        site: site ?? null,
+        confidentiality: confidentiality ?? 'INTERNAL',
+        reviewFrequencyDays: days,
+        nextReviewDate,
+        fileUrl: fileUrl ?? null,
+        status: 'DRAFT',
+        createdById: session.sub,
+        updatedById: session.sub,
+      },
+      include: {
+        category: { select: { id: true, code: true, name: true } },
+        department: { select: { id: true, name: true } },
+        owner: { select: { id: true, name: true } },
+        reviewer: { select: { id: true, name: true } },
+      },
+    });
+
+    systemEventService.log({
+      eventType: 'KC_ENTRY_CREATED',
+      eventCategory: 'KNOWLEDGE',
+      userId: session.sub,
+      userName: session.name,
+      entityType: 'ImsDocument',
+      entityId: document.id,
+      entityName: document.documentNumber,
+      summary: `IMS document ${document.documentNumber} created: ${document.title}`,
+      details: { documentNumber: document.documentNumber, categoryId, status: 'DRAFT' },
+    });
+
+    return NextResponse.json(document, { status: 201 });
+  } catch (error) {
+    logger.error({ error }, 'Failed to create IMS document');
+    return NextResponse.json({ error: 'Failed to create document' }, { status: 500 });
+  }
+}

--- a/src/app/api/ims/documents/route.ts
+++ b/src/app/api/ims/documents/route.ts
@@ -113,8 +113,9 @@ export async function GET(request: Request) {
       orderBy: { updatedAt: 'desc' },
     });
 
+    type DocRow = (typeof documents)[number];
     const now = new Date();
-    const result = documents.map((doc) => {
+    const result = documents.map((doc: DocRow) => {
       let overdueDays: number | null = null;
       if (doc.nextReviewDate && doc.nextReviewDate < now && doc.status === 'APPROVED') {
         overdueDays = Math.floor(

--- a/src/app/api/ims/review-calendar/route.ts
+++ b/src/app/api/ims/review-calendar/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/db';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import { logger } from '@/lib/logger';
+
+export async function GET(request: Request) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const monthsParam = searchParams.get('months');
+    const months = monthsParam ? parseInt(monthsParam, 10) : 6;
+    const lookAheadMonths = isNaN(months) || months < 1 ? 6 : months;
+
+    const now = new Date();
+    const windowEnd = new Date(now);
+    windowEnd.setMonth(windowEnd.getMonth() + lookAheadMonths);
+
+    const documents = await prisma.imsDocument.findMany({
+      where: {
+        deletedAt: null,
+        nextReviewDate: { not: null, lte: windowEnd },
+      },
+      select: {
+        id: true,
+        documentNumber: true,
+        title: true,
+        status: true,
+        nextReviewDate: true,
+        lastReviewDate: true,
+        reviewFrequencyDays: true,
+        category: { select: { id: true, code: true, name: true } },
+        owner: { select: { id: true, name: true } },
+        department: { select: { id: true, name: true } },
+      },
+      orderBy: { nextReviewDate: 'asc' },
+    });
+
+    const now2 = new Date();
+    // Group by month key "YYYY-MM"
+    const groupMap = new Map<string, typeof documents>();
+
+    for (const doc of documents) {
+      if (!doc.nextReviewDate) continue;
+      const d = doc.nextReviewDate;
+      const monthKey = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+      if (!groupMap.has(monthKey)) {
+        groupMap.set(monthKey, []);
+      }
+      groupMap.get(monthKey)!.push(doc);
+    }
+
+    type DocRow = (typeof documents)[number];
+
+    const result = Array.from(groupMap.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([month, docs]) => ({
+        month,
+        documents: docs.map((doc: DocRow) => {
+          let overdueDays: number | null = null;
+          if (doc.nextReviewDate && doc.nextReviewDate < now2 && doc.status === 'APPROVED') {
+            overdueDays = Math.floor(
+              (now2.getTime() - doc.nextReviewDate.getTime()) / (1000 * 60 * 60 * 24)
+            );
+          }
+          return { ...doc, overdueDays };
+        }),
+      }));
+
+    return NextResponse.json(result);
+  } catch (error) {
+    logger.error({ error }, 'Failed to fetch IMS review calendar');
+    return NextResponse.json({ error: 'Failed to fetch review calendar' }, { status: 500 });
+  }
+}

--- a/src/app/api/ims/risks/[id]/assessments/route.ts
+++ b/src/app/api/ims/risks/[id]/assessments/route.ts
@@ -1,0 +1,153 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/db';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import { logger } from '@/lib/logger';
+import { systemEventService } from '@/services/system-events.service';
+
+function computeRiskRating(riskLevel: number): string {
+  if (riskLevel <= 4) return 'LOW';
+  if (riskLevel <= 9) return 'MEDIUM';
+  if (riskLevel <= 15) return 'HIGH';
+  return 'CRITICAL';
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id } = await params;
+
+    const risk = await prisma.imsRisk.findFirst({
+      where: { id, deletedAt: null },
+      select: { id: true },
+    });
+
+    if (!risk) {
+      return NextResponse.json({ error: 'Risk not found' }, { status: 404 });
+    }
+
+    const assessments = await prisma.imsRiskAssessment.findMany({
+      where: { riskId: id },
+      include: {
+        assessedBy: { select: { id: true, name: true } },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    return NextResponse.json(assessments);
+  } catch (error) {
+    logger.error({ error }, 'Failed to fetch IMS risk assessments');
+    return NextResponse.json({ error: 'Failed to fetch assessments' }, { status: 500 });
+  }
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id } = await params;
+
+    const risk = await prisma.imsRisk.findFirst({
+      where: { id, deletedAt: null },
+      select: { id: true, riskNumber: true, reviewFrequencyDays: true },
+    });
+
+    if (!risk) {
+      return NextResponse.json({ error: 'Risk not found' }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const { likelihood, severity, assessmentType, existingControls, recommendations } = body;
+
+    if (
+      typeof likelihood !== 'number' ||
+      typeof severity !== 'number' ||
+      !assessmentType
+    ) {
+      return NextResponse.json(
+        { error: 'Missing required fields: likelihood, severity, assessmentType' },
+        { status: 400 }
+      );
+    }
+
+    if (likelihood < 1 || likelihood > 5 || severity < 1 || severity > 5) {
+      return NextResponse.json(
+        { error: 'likelihood and severity must be between 1 and 5' },
+        { status: 400 }
+      );
+    }
+
+    const riskLevel = likelihood * severity;
+    const riskRating = computeRiskRating(riskLevel);
+
+    const assessment = await prisma.imsRiskAssessment.create({
+      data: {
+        riskId: id,
+        likelihood,
+        severity,
+        riskLevel,
+        riskRating,
+        assessmentType,
+        existingControls: existingControls ?? null,
+        recommendations: recommendations ?? null,
+        assessedById: session.sub,
+      },
+      include: {
+        assessedBy: { select: { id: true, name: true } },
+      },
+    });
+
+    const now = new Date();
+    const nextReviewDate = new Date();
+    nextReviewDate.setDate(nextReviewDate.getDate() + risk.reviewFrequencyDays);
+
+    await prisma.imsRisk.update({
+      where: { id },
+      data: {
+        currentLikelihood: likelihood,
+        currentSeverity: severity,
+        currentRiskLevel: riskLevel,
+        currentRiskRating: riskRating,
+        lastReviewDate: now,
+        nextReviewDate,
+        updatedById: session.sub,
+      },
+    });
+
+    systemEventService.log({
+      eventType: 'IMS_RISK_ASSESSED',
+      eventCategory: 'IMS',
+      userId: session.sub,
+      userName: session.name,
+      entityType: 'ImsRiskAssessment',
+      entityId: assessment.id,
+      entityName: risk.riskNumber,
+      summary: `Risk ${risk.riskNumber} assessed: ${riskRating} (${riskLevel})`,
+      details: { likelihood, severity, riskLevel, riskRating, assessmentType },
+    });
+
+    return NextResponse.json(assessment, { status: 201 });
+  } catch (error) {
+    logger.error({ error }, 'Failed to create IMS risk assessment');
+    return NextResponse.json({ error: 'Failed to create assessment' }, { status: 500 });
+  }
+}

--- a/src/app/api/ims/risks/[id]/hazards/[hazardId]/route.ts
+++ b/src/app/api/ims/risks/[id]/hazards/[hazardId]/route.ts
@@ -1,0 +1,120 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/db';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import { logger } from '@/lib/logger';
+import { systemEventService } from '@/services/system-events.service';
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string; hazardId: string }> }
+) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id, hazardId } = await params;
+
+    const existing = await prisma.imsHazardIdentification.findFirst({
+      where: { id: hazardId, riskId: id },
+      select: { id: true },
+    });
+
+    if (!existing) {
+      return NextResponse.json({ error: 'Hazard not found' }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const {
+      hazardType,
+      controlHierarchy,
+      hazardDescription,
+      location,
+      affectedPersonnel,
+      controlMeasures,
+    } = body;
+
+    const updateData: Record<string, unknown> = {};
+
+    if (hazardType !== undefined) updateData.hazardType = hazardType;
+    if (controlHierarchy !== undefined) updateData.controlHierarchy = controlHierarchy;
+    if (hazardDescription !== undefined) updateData.hazardDescription = hazardDescription;
+    if (location !== undefined) updateData.location = location;
+    if (affectedPersonnel !== undefined) updateData.affectedPersonnel = affectedPersonnel;
+    if (controlMeasures !== undefined) updateData.controlMeasures = controlMeasures;
+
+    const hazard = await prisma.imsHazardIdentification.update({
+      where: { id: hazardId },
+      data: updateData,
+    });
+
+    systemEventService.log({
+      eventType: 'IMS_HAZARD_UPDATED',
+      eventCategory: 'IMS',
+      userId: session.sub,
+      userName: session.name,
+      entityType: 'ImsHazardIdentification',
+      entityId: hazardId,
+      entityName: hazardId,
+      summary: `Hazard ${hazardId} updated for risk ${id}`,
+      details: { updatedFields: Object.keys(updateData) },
+    });
+
+    return NextResponse.json(hazard);
+  } catch (error) {
+    logger.error({ error }, 'Failed to update IMS hazard');
+    return NextResponse.json({ error: 'Failed to update hazard' }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string; hazardId: string }> }
+) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id, hazardId } = await params;
+
+    const existing = await prisma.imsHazardIdentification.findFirst({
+      where: { id: hazardId, riskId: id },
+      select: { id: true },
+    });
+
+    if (!existing) {
+      return NextResponse.json({ error: 'Hazard not found' }, { status: 404 });
+    }
+
+    await prisma.imsHazardIdentification.delete({
+      where: { id: hazardId },
+    });
+
+    systemEventService.log({
+      eventType: 'IMS_HAZARD_DELETED',
+      eventCategory: 'IMS',
+      userId: session.sub,
+      userName: session.name,
+      entityType: 'ImsHazardIdentification',
+      entityId: hazardId,
+      entityName: hazardId,
+      summary: `Hazard ${hazardId} deleted from risk ${id}`,
+      details: { riskId: id, hazardId },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    logger.error({ error }, 'Failed to delete IMS hazard');
+    return NextResponse.json({ error: 'Failed to delete hazard' }, { status: 500 });
+  }
+}

--- a/src/app/api/ims/risks/[id]/hazards/route.ts
+++ b/src/app/api/ims/risks/[id]/hazards/route.ts
@@ -1,0 +1,114 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/db';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import { logger } from '@/lib/logger';
+import { systemEventService } from '@/services/system-events.service';
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id } = await params;
+
+    const risk = await prisma.imsRisk.findFirst({
+      where: { id, deletedAt: null },
+      select: { id: true },
+    });
+
+    if (!risk) {
+      return NextResponse.json({ error: 'Risk not found' }, { status: 404 });
+    }
+
+    const hazards = await prisma.imsHazardIdentification.findMany({
+      where: { riskId: id },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    return NextResponse.json(hazards);
+  } catch (error) {
+    logger.error({ error }, 'Failed to fetch IMS hazards');
+    return NextResponse.json({ error: 'Failed to fetch hazards' }, { status: 500 });
+  }
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id } = await params;
+
+    const risk = await prisma.imsRisk.findFirst({
+      where: { id, deletedAt: null },
+      select: { id: true, riskNumber: true },
+    });
+
+    if (!risk) {
+      return NextResponse.json({ error: 'Risk not found' }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const {
+      hazardType,
+      controlHierarchy,
+      hazardDescription,
+      location,
+      affectedPersonnel,
+      controlMeasures,
+    } = body;
+
+    if (!hazardType || !controlHierarchy) {
+      return NextResponse.json(
+        { error: 'Missing required fields: hazardType, controlHierarchy' },
+        { status: 400 }
+      );
+    }
+
+    const hazard = await prisma.imsHazardIdentification.create({
+      data: {
+        riskId: id,
+        hazardType,
+        controlHierarchy,
+        hazardDescription: hazardDescription ?? null,
+        location: location ?? null,
+        affectedPersonnel: affectedPersonnel ?? null,
+        controlMeasures: controlMeasures ?? null,
+      },
+    });
+
+    systemEventService.log({
+      eventType: 'IMS_HAZARD_CREATED',
+      eventCategory: 'IMS',
+      userId: session.sub,
+      userName: session.name,
+      entityType: 'ImsHazardIdentification',
+      entityId: hazard.id,
+      entityName: risk.riskNumber,
+      summary: `Hazard identified for risk ${risk.riskNumber}: ${hazardType}`,
+      details: { riskId: id, hazardType, controlHierarchy },
+    });
+
+    return NextResponse.json(hazard, { status: 201 });
+  } catch (error) {
+    logger.error({ error }, 'Failed to create IMS hazard');
+    return NextResponse.json({ error: 'Failed to create hazard' }, { status: 500 });
+  }
+}

--- a/src/app/api/ims/risks/[id]/route.ts
+++ b/src/app/api/ims/risks/[id]/route.ts
@@ -1,0 +1,200 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/db';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import { logger } from '@/lib/logger';
+import { systemEventService } from '@/services/system-events.service';
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id } = await params;
+
+    const risk = await prisma.imsRisk.findFirst({
+      where: { id, deletedAt: null },
+      include: {
+        owner: { select: { id: true, name: true } },
+        department: { select: { id: true, name: true } },
+        assessments: {
+          include: {
+            assessedBy: { select: { id: true, name: true } },
+          },
+          orderBy: { createdAt: 'desc' },
+        },
+        treatments: {
+          include: {
+            responsible: { select: { id: true, name: true } },
+          },
+          orderBy: { createdAt: 'desc' },
+        },
+        hazards: {
+          orderBy: { createdAt: 'desc' },
+        },
+        _count: {
+          select: {
+            assessments: true,
+            treatments: true,
+            hazards: true,
+          },
+        },
+      },
+    });
+
+    if (!risk) {
+      return NextResponse.json({ error: 'Risk not found' }, { status: 404 });
+    }
+
+    return NextResponse.json(risk);
+  } catch (error) {
+    logger.error({ error }, 'Failed to fetch IMS risk');
+    return NextResponse.json({ error: 'Failed to fetch risk' }, { status: 500 });
+  }
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id } = await params;
+
+    const existing = await prisma.imsRisk.findFirst({
+      where: { id, deletedAt: null },
+      select: { id: true, riskNumber: true, reviewFrequencyDays: true },
+    });
+
+    if (!existing) {
+      return NextResponse.json({ error: 'Risk not found' }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const {
+      title,
+      titleAr,
+      category,
+      type,
+      description,
+      source,
+      applicableStandards,
+      ownerId,
+      departmentId,
+      status,
+      reviewFrequencyDays,
+    } = body;
+
+    const updateData: Record<string, unknown> = { updatedById: session.sub };
+
+    if (title !== undefined) updateData.title = title;
+    if (titleAr !== undefined) updateData.titleAr = titleAr;
+    if (category !== undefined) updateData.category = category;
+    if (type !== undefined) updateData.type = type;
+    if (description !== undefined) updateData.description = description;
+    if (source !== undefined) updateData.source = source;
+    if (applicableStandards !== undefined) updateData.applicableStandards = applicableStandards;
+    if (ownerId !== undefined) updateData.ownerId = ownerId;
+    if (departmentId !== undefined) updateData.departmentId = departmentId;
+    if (status !== undefined) updateData.status = status;
+
+    if (reviewFrequencyDays !== undefined) {
+      updateData.reviewFrequencyDays = reviewFrequencyDays;
+      const nextReviewDate = new Date();
+      nextReviewDate.setDate(nextReviewDate.getDate() + reviewFrequencyDays);
+      updateData.nextReviewDate = nextReviewDate;
+    }
+
+    const risk = await prisma.imsRisk.update({
+      where: { id },
+      data: updateData,
+      include: {
+        owner: { select: { id: true, name: true } },
+        department: { select: { id: true, name: true } },
+      },
+    });
+
+    systemEventService.log({
+      eventType: 'IMS_RISK_UPDATED',
+      eventCategory: 'IMS',
+      userId: session.sub,
+      userName: session.name,
+      entityType: 'ImsRisk',
+      entityId: risk.id,
+      entityName: risk.riskNumber,
+      summary: `IMS risk ${risk.riskNumber} updated`,
+      details: { updatedFields: Object.keys(updateData) },
+    });
+
+    return NextResponse.json(risk);
+  } catch (error) {
+    logger.error({ error }, 'Failed to update IMS risk');
+    return NextResponse.json({ error: 'Failed to update risk' }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id } = await params;
+
+    const existing = await prisma.imsRisk.findFirst({
+      where: { id, deletedAt: null },
+      select: { id: true, riskNumber: true, title: true },
+    });
+
+    if (!existing) {
+      return NextResponse.json({ error: 'Risk not found' }, { status: 404 });
+    }
+
+    await prisma.imsRisk.update({
+      where: { id },
+      data: {
+        deletedAt: new Date(),
+        deletedById: session.sub,
+      },
+    });
+
+    systemEventService.log({
+      eventType: 'IMS_RISK_DELETED',
+      eventCategory: 'IMS',
+      userId: session.sub,
+      userName: session.name,
+      entityType: 'ImsRisk',
+      entityId: id,
+      entityName: existing.riskNumber,
+      summary: `IMS risk ${existing.riskNumber} deleted`,
+      details: { riskNumber: existing.riskNumber, title: existing.title },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    logger.error({ error }, 'Failed to delete IMS risk');
+    return NextResponse.json({ error: 'Failed to delete risk' }, { status: 500 });
+  }
+}

--- a/src/app/api/ims/risks/[id]/treatments/[treatmentId]/route.ts
+++ b/src/app/api/ims/risks/[id]/treatments/[treatmentId]/route.ts
@@ -1,0 +1,119 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/db';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import { logger } from '@/lib/logger';
+import { systemEventService } from '@/services/system-events.service';
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string; treatmentId: string }> }
+) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id, treatmentId } = await params;
+
+    const existing = await prisma.imsRiskTreatment.findFirst({
+      where: { id: treatmentId, riskId: id },
+      select: { id: true },
+    });
+
+    if (!existing) {
+      return NextResponse.json({ error: 'Treatment not found' }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const { status, effectiveness, completedDate, notes, description, responsibleId, targetDate } =
+      body;
+
+    const updateData: Record<string, unknown> = {};
+
+    if (status !== undefined) updateData.status = status;
+    if (effectiveness !== undefined) updateData.effectiveness = effectiveness;
+    if (completedDate !== undefined)
+      updateData.completedDate = completedDate ? new Date(completedDate) : null;
+    if (notes !== undefined) updateData.notes = notes;
+    if (description !== undefined) updateData.description = description;
+    if (responsibleId !== undefined) updateData.responsibleId = responsibleId;
+    if (targetDate !== undefined) updateData.targetDate = targetDate ? new Date(targetDate) : null;
+
+    const treatment = await prisma.imsRiskTreatment.update({
+      where: { id: treatmentId },
+      data: updateData,
+      include: {
+        responsible: { select: { id: true, name: true } },
+      },
+    });
+
+    systemEventService.log({
+      eventType: 'IMS_RISK_TREATMENT_UPDATED',
+      eventCategory: 'IMS',
+      userId: session.sub,
+      userName: session.name,
+      entityType: 'ImsRiskTreatment',
+      entityId: treatmentId,
+      entityName: treatmentId,
+      summary: `Treatment ${treatmentId} updated for risk ${id}`,
+      details: { updatedFields: Object.keys(updateData) },
+    });
+
+    return NextResponse.json(treatment);
+  } catch (error) {
+    logger.error({ error }, 'Failed to update IMS risk treatment');
+    return NextResponse.json({ error: 'Failed to update treatment' }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string; treatmentId: string }> }
+) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id, treatmentId } = await params;
+
+    const existing = await prisma.imsRiskTreatment.findFirst({
+      where: { id: treatmentId, riskId: id },
+      select: { id: true },
+    });
+
+    if (!existing) {
+      return NextResponse.json({ error: 'Treatment not found' }, { status: 404 });
+    }
+
+    await prisma.imsRiskTreatment.delete({
+      where: { id: treatmentId },
+    });
+
+    systemEventService.log({
+      eventType: 'IMS_RISK_TREATMENT_DELETED',
+      eventCategory: 'IMS',
+      userId: session.sub,
+      userName: session.name,
+      entityType: 'ImsRiskTreatment',
+      entityId: treatmentId,
+      entityName: treatmentId,
+      summary: `Treatment ${treatmentId} deleted from risk ${id}`,
+      details: { riskId: id, treatmentId },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    logger.error({ error }, 'Failed to delete IMS risk treatment');
+    return NextResponse.json({ error: 'Failed to delete treatment' }, { status: 500 });
+  }
+}

--- a/src/app/api/ims/risks/[id]/treatments/route.ts
+++ b/src/app/api/ims/risks/[id]/treatments/route.ts
@@ -1,0 +1,112 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/db';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import { logger } from '@/lib/logger';
+import { systemEventService } from '@/services/system-events.service';
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id } = await params;
+
+    const risk = await prisma.imsRisk.findFirst({
+      where: { id, deletedAt: null },
+      select: { id: true },
+    });
+
+    if (!risk) {
+      return NextResponse.json({ error: 'Risk not found' }, { status: 404 });
+    }
+
+    const treatments = await prisma.imsRiskTreatment.findMany({
+      where: { riskId: id },
+      include: {
+        responsible: { select: { id: true, name: true } },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    return NextResponse.json(treatments);
+  } catch (error) {
+    logger.error({ error }, 'Failed to fetch IMS risk treatments');
+    return NextResponse.json({ error: 'Failed to fetch treatments' }, { status: 500 });
+  }
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id } = await params;
+
+    const risk = await prisma.imsRisk.findFirst({
+      where: { id, deletedAt: null },
+      select: { id: true, riskNumber: true },
+    });
+
+    if (!risk) {
+      return NextResponse.json({ error: 'Risk not found' }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const { treatmentType, description, responsibleId, targetDate, status } = body;
+
+    if (!treatmentType || !description) {
+      return NextResponse.json(
+        { error: 'Missing required fields: treatmentType, description' },
+        { status: 400 }
+      );
+    }
+
+    const treatment = await prisma.imsRiskTreatment.create({
+      data: {
+        riskId: id,
+        treatmentType,
+        description,
+        responsibleId: responsibleId ?? null,
+        targetDate: targetDate ? new Date(targetDate) : null,
+        status: status ?? 'PLANNED',
+      },
+      include: {
+        responsible: { select: { id: true, name: true } },
+      },
+    });
+
+    systemEventService.log({
+      eventType: 'IMS_RISK_TREATMENT_CREATED',
+      eventCategory: 'IMS',
+      userId: session.sub,
+      userName: session.name,
+      entityType: 'ImsRiskTreatment',
+      entityId: treatment.id,
+      entityName: risk.riskNumber,
+      summary: `Treatment created for risk ${risk.riskNumber}: ${treatmentType}`,
+      details: { riskId: id, treatmentType, status: treatment.status },
+    });
+
+    return NextResponse.json(treatment, { status: 201 });
+  } catch (error) {
+    logger.error({ error }, 'Failed to create IMS risk treatment');
+    return NextResponse.json({ error: 'Failed to create treatment' }, { status: 500 });
+  }
+}

--- a/src/app/api/ims/risks/dashboard/route.ts
+++ b/src/app/api/ims/risks/dashboard/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import prisma from '@/lib/db';
+import logger from '@/lib/logger';
+
+export async function GET() {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+    if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const now = new Date();
+
+    const [
+      allRisks,
+      allTreatments,
+      recentRisks,
+    ] = await Promise.all([
+      prisma.imsRisk.findMany({
+        where: { deletedAt: null },
+        select: {
+          id: true, type: true, status: true, category: true,
+          currentRiskRating: true, currentRiskLevel: true,
+          nextReviewDate: true, title: true, riskNumber: true,
+          updatedAt: true,
+        },
+      }),
+      prisma.imsRiskTreatment.findMany({
+        where: { status: { notIn: ['COMPLETED', 'CANCELLED'] }, targetDate: { lt: now } },
+        select: { id: true },
+      }),
+      prisma.imsRisk.findMany({
+        where: { deletedAt: null },
+        orderBy: { updatedAt: 'desc' },
+        take: 5,
+        select: { id: true, riskNumber: true, title: true, type: true, currentRiskRating: true, status: true, updatedAt: true },
+      }),
+    ]);
+
+    const risks = allRisks.filter(r => r.type === 'RISK');
+    const opportunities = allRisks.filter(r => r.type === 'OPPORTUNITY');
+
+    const byRating = { LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0 } as Record<string, number>;
+    risks.forEach(r => { byRating[r.currentRiskRating] = (byRating[r.currentRiskRating] ?? 0) + 1; });
+
+    const byCategory: Record<string, number> = {};
+    allRisks.forEach(r => { byCategory[r.category] = (byCategory[r.category] ?? 0) + 1; });
+
+    const byStatus: Record<string, number> = {};
+    allRisks.forEach(r => { byStatus[r.status] = (byStatus[r.status] ?? 0) + 1; });
+
+    const overdueReviews = allRisks.filter(
+      r => r.nextReviewDate && r.nextReviewDate < now && r.status !== 'CLOSED'
+    ).length;
+
+    const topRisks = [...risks]
+      .sort((a, b) => b.currentRiskLevel - a.currentRiskLevel)
+      .slice(0, 5);
+
+    return NextResponse.json({
+      totalRisks: risks.length,
+      totalOpportunities: opportunities.length,
+      byRating,
+      byCategory,
+      byStatus,
+      overdueReviews,
+      overdueTreatments: allTreatments.length,
+      recentActivity: recentRisks,
+      topRisks,
+    });
+  } catch (error) {
+    logger.error({ error }, 'Failed to fetch IMS risk dashboard');
+    return NextResponse.json({ error: 'Failed to fetch risk dashboard' }, { status: 500 });
+  }
+}

--- a/src/app/api/ims/risks/matrix/route.ts
+++ b/src/app/api/ims/risks/matrix/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import prisma from '@/lib/db';
+import logger from '@/lib/logger';
+
+function getRating(level: number): string {
+  if (level <= 4) return 'LOW';
+  if (level <= 9) return 'MEDIUM';
+  if (level <= 15) return 'HIGH';
+  return 'CRITICAL';
+}
+
+export async function GET(request: Request) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+    if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const { searchParams } = new URL(request.url);
+    const standard = searchParams.get('standard');
+
+    const risks = await prisma.imsRisk.findMany({
+      where: {
+        deletedAt: null,
+        status: { not: 'CLOSED' },
+        ...(standard
+          ? { applicableStandards: { path: '$', array_contains: standard } }
+          : {}),
+      },
+      select: {
+        id: true,
+        riskNumber: true,
+        title: true,
+        type: true,
+        status: true,
+        currentLikelihood: true,
+        currentSeverity: true,
+        currentRiskLevel: true,
+        currentRiskRating: true,
+      },
+    });
+
+    // Build 5x5 matrix
+    const cells = [];
+    for (let severity = 5; severity >= 1; severity--) {
+      for (let likelihood = 1; likelihood <= 5; likelihood++) {
+        const level = likelihood * severity;
+        const rating = getRating(level);
+        const cellRisks = risks.filter(
+          r => r.currentLikelihood === likelihood && r.currentSeverity === severity
+        );
+        cells.push({ likelihood, severity, riskLevel: level, riskRating: rating, risks: cellRisks });
+      }
+    }
+
+    const summary = {
+      LOW: risks.filter(r => r.currentRiskRating === 'LOW').length,
+      MEDIUM: risks.filter(r => r.currentRiskRating === 'MEDIUM').length,
+      HIGH: risks.filter(r => r.currentRiskRating === 'HIGH').length,
+      CRITICAL: risks.filter(r => r.currentRiskRating === 'CRITICAL').length,
+    };
+
+    return NextResponse.json({ cells, summary, total: risks.length });
+  } catch (error) {
+    logger.error({ error }, 'Failed to fetch risk matrix');
+    return NextResponse.json({ error: 'Failed to fetch risk matrix' }, { status: 500 });
+  }
+}

--- a/src/app/api/ims/risks/overdue-reviews/route.ts
+++ b/src/app/api/ims/risks/overdue-reviews/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import prisma from '@/lib/db';
+import logger from '@/lib/logger';
+
+export async function GET() {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+    if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const now = new Date();
+
+    const risks = await prisma.imsRisk.findMany({
+      where: {
+        deletedAt: null,
+        nextReviewDate: { lt: now },
+        status: { notIn: ['CLOSED'] },
+      },
+      include: {
+        owner: { select: { id: true, name: true } },
+        department: { select: { id: true, name: true } },
+      },
+      orderBy: { nextReviewDate: 'asc' },
+    });
+
+    const result = risks.map(r => ({
+      ...r,
+      overdueDays: r.nextReviewDate
+        ? Math.floor((now.getTime() - r.nextReviewDate.getTime()) / 86_400_000)
+        : null,
+    }));
+
+    return NextResponse.json(result);
+  } catch (error) {
+    logger.error({ error }, 'Failed to fetch overdue risk reviews');
+    return NextResponse.json({ error: 'Failed to fetch overdue reviews' }, { status: 500 });
+  }
+}

--- a/src/app/api/ims/risks/route.ts
+++ b/src/app/api/ims/risks/route.ts
@@ -1,0 +1,191 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/db';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import { logger } from '@/lib/logger';
+import { systemEventService } from '@/services/system-events.service';
+
+function computeRiskRating(riskLevel: number): string {
+  if (riskLevel <= 4) return 'LOW';
+  if (riskLevel <= 9) return 'MEDIUM';
+  if (riskLevel <= 15) return 'HIGH';
+  return 'CRITICAL';
+}
+
+async function generateRiskNumber(type: string): Promise<string> {
+  const prefix = type === 'OPPORTUNITY' ? 'OPP' : 'RISK';
+  const year = new Date().getFullYear();
+  const yearStart = new Date(`${year}-01-01T00:00:00.000Z`);
+  const yearEnd = new Date(`${year + 1}-01-01T00:00:00.000Z`);
+
+  const count = await prisma.imsRisk.count({
+    where: {
+      type,
+      createdAt: { gte: yearStart, lt: yearEnd },
+    },
+  });
+
+  const sequence = (count + 1).toString().padStart(3, '0');
+  return `${prefix}-${year}-${sequence}`;
+}
+
+export async function GET(request: Request) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const type = searchParams.get('type');
+    const category = searchParams.get('category');
+    const currentRiskRating = searchParams.get('currentRiskRating');
+    const status = searchParams.get('status');
+    const ownerId = searchParams.get('ownerId');
+    const standard = searchParams.get('standard');
+    const search = searchParams.get('search');
+
+    const where: Record<string, unknown> = { deletedAt: null };
+
+    if (type) where.type = type;
+    if (category) where.category = category;
+    if (currentRiskRating) where.currentRiskRating = currentRiskRating;
+    if (status) where.status = status;
+    if (ownerId) where.ownerId = ownerId;
+
+    if (search) {
+      where.title = { contains: search };
+    }
+
+    if (standard) {
+      where.applicableStandards = { path: '$', string_contains: standard };
+    }
+
+    const risks = await prisma.imsRisk.findMany({
+      where,
+      select: {
+        id: true,
+        riskNumber: true,
+        type: true,
+        title: true,
+        titleAr: true,
+        description: true,
+        source: true,
+        applicableStandards: true,
+        category: true,
+        status: true,
+        currentLikelihood: true,
+        currentSeverity: true,
+        currentRiskLevel: true,
+        currentRiskRating: true,
+        reviewFrequencyDays: true,
+        nextReviewDate: true,
+        lastReviewDate: true,
+        createdAt: true,
+        updatedAt: true,
+        owner: { select: { id: true, name: true } },
+        department: { select: { id: true, name: true } },
+        _count: {
+          select: {
+            assessments: true,
+            treatments: true,
+            hazards: true,
+          },
+        },
+      },
+      orderBy: [{ currentRiskLevel: 'desc' }, { updatedAt: 'desc' }],
+    });
+
+    return NextResponse.json(risks);
+  } catch (error) {
+    logger.error({ error }, 'Failed to fetch IMS risks');
+    return NextResponse.json({ error: 'Failed to fetch risks' }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const {
+      title,
+      titleAr,
+      category,
+      type,
+      description,
+      source,
+      applicableStandards,
+      ownerId,
+      departmentId,
+      reviewFrequencyDays,
+    } = body;
+
+    if (!title || !category || !type) {
+      return NextResponse.json(
+        { error: 'Missing required fields: title, category, type' },
+        { status: 400 }
+      );
+    }
+
+    const riskNumber = await generateRiskNumber(type);
+
+    const days = typeof reviewFrequencyDays === 'number' ? reviewFrequencyDays : 90;
+    const nextReviewDate = new Date();
+    nextReviewDate.setDate(nextReviewDate.getDate() + days);
+
+    const risk = await prisma.imsRisk.create({
+      data: {
+        riskNumber,
+        type,
+        title,
+        titleAr: titleAr ?? null,
+        category,
+        description: description ?? null,
+        source: source ?? null,
+        applicableStandards: applicableStandards ?? null,
+        ownerId: ownerId ?? null,
+        departmentId: departmentId ?? null,
+        reviewFrequencyDays: days,
+        nextReviewDate,
+        currentLikelihood: 1,
+        currentSeverity: 1,
+        currentRiskLevel: 1,
+        currentRiskRating: 'LOW',
+        status: 'OPEN',
+        createdById: session.sub,
+        updatedById: session.sub,
+      },
+      include: {
+        owner: { select: { id: true, name: true } },
+        department: { select: { id: true, name: true } },
+      },
+    });
+
+    systemEventService.log({
+      eventType: 'IMS_RISK_CREATED',
+      eventCategory: 'IMS',
+      userId: session.sub,
+      userName: session.name,
+      entityType: 'ImsRisk',
+      entityId: risk.id,
+      entityName: risk.riskNumber,
+      summary: `IMS risk ${risk.riskNumber} created: ${risk.title}`,
+      details: { riskNumber: risk.riskNumber, type, category, status: 'OPEN' },
+    });
+
+    return NextResponse.json(risk, { status: 201 });
+  } catch (error) {
+    logger.error({ error }, 'Failed to create IMS risk');
+    return NextResponse.json({ error: 'Failed to create risk' }, { status: 500 });
+  }
+}

--- a/src/app/changelog/_page-client.tsx
+++ b/src/app/changelog/_page-client.tsx
@@ -23,10 +23,48 @@ type ChangelogVersion = {
 // Version order: Most recent first
 const hardcodedVersions: ChangelogVersion[] = [
   {
+    version: '22.0.0',
+    date: 'April 27, 2026',
+    type: 'major',
+    status: 'current',
+    mainTitle: 'IMS — Integrated Management System',
+    highlights: [
+      'Full ISO 9001:2015, ISO 14001:2015, and ISO 45001:2018 integrated management system module.',
+      'Document Control with versioned revisions, controlled distribution, and acknowledgement tracking.',
+      'Risk Register with 5×5 likelihood × severity scoring, treatment tracking, and interactive risk matrix.',
+      'Clause Matrix for mapping documents to ISO standard clauses with Excel export.',
+      'Review Calendar for upcoming document review scheduling.',
+      'Seeded all ISO 9001/14001/45001 clauses (§4–10) and two workflow definitions.',
+    ],
+    changes: {
+      added: [
+        'IMS Document Control — registry, versioned revisions, controlled distribution, DCR lifecycle',
+        'IMS Clause Matrix — document-to-clause coverage map with Excel export (XLSX)',
+        'IMS Review Calendar — monthly document review timeline with overdue highlighting',
+        'IMS Risk Register — full risk and opportunity register (ISO 9001 §6.1, ISO 14001 §6.1, ISO 45001 §6.1)',
+        'IMS Risk Assessments — versioned per-risk assessments with inherent/residual rating',
+        'IMS Risk Treatments — action tracking with responsible, target date, effectiveness rating',
+        'IMS Hazard Identification — OHS hazard log with hierarchy of controls (ISO 45001)',
+        'IMS Risk Matrix — interactive 5×5 heat map with ISO standard filter and drill-down',
+        'IMS Treatments Tracker — cross-register treatment view with overdue detection',
+        'IMS Dashboard — aggregated KPIs: documents, risks, DCRs, overdue reviews',
+        'Workflow definitions: IMS_REVISION_APPROVAL (3-step) and IMS_CHANGE_REQUEST (2-step)',
+        '12 new Prisma models: ImsCategory, ImsDocument, ImsRevision, ImsDistribution, ImsDistributionRecipient, ImsChangeRequest, ImsClause, ImsClauseMapping, ImsRisk, ImsRiskAssessment, ImsRiskTreatment, ImsHazardIdentification',
+        '15 IMS RBAC permissions across Admin, CEO, Manager, Engineer, Document Controller roles',
+        'Sidebar IMS section with 8 navigation items',
+        'All ISO 9001/14001/45001 clauses §4–10 seeded with parent-child hierarchy',
+      ],
+      fixed: [],
+      changed: [
+        'Version bumped to 22.0.0',
+      ],
+    },
+  },
+  {
     version: '21.2.0',
     date: 'April 27, 2026',
     type: 'minor',
-    status: 'current',
+    status: 'previous',
     mainTitle: 'Business Development — UX Improvements & Archive CRUD',
     highlights: [
       'Company logos now fall back gracefully to initials when an image cannot be loaded; logos display larger in the company table.',

--- a/src/app/ims/_page-client.tsx
+++ b/src/app/ims/_page-client.tsx
@@ -1,0 +1,693 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import Link from 'next/link';
+import {
+  ShieldCheck,
+  FileText,
+  CalendarX,
+  GitPullRequest,
+  AlertTriangle,
+  RefreshCw,
+  ExternalLink,
+  Plus,
+  ClipboardList,
+  BookOpen,
+  CheckSquare,
+} from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Progress } from '@/components/ui/progress';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { cn } from '@/lib/utils';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type ClauseCoverage = {
+  standard: string;
+  totalClauses: number;
+  mappedClauses: number;
+  percentage: number;
+};
+
+type RecentActivity = {
+  id: string;
+  documentNumber: string;
+  title: string;
+  status: string;
+  updatedAt: string;
+  createdAt: string;
+};
+
+type DashboardData = {
+  totalDocuments: number;
+  byStatus: Record<string, number>;
+  overdueReviews: number;
+  pendingDCRs: number;
+  unacknowledgedDistributions: number;
+  clauseCoverage: ClauseCoverage[];
+  recentActivity: RecentActivity[];
+};
+
+type RiskDashboardData = {
+  totalRisks: number;
+  totalOpportunities: number;
+  byRating: Record<string, number>;
+  byCategory: Record<string, number>;
+  byStatus: Record<string, number>;
+  overdueReviews: number;
+  overdueTreatments: number;
+  recentActivity: Array<{
+    id: string;
+    riskNumber: string;
+    title: string;
+    type: string;
+    currentRiskRating: string;
+    status: string;
+    updatedAt: string;
+  }>;
+  topRisks: Array<{
+    id: string;
+    riskNumber: string;
+    title: string;
+    type: string;
+    currentRiskRating: string;
+    status: string;
+    updatedAt: string;
+  }>;
+};
+
+type OverdueDoc = {
+  id: string;
+  documentNumber: string;
+  title: string;
+  department: { id: string; name: string } | null;
+  nextReviewDate: string | null;
+  overdueDays: number | null;
+  status: string;
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function timeAgo(dateStr: string): string {
+  const date = new Date(dateStr);
+  const diffMs = Date.now() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60_000);
+  if (diffMins < 1) return 'just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  const diffHours = Math.floor(diffMins / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 30) return `${diffDays}d ago`;
+  const diffMonths = Math.floor(diffDays / 30);
+  return `${diffMonths}mo ago`;
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const map: Record<string, { label: string; className: string }> = {
+    DRAFT:        { label: 'Draft',        className: 'bg-gray-100 text-gray-700 border-gray-200' },
+    UNDER_REVIEW: { label: 'Under Review', className: 'bg-blue-100 text-blue-700 border-blue-200' },
+    APPROVED:     { label: 'Approved',     className: 'bg-green-100 text-green-700 border-green-200' },
+    OBSOLETE:     { label: 'Obsolete',     className: 'bg-red-100 text-red-700 border-red-200' },
+  };
+  const cfg = map[status] ?? { label: status, className: 'bg-gray-100 text-gray-600 border-gray-200' };
+  return (
+    <Badge variant="outline" className={cn('text-xs font-medium', cfg.className)}>
+      {cfg.label}
+    </Badge>
+  );
+}
+
+function RiskRatingBadge({ rating }: { rating: string }) {
+  const map: Record<string, { label: string; className: string }> = {
+    LOW:      { label: 'Low',      className: 'bg-green-100 text-green-700 border-green-200' },
+    MEDIUM:   { label: 'Medium',   className: 'bg-yellow-100 text-yellow-700 border-yellow-200' },
+    HIGH:     { label: 'High',     className: 'bg-orange-100 text-orange-700 border-orange-200' },
+    CRITICAL: { label: 'Critical', className: 'bg-red-100 text-red-700 border-red-200' },
+  };
+  const cfg = map[rating] ?? { label: rating, className: 'bg-gray-100 text-gray-600 border-gray-200' };
+  return (
+    <Badge variant="outline" className={cn('text-xs font-semibold', cfg.className)}>
+      {cfg.label}
+    </Badge>
+  );
+}
+
+// ─── Skeleton Loaders ─────────────────────────────────────────────────────────
+
+function KpiSkeleton() {
+  return (
+    <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+      {Array.from({ length: 4 }).map((_, i) => (
+        <Card key={i} className="border shadow-sm">
+          <CardContent className="p-5">
+            <Skeleton className="h-4 w-24 mb-3" />
+            <Skeleton className="h-8 w-12 mb-1" />
+            <Skeleton className="h-3 w-16" />
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+function TableSkeleton({ rows = 5 }: { rows?: number }) {
+  return (
+    <div className="space-y-2">
+      {Array.from({ length: rows }).map((_, i) => (
+        <Skeleton key={i} className="h-10 w-full rounded" />
+      ))}
+    </div>
+  );
+}
+
+// ─── KPI Card ─────────────────────────────────────────────────────────────────
+
+interface KpiCardProps {
+  label: string;
+  value: number | string;
+  sub?: string;
+  icon: React.ReactNode;
+  highlight?: boolean;
+  highlightColor?: string;
+}
+
+function KpiCard({ label, value, sub, icon, highlight, highlightColor }: KpiCardProps) {
+  return (
+    <Card className={cn(
+      'border shadow-sm transition-shadow hover:shadow-md',
+      highlight && highlightColor ? highlightColor : '',
+    )}>
+      <CardContent className="p-5">
+        <div className="flex items-start justify-between">
+          <div className="flex-1">
+            <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-1">
+              {label}
+            </p>
+            <p className={cn(
+              'text-3xl font-bold',
+              highlight && value !== 0 ? 'text-red-600' : 'text-foreground',
+            )}>
+              {value}
+            </p>
+            {sub && (
+              <p className="text-xs text-muted-foreground mt-1">{sub}</p>
+            )}
+          </div>
+          <div className="ml-3 flex-shrink-0">{icon}</div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Main Component ───────────────────────────────────────────────────────────
+
+export function ImsDashboardClient() {
+  const [dashboard, setDashboard] = useState<DashboardData | null>(null);
+  const [riskDashboard, setRiskDashboard] = useState<RiskDashboardData | null>(null);
+  const [overdueDocs, setOverdueDocs] = useState<OverdueDoc[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async (isRefresh = false) => {
+    if (isRefresh) setRefreshing(true);
+    else setLoading(true);
+    setError(null);
+
+    try {
+      const [dashRes, riskRes, overdueRes] = await Promise.all([
+        fetch('/api/ims/dashboard'),
+        fetch('/api/ims/risks/dashboard'),
+        fetch('/api/ims/documents?overdue=true&status=APPROVED'),
+      ]);
+
+      if (dashRes.ok) {
+        const data = await dashRes.json() as DashboardData;
+        setDashboard(data);
+      }
+      if (riskRes.ok) {
+        const data = await riskRes.json() as RiskDashboardData;
+        setRiskDashboard(data);
+      }
+      if (overdueRes.ok) {
+        const data = await overdueRes.json() as OverdueDoc[];
+        setOverdueDocs(Array.isArray(data) ? data.slice(0, 8) : []);
+      }
+    } catch {
+      setError('Failed to load dashboard data. Please try again.');
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  // ─── Standard display config ─────────────────────────────────────────────
+
+  const standardConfig: Record<string, { label: string; short: string; color: string; barClass: string }> = {
+    ISO_9001:  { label: 'ISO 9001:2015',  short: 'Quality',            color: 'text-green-700',  barClass: '[&>div]:bg-green-500' },
+    ISO_14001: { label: 'ISO 14001:2015', short: 'Environmental',      color: 'text-blue-700',   barClass: '[&>div]:bg-blue-500' },
+    ISO_45001: { label: 'ISO 45001:2018', short: 'OH&S',               color: 'text-purple-700', barClass: '[&>div]:bg-purple-500' },
+  };
+
+  // ─── Render ──────────────────────────────────────────────────────────────
+
+  return (
+    <div className="min-h-screen bg-background">
+      {/* ── Hero ── */}
+      <div className="relative overflow-hidden bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white">
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,_rgba(99,102,241,0.15),_transparent_60%)]" />
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_bottom_left,_rgba(16,185,129,0.1),_transparent_60%)]" />
+        <div className="relative px-6 py-10 md:px-10 md:py-14">
+          <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-6">
+            <div className="flex items-start gap-4">
+              <div className="p-3 rounded-2xl bg-white/10 backdrop-blur-sm border border-white/20 shadow-lg">
+                <ShieldCheck className="h-8 w-8 text-emerald-400" />
+              </div>
+              <div>
+                <div className="flex items-center gap-3 mb-2">
+                  <h1 className="text-2xl md:text-3xl font-bold tracking-tight">
+                    Integrated Management System
+                  </h1>
+                  <Badge className="bg-emerald-500/20 text-emerald-300 border border-emerald-400/30 text-xs font-semibold px-2 py-0.5">
+                    IMS Active
+                  </Badge>
+                </div>
+                <p className="text-slate-400 text-sm md:text-base font-medium tracking-widest uppercase">
+                  ISO 9001 · ISO 14001 · ISO 45001
+                </p>
+              </div>
+            </div>
+            <div className="flex items-center gap-3">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => fetchData(true)}
+                disabled={refreshing}
+                className="border-white/20 bg-white/10 text-white hover:bg-white/20 hover:text-white backdrop-blur-sm"
+              >
+                <RefreshCw className={cn('h-4 w-4 mr-2', refreshing && 'animate-spin')} />
+                Refresh
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="px-6 py-8 md:px-10 space-y-8 max-w-screen-2xl mx-auto">
+
+        {/* ── Error banner ── */}
+        {error && (
+          <div className="flex items-center gap-3 px-4 py-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">
+            <AlertTriangle className="h-4 w-4 flex-shrink-0" />
+            {error}
+          </div>
+        )}
+
+        {/* ── KPI Strip ── */}
+        {loading ? (
+          <KpiSkeleton />
+        ) : (
+          <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+            <KpiCard
+              label="Total Documents"
+              value={dashboard?.totalDocuments ?? 0}
+              sub={`${dashboard?.byStatus?.APPROVED ?? 0} approved`}
+              icon={
+                <div className="p-2.5 rounded-xl bg-blue-50 border border-blue-100">
+                  <FileText className="h-5 w-5 text-blue-600" />
+                </div>
+              }
+            />
+            <KpiCard
+              label="Overdue Reviews"
+              value={dashboard?.overdueReviews ?? 0}
+              sub={dashboard?.overdueReviews === 0 ? 'All up to date' : 'Require attention'}
+              icon={
+                <div className={cn(
+                  'p-2.5 rounded-xl border',
+                  (dashboard?.overdueReviews ?? 0) > 0
+                    ? 'bg-red-50 border-red-100'
+                    : 'bg-gray-50 border-gray-100',
+                )}>
+                  <CalendarX className={cn(
+                    'h-5 w-5',
+                    (dashboard?.overdueReviews ?? 0) > 0 ? 'text-red-600' : 'text-gray-400',
+                  )} />
+                </div>
+              }
+              highlight={(dashboard?.overdueReviews ?? 0) > 0}
+            />
+            <KpiCard
+              label="Pending DCRs"
+              value={dashboard?.pendingDCRs ?? 0}
+              sub="Awaiting action"
+              icon={
+                <div className={cn(
+                  'p-2.5 rounded-xl border',
+                  (dashboard?.pendingDCRs ?? 0) > 0
+                    ? 'bg-amber-50 border-amber-100'
+                    : 'bg-gray-50 border-gray-100',
+                )}>
+                  <GitPullRequest className={cn(
+                    'h-5 w-5',
+                    (dashboard?.pendingDCRs ?? 0) > 0 ? 'text-amber-600' : 'text-gray-400',
+                  )} />
+                </div>
+              }
+            />
+            <KpiCard
+              label="Open Risks"
+              value={riskDashboard?.totalRisks ?? 0}
+              sub={`${riskDashboard?.byRating?.CRITICAL ?? 0} critical`}
+              icon={
+                <div className={cn(
+                  'p-2.5 rounded-xl border',
+                  (riskDashboard?.byRating?.CRITICAL ?? 0) > 0
+                    ? 'bg-orange-50 border-orange-100'
+                    : 'bg-gray-50 border-gray-100',
+                )}>
+                  <AlertTriangle className={cn(
+                    'h-5 w-5',
+                    (riskDashboard?.byRating?.CRITICAL ?? 0) > 0 ? 'text-orange-600' : 'text-gray-400',
+                  )} />
+                </div>
+              }
+            />
+          </div>
+        )}
+
+        {/* ── Clause Coverage ── */}
+        <Card className="border shadow-sm">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base font-semibold flex items-center gap-2">
+              <BookOpen className="h-4 w-4 text-slate-500" />
+              Clause Coverage
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-5 pt-2">
+            {loading ? (
+              <div className="space-y-4">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <div key={i} className="space-y-2">
+                    <Skeleton className="h-4 w-40" />
+                    <Skeleton className="h-2.5 w-full rounded-full" />
+                  </div>
+                ))}
+              </div>
+            ) : (
+              (dashboard?.clauseCoverage ?? [] as ClauseCoverage[]).map((cov: ClauseCoverage) => {
+                const cfg = standardConfig[cov.standard];
+                if (!cfg) return null;
+                return (
+                  <div key={cov.standard} className="space-y-1.5">
+                    <div className="flex items-center justify-between text-sm">
+                      <div className="flex items-center gap-2">
+                        <span className={cn('font-semibold', cfg.color)}>{cfg.label}</span>
+                        <span className="text-muted-foreground text-xs">— {cfg.short}</span>
+                      </div>
+                      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                        <span className="font-medium text-foreground">{cov.mappedClauses}/{cov.totalClauses} clauses</span>
+                        <span className={cn(
+                          'font-bold text-sm',
+                          cov.percentage >= 80 ? 'text-green-600' :
+                          cov.percentage >= 50 ? 'text-amber-600' : 'text-red-600',
+                        )}>
+                          {cov.percentage}%
+                        </span>
+                      </div>
+                    </div>
+                    <Progress
+                      value={cov.percentage}
+                      className={cn('h-2.5 bg-gray-100', cfg.barClass)}
+                    />
+                  </div>
+                );
+              })
+            )}
+          </CardContent>
+        </Card>
+
+        {/* ── Two-column content ── */}
+        <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+
+          {/* ── Left column ── */}
+          <div className="space-y-6">
+
+            {/* Overdue Reviews table */}
+            <Card className="border shadow-sm">
+              <CardHeader className="pb-3">
+                <div className="flex items-center justify-between">
+                  <CardTitle className="text-base font-semibold flex items-center gap-2">
+                    <CalendarX className="h-4 w-4 text-red-500" />
+                    Overdue Reviews
+                  </CardTitle>
+                  <Link href="/ims/documents?overdue=true">
+                    <Button variant="ghost" size="sm" className="text-xs text-muted-foreground h-7 gap-1">
+                      View all <ExternalLink className="h-3 w-3" />
+                    </Button>
+                  </Link>
+                </div>
+              </CardHeader>
+              <CardContent className="pt-0">
+                {loading ? (
+                  <TableSkeleton rows={4} />
+                ) : overdueDocs.length === 0 ? (
+                  <div className="flex flex-col items-center justify-center py-10 text-center">
+                    <div className="p-3 rounded-full bg-green-50 mb-3">
+                      <CheckSquare className="h-6 w-6 text-green-500" />
+                    </div>
+                    <p className="text-sm font-medium text-green-700">No overdue reviews — great work!</p>
+                    <p className="text-xs text-muted-foreground mt-1">All documents are reviewed on schedule.</p>
+                  </div>
+                ) : (
+                  <div className="overflow-x-auto">
+                    <Table>
+                      <TableHeader>
+                        <TableRow className="border-b">
+                          <TableHead className="text-xs font-semibold text-muted-foreground">Doc #</TableHead>
+                          <TableHead className="text-xs font-semibold text-muted-foreground">Title</TableHead>
+                          <TableHead className="text-xs font-semibold text-muted-foreground hidden md:table-cell">Department</TableHead>
+                          <TableHead className="text-xs font-semibold text-muted-foreground text-right">Overdue</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {overdueDocs.map((doc: OverdueDoc) => (
+                          <TableRow key={doc.id} className="hover:bg-muted/50">
+                            <TableCell className="font-mono text-xs text-muted-foreground whitespace-nowrap">
+                              {doc.documentNumber}
+                            </TableCell>
+                            <TableCell className="text-sm font-medium max-w-[160px] truncate">
+                              <Link
+                                href={`/ims/documents/${doc.id}`}
+                                className="hover:underline text-foreground"
+                              >
+                                {doc.title}
+                              </Link>
+                            </TableCell>
+                            <TableCell className="text-xs text-muted-foreground hidden md:table-cell">
+                              {doc.department?.name ?? '—'}
+                            </TableCell>
+                            <TableCell className="text-right">
+                              <Badge className="bg-red-100 text-red-700 border border-red-200 text-xs font-semibold">
+                                {doc.overdueDays != null ? `${doc.overdueDays}d` : '—'}
+                              </Badge>
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+
+            {/* My Approvals */}
+            <Card className="border shadow-sm">
+              <CardHeader className="pb-3">
+                <CardTitle className="text-base font-semibold flex items-center gap-2">
+                  <ClipboardList className="h-4 w-4 text-blue-500" />
+                  My Approvals
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="pt-0">
+                <p className="text-sm text-muted-foreground mb-4">
+                  View and action documents awaiting your approval in the workflow queue.
+                </p>
+                <Link href="/workflow/my-approvals">
+                  <Button className="w-full gap-2" variant="outline">
+                    <ExternalLink className="h-4 w-4" />
+                    Go to My Approvals
+                  </Button>
+                </Link>
+              </CardContent>
+            </Card>
+
+          </div>
+
+          {/* ── Right column ── */}
+          <div className="space-y-6">
+
+            {/* Risk Overview */}
+            <Card className="border shadow-sm">
+              <CardHeader className="pb-3">
+                <div className="flex items-center justify-between">
+                  <CardTitle className="text-base font-semibold flex items-center gap-2">
+                    <AlertTriangle className="h-4 w-4 text-orange-500" />
+                    Risk Overview
+                  </CardTitle>
+                  <Link href="/ims/risks">
+                    <Button variant="ghost" size="sm" className="text-xs text-muted-foreground h-7 gap-1">
+                      Risk Register <ExternalLink className="h-3 w-3" />
+                    </Button>
+                  </Link>
+                </div>
+              </CardHeader>
+              <CardContent className="pt-0">
+                {loading ? (
+                  <div className="flex gap-3">
+                    {Array.from({ length: 4 }).map((_, i) => (
+                      <Skeleton key={i} className="h-10 flex-1 rounded-lg" />
+                    ))}
+                  </div>
+                ) : (
+                  <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                    {(['LOW', 'MEDIUM', 'HIGH', 'CRITICAL'] as const).map((rating) => {
+                      const count = riskDashboard?.byRating[rating] ?? 0;
+                      const styles: Record<string, { bg: string; border: string; text: string; dot: string }> = {
+                        LOW:      { bg: 'bg-green-50',  border: 'border-green-200',  text: 'text-green-800',  dot: 'bg-green-500' },
+                        MEDIUM:   { bg: 'bg-yellow-50', border: 'border-yellow-200', text: 'text-yellow-800', dot: 'bg-yellow-500' },
+                        HIGH:     { bg: 'bg-orange-50', border: 'border-orange-200', text: 'text-orange-800', dot: 'bg-orange-500' },
+                        CRITICAL: { bg: 'bg-red-50',    border: 'border-red-200',    text: 'text-red-800',    dot: 'bg-red-500' },
+                      };
+                      const s = styles[rating];
+                      return (
+                        <div
+                          key={rating}
+                          className={cn(
+                            'flex flex-col items-center justify-center p-3 rounded-xl border',
+                            s.bg, s.border,
+                          )}
+                        >
+                          <div className={cn('w-2 h-2 rounded-full mb-2', s.dot)} />
+                          <span className={cn('text-2xl font-bold', s.text)}>{count}</span>
+                          <span className={cn('text-xs font-medium mt-0.5 capitalize', s.text)}>
+                            {rating.charAt(0) + rating.slice(1).toLowerCase()}
+                          </span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+
+            {/* Recent Activity */}
+            <Card className="border shadow-sm">
+              <CardHeader className="pb-3">
+                <CardTitle className="text-base font-semibold flex items-center gap-2">
+                  <FileText className="h-4 w-4 text-slate-500" />
+                  Recent Activity
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="pt-0">
+                {loading ? (
+                  <div className="space-y-3">
+                    {Array.from({ length: 5 }).map((_, i) => (
+                      <div key={i} className="flex items-center gap-3">
+                        <Skeleton className="h-8 w-8 rounded-lg flex-shrink-0" />
+                        <div className="flex-1 space-y-1">
+                          <Skeleton className="h-3.5 w-3/4" />
+                          <Skeleton className="h-3 w-1/3" />
+                        </div>
+                        <Skeleton className="h-5 w-16 rounded" />
+                      </div>
+                    ))}
+                  </div>
+                ) : (dashboard?.recentActivity ?? []).length === 0 ? (
+                  <p className="text-sm text-muted-foreground text-center py-6">No recent activity.</p>
+                ) : (
+                  <div className="space-y-2">
+                    {(dashboard?.recentActivity ?? [] as RecentActivity[]).map((doc: RecentActivity) => (
+                      <div
+                        key={doc.id}
+                        className="flex items-center gap-3 p-2 rounded-lg hover:bg-muted/50 transition-colors"
+                      >
+                        <div className="p-1.5 rounded-lg bg-slate-100 flex-shrink-0">
+                          <FileText className="h-3.5 w-3.5 text-slate-500" />
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <Link
+                            href={`/ims/documents/${doc.id}`}
+                            className="text-sm font-medium truncate block hover:underline text-foreground"
+                          >
+                            {doc.title}
+                          </Link>
+                          <p className="text-xs text-muted-foreground font-mono">{doc.documentNumber}</p>
+                        </div>
+                        <div className="flex flex-col items-end gap-1 flex-shrink-0">
+                          <StatusBadge status={doc.status} />
+                          <span className="text-xs text-muted-foreground">{timeAgo(doc.updatedAt)}</span>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+
+            {/* Quick Links */}
+            <Card className="border shadow-sm">
+              <CardHeader className="pb-3">
+                <CardTitle className="text-base font-semibold">Quick Links</CardTitle>
+              </CardHeader>
+              <CardContent className="pt-0">
+                <div className="grid grid-cols-2 gap-2">
+                  <Link href="/ims/documents/new">
+                    <Button variant="outline" className="w-full gap-2 h-10 justify-start text-sm">
+                      <Plus className="h-4 w-4 text-blue-500" />
+                      New Document
+                    </Button>
+                  </Link>
+                  <Link href="/ims/change-requests/new">
+                    <Button variant="outline" className="w-full gap-2 h-10 justify-start text-sm">
+                      <GitPullRequest className="h-4 w-4 text-amber-500" />
+                      New DCR
+                    </Button>
+                  </Link>
+                  <Link href="/ims/risks">
+                    <Button variant="outline" className="w-full gap-2 h-10 justify-start text-sm">
+                      <AlertTriangle className="h-4 w-4 text-orange-500" />
+                      Risk Register
+                    </Button>
+                  </Link>
+                  <Link href="/ims/clause-matrix">
+                    <Button variant="outline" className="w-full gap-2 h-10 justify-start text-sm">
+                      <BookOpen className="h-4 w-4 text-purple-500" />
+                      Clause Matrix
+                    </Button>
+                  </Link>
+                </div>
+              </CardContent>
+            </Card>
+
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/ims/change-requests/_page-client.tsx
+++ b/src/app/ims/change-requests/_page-client.tsx
@@ -1,0 +1,623 @@
+'use client';
+
+import React, { useState, useEffect, useCallback } from 'react';
+import Link from 'next/link';
+import {
+  GitPullRequest,
+  Plus,
+  Search,
+  X,
+  AlertTriangle,
+} from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Skeleton } from '@/components/ui/skeleton';
+import { cn } from '@/lib/utils';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type DcrDocument = {
+  id: string;
+  documentNumber: string;
+  title: string;
+};
+
+type ChangeRequest = {
+  id: string;
+  dcrNumber: string;
+  title: string;
+  description: string | null;
+  reason: string | null;
+  status: string;
+  priority: string;
+  createdAt: string;
+  document: DcrDocument | null;
+  requestedBy: { id: string; name: string } | null;
+};
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const STATUS_OPTIONS = [
+  { value: 'ALL', label: 'All Statuses' },
+  { value: 'SUBMITTED', label: 'Submitted' },
+  { value: 'UNDER_REVIEW', label: 'Under Review' },
+  { value: 'APPROVED', label: 'Approved' },
+  { value: 'REJECTED', label: 'Rejected' },
+  { value: 'IMPLEMENTED', label: 'Implemented' },
+  { value: 'WITHDRAWN', label: 'Withdrawn' },
+];
+
+const PRIORITY_OPTIONS = [
+  { value: 'ALL', label: 'All Priorities' },
+  { value: 'LOW', label: 'Low' },
+  { value: 'MEDIUM', label: 'Medium' },
+  { value: 'HIGH', label: 'High' },
+  { value: 'CRITICAL', label: 'Critical' },
+];
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function timeAgo(dateStr: string): string {
+  const date = new Date(dateStr);
+  const diffMs = Date.now() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60_000);
+  if (diffMins < 1) return 'just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  const diffHours = Math.floor(diffMins / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 30) return `${diffDays}d ago`;
+  const diffMonths = Math.floor(diffDays / 30);
+  return `${diffMonths}mo ago`;
+}
+
+function statusBadge(status: string): { label: string; className: string } {
+  const map: Record<string, { label: string; className: string }> = {
+    SUBMITTED:    { label: 'Submitted',    className: 'bg-blue-100 text-blue-700 border-blue-200' },
+    UNDER_REVIEW: { label: 'Under Review', className: 'bg-amber-100 text-amber-700 border-amber-200' },
+    APPROVED:     { label: 'Approved',     className: 'bg-green-100 text-green-700 border-green-200' },
+    REJECTED:     { label: 'Rejected',     className: 'bg-red-100 text-red-700 border-red-200' },
+    IMPLEMENTED:  { label: 'Implemented',  className: 'bg-emerald-100 text-emerald-700 border-emerald-200' },
+    WITHDRAWN:    { label: 'Withdrawn',    className: 'bg-gray-100 text-gray-600 border-gray-200' },
+  };
+  return map[status] ?? { label: status, className: 'bg-gray-100 text-gray-600 border-gray-200' };
+}
+
+function priorityBadge(priority: string): { label: string; className: string } {
+  const map: Record<string, { label: string; className: string }> = {
+    LOW:      { label: 'Low',      className: 'bg-green-100 text-green-700 border-green-200' },
+    MEDIUM:   { label: 'Medium',   className: 'bg-yellow-100 text-yellow-700 border-yellow-200' },
+    HIGH:     { label: 'High',     className: 'bg-orange-100 text-orange-700 border-orange-200' },
+    CRITICAL: { label: 'Critical', className: 'bg-red-100 text-red-700 border-red-200' },
+  };
+  return map[priority] ?? { label: priority, className: 'bg-gray-100 text-gray-600 border-gray-200' };
+}
+
+// ─── Skeleton ─────────────────────────────────────────────────────────────────
+
+function TableSkeleton() {
+  return (
+    <div className="space-y-2">
+      {Array.from({ length: 8 }).map((_, i) => (
+        <Skeleton key={i} className="h-12 w-full rounded" />
+      ))}
+    </div>
+  );
+}
+
+// ─── Empty State ──────────────────────────────────────────────────────────────
+
+function EmptyState() {
+  return (
+    <div className="flex flex-col items-center justify-center py-20 text-center">
+      <div className="p-5 rounded-2xl bg-slate-100 dark:bg-slate-800 mb-4">
+        <GitPullRequest className="h-10 w-10 text-slate-400" />
+      </div>
+      <h3 className="text-base font-semibold text-foreground mb-1">No change requests found</h3>
+      <p className="text-sm text-muted-foreground max-w-xs">
+        Try adjusting your filters or create a new DCR.
+      </p>
+    </div>
+  );
+}
+
+// ─── New DCR Dialog ───────────────────────────────────────────────────────────
+
+interface NewDcrDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onCreated: () => void;
+}
+
+function NewDcrDialog({ open, onClose, onCreated }: NewDcrDialogProps) {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [reason, setReason] = useState('');
+  const [priority, setPriority] = useState('MEDIUM');
+  const [documentId, setDocumentId] = useState('NONE');
+  const [documents, setDocuments] = useState<DcrDocument[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    fetch('/api/ims/documents')
+      .then((r) => r.json())
+      .then((data: unknown) => {
+        if (Array.isArray(data)) {
+          setDocuments(
+            (data as Array<{ id: string; documentNumber: string; title: string }>).map(
+              (d: { id: string; documentNumber: string; title: string }) => ({
+                id: d.id,
+                documentNumber: d.documentNumber,
+                title: d.title,
+              })
+            )
+          );
+        }
+      })
+      .catch(() => {});
+  }, [open]);
+
+  function resetForm() {
+    setTitle('');
+    setDescription('');
+    setReason('');
+    setPriority('MEDIUM');
+    setDocumentId('NONE');
+    setError(null);
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!title.trim()) {
+      setError('Title is required.');
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/ims/change-requests', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: title.trim(),
+          description: description.trim() || null,
+          reason: reason.trim() || null,
+          priority,
+          documentId: documentId === 'NONE' ? null : documentId,
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json() as { error?: string };
+        throw new Error(body.error ?? 'Failed to create DCR');
+      }
+      resetForm();
+      onCreated();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create DCR');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function handleClose() {
+    resetForm();
+    onClose();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(v: boolean) => { if (!v) handleClose(); }}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <GitPullRequest className="h-5 w-5 text-amber-500" />
+            New Change Request
+          </DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4 mt-1">
+          {error && (
+            <div className="flex items-center gap-2 px-3 py-2 bg-red-50 border border-red-200 rounded-md text-red-700 text-sm">
+              <AlertTriangle className="h-4 w-4 flex-shrink-0" />
+              {error}
+            </div>
+          )}
+
+          {/* Title */}
+          <div className="space-y-1.5">
+            <Label htmlFor="dcr-title" className="text-sm font-medium">
+              Title <span className="text-red-500">*</span>
+            </Label>
+            <Input
+              id="dcr-title"
+              placeholder="Brief description of the requested change"
+              value={title}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setTitle(e.target.value)}
+              required
+              className="h-9 text-sm"
+            />
+          </div>
+
+          {/* Description */}
+          <div className="space-y-1.5">
+            <Label htmlFor="dcr-description" className="text-sm font-medium">Description</Label>
+            <Textarea
+              id="dcr-description"
+              placeholder="Detailed description of the change…"
+              value={description}
+              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setDescription(e.target.value)}
+              rows={3}
+              className="text-sm resize-none"
+            />
+          </div>
+
+          {/* Reason */}
+          <div className="space-y-1.5">
+            <Label htmlFor="dcr-reason" className="text-sm font-medium">Reason / Justification</Label>
+            <Textarea
+              id="dcr-reason"
+              placeholder="Why is this change needed?"
+              value={reason}
+              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setReason(e.target.value)}
+              rows={2}
+              className="text-sm resize-none"
+            />
+          </div>
+
+          {/* Priority + Document in a row */}
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <Label className="text-sm font-medium">Priority</Label>
+              <Select value={priority} onValueChange={setPriority}>
+                <SelectTrigger className="h-9 text-sm">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {PRIORITY_OPTIONS.filter((o) => o.value !== 'ALL').map((opt) => (
+                    <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1.5">
+              <Label className="text-sm font-medium">Related Document</Label>
+              <Select value={documentId} onValueChange={setDocumentId}>
+                <SelectTrigger className="h-9 text-sm">
+                  <SelectValue placeholder="None" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="NONE">None</SelectItem>
+                  {documents.map((doc: DcrDocument) => (
+                    <SelectItem key={doc.id} value={doc.id}>
+                      <span className="font-mono text-xs mr-1.5 text-muted-foreground">
+                        {doc.documentNumber}
+                      </span>
+                      {doc.title}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <DialogFooter className="pt-2">
+            <Button type="button" variant="outline" onClick={handleClose} disabled={submitting}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitting} className="bg-blue-600 hover:bg-blue-700 text-white border-0">
+              {submitting ? 'Creating…' : 'Create DCR'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ─── Main Component ───────────────────────────────────────────────────────────
+
+export function ImsDcrClient() {
+  const [changeRequests, setChangeRequests] = useState<ChangeRequest[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  // Filters
+  const [search, setSearch] = useState('');
+  const [status, setStatus] = useState('ALL');
+  const [priority, setPriority] = useState('ALL');
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      if (search) params.set('search', search);
+      if (status !== 'ALL') params.set('status', status);
+      if (priority !== 'ALL') params.set('priority', priority);
+
+      const res = await fetch(`/api/ims/change-requests?${params.toString()}`);
+      if (!res.ok) throw new Error('Failed to fetch change requests');
+      const data = await res.json() as ChangeRequest[];
+      setChangeRequests(Array.isArray(data) ? data : []);
+    } catch {
+      setError('Failed to load change requests. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  }, [search, status, priority]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  function clearFilters() {
+    setSearch('');
+    setStatus('ALL');
+    setPriority('ALL');
+  }
+
+  const hasActiveFilters = search !== '' || status !== 'ALL' || priority !== 'ALL';
+
+  return (
+    <div className="min-h-screen bg-background">
+      {/* ── Hero ── */}
+      <div className="relative overflow-hidden bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white">
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,_rgba(99,102,241,0.15),_transparent_60%)]" />
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_bottom_left,_rgba(16,185,129,0.1),_transparent_60%)]" />
+        <div className="relative px-6 py-10 md:px-10 md:py-12">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+            <div className="flex items-start gap-4">
+              <div className="p-3 rounded-2xl bg-white/10 backdrop-blur-sm border border-white/20 shadow-lg">
+                <GitPullRequest className="h-7 w-7 text-amber-400" />
+              </div>
+              <div>
+                <div className="flex items-center gap-3 mb-1">
+                  <h1 className="text-2xl md:text-3xl font-bold tracking-tight">
+                    Change Requests
+                  </h1>
+                  {!loading && (
+                    <Badge className="bg-white/10 text-white border border-white/20 text-xs font-semibold px-2 py-0.5">
+                      {changeRequests.length} DCR{changeRequests.length !== 1 ? 's' : ''}
+                    </Badge>
+                  )}
+                </div>
+                <p className="text-slate-400 text-sm font-medium">
+                  IMS · Document Change Requests
+                </p>
+              </div>
+            </div>
+            <Button
+              size="sm"
+              onClick={() => setDialogOpen(true)}
+              className="bg-amber-500 hover:bg-amber-600 text-white border-0 gap-2 shadow-sm"
+            >
+              <Plus className="h-4 w-4" />
+              New DCR
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <div className="px-6 py-6 md:px-10 space-y-5 max-w-screen-2xl mx-auto">
+
+        {/* ── Error banner ── */}
+        {error && (
+          <div className="flex items-center gap-3 px-4 py-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">
+            <AlertTriangle className="h-4 w-4 flex-shrink-0" />
+            {error}
+          </div>
+        )}
+
+        {/* ── Filters ── */}
+        <Card className="border shadow-sm">
+          <CardContent className="p-4">
+            <div className="flex flex-wrap gap-3 items-center">
+              {/* Search */}
+              <div className="relative flex-1 min-w-[200px] max-w-xs">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                <Input
+                  placeholder="Search title or DCR number…"
+                  value={search}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearch(e.target.value)}
+                  className="pl-9 h-9 text-sm"
+                />
+              </div>
+
+              {/* Status */}
+              <Select value={status} onValueChange={setStatus}>
+                <SelectTrigger className="h-9 text-sm w-[180px]">
+                  <SelectValue placeholder="All Statuses" />
+                </SelectTrigger>
+                <SelectContent>
+                  {STATUS_OPTIONS.map((opt) => (
+                    <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              {/* Priority */}
+              <Select value={priority} onValueChange={setPriority}>
+                <SelectTrigger className="h-9 text-sm w-[160px]">
+                  <SelectValue placeholder="All Priorities" />
+                </SelectTrigger>
+                <SelectContent>
+                  {PRIORITY_OPTIONS.map((opt) => (
+                    <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              {/* Clear */}
+              {hasActiveFilters && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={clearFilters}
+                  className="h-9 gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+                >
+                  <X className="h-3.5 w-3.5" />
+                  Clear
+                </Button>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* ── Table ── */}
+        <Card className="border shadow-sm">
+          <CardContent className="p-0">
+            {loading ? (
+              <div className="p-6">
+                <TableSkeleton />
+              </div>
+            ) : changeRequests.length === 0 ? (
+              <EmptyState />
+            ) : (
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow className="border-b bg-muted/30">
+                      <TableHead className="text-xs font-semibold text-muted-foreground uppercase tracking-wide whitespace-nowrap pl-4">
+                        DCR #
+                      </TableHead>
+                      <TableHead className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                        Title
+                      </TableHead>
+                      <TableHead className="text-xs font-semibold text-muted-foreground uppercase tracking-wide whitespace-nowrap hidden lg:table-cell">
+                        Document
+                      </TableHead>
+                      <TableHead className="text-xs font-semibold text-muted-foreground uppercase tracking-wide whitespace-nowrap">
+                        Priority
+                      </TableHead>
+                      <TableHead className="text-xs font-semibold text-muted-foreground uppercase tracking-wide whitespace-nowrap">
+                        Status
+                      </TableHead>
+                      <TableHead className="text-xs font-semibold text-muted-foreground uppercase tracking-wide whitespace-nowrap hidden md:table-cell">
+                        Requested By
+                      </TableHead>
+                      <TableHead className="text-xs font-semibold text-muted-foreground uppercase tracking-wide whitespace-nowrap hidden md:table-cell">
+                        Created
+                      </TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {changeRequests.map((dcr: ChangeRequest) => {
+                      const sBadge = statusBadge(dcr.status);
+                      const pBadge = priorityBadge(dcr.priority);
+                      return (
+                        <TableRow key={dcr.id} className="hover:bg-muted/40 transition-colors">
+                          {/* DCR Number */}
+                          <TableCell className="pl-4 whitespace-nowrap">
+                            <span className="font-mono text-xs font-bold text-slate-700 dark:text-slate-300">
+                              {dcr.dcrNumber}
+                            </span>
+                          </TableCell>
+
+                          {/* Title */}
+                          <TableCell className="max-w-[260px]">
+                            <span className="text-sm font-medium text-foreground line-clamp-1">
+                              {dcr.title}
+                            </span>
+                            {dcr.description && (
+                              <p className="text-xs text-muted-foreground line-clamp-1 mt-0.5">
+                                {dcr.description}
+                              </p>
+                            )}
+                          </TableCell>
+
+                          {/* Document */}
+                          <TableCell className="hidden lg:table-cell whitespace-nowrap">
+                            {dcr.document ? (
+                              <Link
+                                href={`/ims/documents/${dcr.document.id}`}
+                                className="font-mono text-xs text-blue-600 hover:underline dark:text-blue-400"
+                              >
+                                {dcr.document.documentNumber}
+                              </Link>
+                            ) : (
+                              <span className="text-muted-foreground text-xs">—</span>
+                            )}
+                          </TableCell>
+
+                          {/* Priority */}
+                          <TableCell className="whitespace-nowrap">
+                            <Badge
+                              variant="outline"
+                              className={cn('text-xs font-semibold', pBadge.className)}
+                            >
+                              {pBadge.label}
+                            </Badge>
+                          </TableCell>
+
+                          {/* Status */}
+                          <TableCell className="whitespace-nowrap">
+                            <Badge
+                              variant="outline"
+                              className={cn('text-xs font-medium', sBadge.className)}
+                            >
+                              {sBadge.label}
+                            </Badge>
+                          </TableCell>
+
+                          {/* Requested By */}
+                          <TableCell className="hidden md:table-cell whitespace-nowrap">
+                            <span className="text-xs text-muted-foreground">
+                              {dcr.requestedBy?.name ?? '—'}
+                            </span>
+                          </TableCell>
+
+                          {/* Created */}
+                          <TableCell className="hidden md:table-cell whitespace-nowrap">
+                            <span className="text-xs text-muted-foreground">
+                              {timeAgo(dcr.createdAt)}
+                            </span>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+      </div>
+
+      {/* ── New DCR Dialog ── */}
+      <NewDcrDialog
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        onCreated={fetchData}
+      />
+    </div>
+  );
+}

--- a/src/app/ims/change-requests/page.tsx
+++ b/src/app/ims/change-requests/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from 'next';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { verifySession } from '@/lib/jwt';
+import { ImsDcrClient } from './_page-client';
+
+export const metadata: Metadata = {
+  title: 'Change Requests | IMS | OTS',
+};
+
+export const dynamic = 'force-dynamic';
+
+export default async function ImsChangeRequestsPage() {
+  const store = await cookies();
+  const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+  const session = token ? verifySession(token) : null;
+
+  if (!session) redirect('/login');
+
+  return <ImsDcrClient />;
+}

--- a/src/app/ims/clause-matrix/_page-client.tsx
+++ b/src/app/ims/clause-matrix/_page-client.tsx
@@ -1,0 +1,569 @@
+'use client';
+
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import {
+  BookOpen,
+  AlertTriangle,
+  Download,
+  FileText,
+} from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Progress } from '@/components/ui/progress';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { cn } from '@/lib/utils';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type Clause = {
+  id: string;
+  standard: string;
+  clause: string;
+  title: string;
+  level: number;
+  parentId: string | null;
+};
+
+type MatrixDocument = {
+  id: string;
+  documentNumber: string;
+  title: string;
+  status: string;
+  clauseIds: string[];
+};
+
+type Coverage = {
+  standard: string;
+  totalClauses: number;
+  mappedClauses: number;
+  percentage: number;
+};
+
+type MatrixData = {
+  clauses: Record<string, Clause[]>;
+  documents: MatrixDocument[];
+  coverage: Coverage[];
+};
+
+type Standard = 'ISO_9001' | 'ISO_14001' | 'ISO_45001';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const STANDARDS: { key: Standard; label: string; color: string }[] = [
+  { key: 'ISO_9001',  label: 'ISO 9001',  color: 'text-green-700' },
+  { key: 'ISO_14001', label: 'ISO 14001', color: 'text-blue-700' },
+  { key: 'ISO_45001', label: 'ISO 45001', color: 'text-purple-700' },
+];
+
+const STANDARD_LABELS: Record<Standard, string> = {
+  ISO_9001:  'ISO 9001:2015',
+  ISO_14001: 'ISO 14001:2015',
+  ISO_45001: 'ISO 45001:2018',
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function topLevelClause(clauseStr: string): string {
+  return clauseStr.split('.')[0];
+}
+
+function getCoverageBarClass(standard: Standard): string {
+  if (standard === 'ISO_9001')  return '[&>div]:bg-green-500';
+  if (standard === 'ISO_14001') return '[&>div]:bg-blue-500';
+  return '[&>div]:bg-purple-500';
+}
+
+// ─── Skeletons ────────────────────────────────────────────────────────────────
+
+function MatrixSkeleton() {
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-2">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Skeleton key={i} className="h-9 w-28 rounded" />
+        ))}
+      </div>
+      <Skeleton className="h-6 w-64" />
+      <div className="overflow-x-auto">
+        <div className="grid gap-1" style={{ gridTemplateColumns: 'minmax(180px,auto) repeat(5, 60px)' }}>
+          {Array.from({ length: 30 }).map((_, i) => (
+            <Skeleton key={i} className="h-8 w-full rounded" />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Cell Component ───────────────────────────────────────────────────────────
+
+interface CellProps {
+  mapped: boolean;
+  toggling: boolean;
+  onToggle: () => void;
+}
+
+function MatrixCell({ mapped, toggling, onToggle }: CellProps) {
+  return (
+    <button
+      onClick={onToggle}
+      disabled={toggling}
+      className={cn(
+        'w-full h-8 flex items-center justify-center rounded transition-colors text-sm border',
+        mapped
+          ? 'bg-green-100 border-green-300 text-green-700 hover:bg-green-200'
+          : 'bg-muted/30 border-transparent text-transparent hover:bg-muted/60 hover:text-muted-foreground',
+        toggling && 'opacity-50 cursor-wait',
+      )}
+      title={mapped ? 'Click to remove mapping' : 'Click to add mapping'}
+    >
+      {mapped ? '✓' : '·'}
+    </button>
+  );
+}
+
+// ─── Standard Grid ────────────────────────────────────────────────────────────
+
+interface StandardGridProps {
+  standardKey: Standard;
+  clauses: Clause[];
+  documents: MatrixDocument[];
+  onToggle: (docId: string, clauseId: string, mapped: boolean) => Promise<void>;
+  togglingKey: string | null;
+}
+
+function StandardGrid({ standardKey, clauses, documents, onToggle, togglingKey }: StandardGridProps) {
+  // Hooks must be called unconditionally before any early returns
+  const clausesByTop = useMemo(() => {
+    const map: Record<string, Clause[]> = {};
+    for (const c of clauses) {
+      const top = topLevelClause(c.clause);
+      if (!map[top]) map[top] = [];
+      map[top].push(c);
+    }
+    return map;
+  }, [clauses]);
+
+  const docClauseIds = useMemo(() => {
+    return new Map<string, Set<string>>(
+      documents.map((d: MatrixDocument) => [d.id, new Set(d.clauseIds)])
+    );
+  }, [documents]);
+
+  const topLevelKeys = useMemo(() => {
+    return Array.from(new Set(clauses.map((c: Clause) => topLevelClause(c.clause)))).sort((a, b) => {
+      const na = parseFloat(a);
+      const nb = parseFloat(b);
+      if (!isNaN(na) && !isNaN(nb)) return na - nb;
+      return a.localeCompare(b);
+    });
+  }, [clauses]);
+
+  if (documents.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-center">
+        <div className="p-4 rounded-2xl bg-slate-100 dark:bg-slate-800 mb-4">
+          <FileText className="h-8 w-8 text-slate-400" />
+        </div>
+        <h3 className="text-base font-semibold text-foreground mb-1">No documents in the registry yet</h3>
+        <p className="text-sm text-muted-foreground max-w-xs">
+          Add documents first, then map them to standard clauses here.
+        </p>
+      </div>
+    );
+  }
+
+  if (clauses.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-center">
+        <p className="text-sm text-muted-foreground">No clauses found for this standard.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse text-sm" style={{ minWidth: `${180 + documents.length * 68}px` }}>
+        <thead>
+          <tr className="border-b bg-muted/30">
+            <th className="text-left text-xs font-semibold text-muted-foreground uppercase tracking-wide px-3 py-2 min-w-[180px] sticky left-0 bg-muted/30 z-10">
+              Clause
+            </th>
+            {documents.map((doc) => (
+              <th
+                key={doc.id}
+                className="text-center px-1 py-2 min-w-[60px] max-w-[80px]"
+                title={`${doc.documentNumber} — ${doc.title}`}
+              >
+                <span className="font-mono text-xs text-muted-foreground truncate block max-w-[72px] mx-auto">
+                  {doc.documentNumber}
+                </span>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {topLevelKeys.map((topKey) => {
+            const group = clausesByTop[topKey] ?? [];
+
+            // Check if this top-level section has zero mapped documents across ALL its clauses
+            const hasAnyMapping = documents.some((doc) => {
+              const docSet = docClauseIds.get(doc.id);
+              if (!docSet) return false;
+              return group.some((c) => docSet.has(c.id));
+            });
+
+            return group.map((clause, idx) => {
+              const isFirstInGroup = idx === 0;
+              const isGap = isFirstInGroup && !hasAnyMapping;
+
+              return (
+                <tr
+                  key={clause.id}
+                  className={cn(
+                    'border-b last:border-b-0 hover:bg-muted/20 transition-colors',
+                    clause.level === 1 && 'bg-muted/10',
+                  )}
+                >
+                  {/* Clause label */}
+                  <td
+                    className={cn(
+                      'px-3 py-1.5 sticky left-0 z-10 bg-background',
+                      clause.level === 1 && 'bg-muted/10',
+                    )}
+                  >
+                    <div className="flex items-center gap-2">
+                      {isGap && isFirstInGroup && (
+                        <span
+                          className="inline-block w-2 h-2 rounded-full bg-red-500 flex-shrink-0"
+                          title="Gap: no documents mapped to this clause section"
+                        />
+                      )}
+                      <span
+                        className={cn(
+                          'font-mono text-xs',
+                          clause.level === 1 ? 'font-bold text-foreground' : 'text-muted-foreground',
+                          isGap && isFirstInGroup && 'text-red-700',
+                          clause.level > 1 && `pl-${Math.min((clause.level - 1) * 3, 12)}`,
+                        )}
+                        style={{ paddingLeft: clause.level > 1 ? `${(clause.level - 1) * 12}px` : undefined }}
+                      >
+                        {clause.clause}
+                      </span>
+                      <span
+                        className={cn(
+                          'text-xs truncate max-w-[200px]',
+                          clause.level === 1 ? 'font-semibold text-foreground' : 'text-muted-foreground',
+                          isGap && isFirstInGroup && 'text-red-700',
+                        )}
+                        title={clause.title}
+                      >
+                        {clause.title}
+                      </span>
+                    </div>
+                  </td>
+
+                  {/* Document cells */}
+                  {documents.map((doc) => {
+                    const docSet = docClauseIds.get(doc.id);
+                    const mapped = docSet ? docSet.has(clause.id) : false;
+                    const key = `${doc.id}-${clause.id}`;
+                    return (
+                      <td key={doc.id} className="px-1 py-1">
+                        <MatrixCell
+                          mapped={mapped}
+                          toggling={togglingKey === key}
+                          onToggle={() => onToggle(doc.id, clause.id, mapped)}
+                        />
+                      </td>
+                    );
+                  })}
+                </tr>
+              );
+            });
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ─── Main Component ───────────────────────────────────────────────────────────
+
+export function ImsClauseMatrixClient() {
+  const [data, setData] = useState<MatrixData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<Standard>('ISO_9001');
+  const [togglingKey, setTogglingKey] = useState<string | null>(null);
+  const [exporting, setExporting] = useState(false);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/ims/clause-matrix');
+      if (!res.ok) throw new Error('Failed to fetch clause matrix');
+      const json = await res.json() as MatrixData;
+      setData(json);
+    } catch {
+      setError('Failed to load clause matrix. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  async function handleToggle(docId: string, clauseId: string, mapped: boolean) {
+    const key = `${docId}-${clauseId}`;
+    setTogglingKey(key);
+    try {
+      if (mapped) {
+        const res = await fetch(`/api/ims/clause-matrix/${docId}/${clauseId}`, { method: 'DELETE' });
+        if (!res.ok) throw new Error('Failed to remove mapping');
+      } else {
+        const res = await fetch(`/api/ims/clause-matrix/${docId}/${clauseId}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        });
+        if (!res.ok && res.status !== 409) throw new Error('Failed to add mapping');
+      }
+      // Optimistic update
+      setData((prev: MatrixData | null) => {
+        if (!prev) return prev;
+        const updated = prev.documents.map((doc: MatrixDocument) => {
+          if (doc.id !== docId) return doc;
+          const newClauseIds = mapped
+            ? doc.clauseIds.filter((id: string) => id !== clauseId)
+            : [...doc.clauseIds, clauseId];
+          return { ...doc, clauseIds: newClauseIds };
+        });
+        // Recalculate coverage
+        const coverage = prev.coverage.map((cov: Coverage) => {
+          const stdClauses: Clause[] = prev.clauses[cov.standard] ?? [];
+          const clauseIdSet = new Set(stdClauses.map((c: Clause) => c.id));
+          const mappedSet = new Set<string>();
+          for (const doc of updated) {
+            for (const cid of doc.clauseIds) {
+              if (clauseIdSet.has(cid)) mappedSet.add(cid);
+            }
+          }
+          const mappedClauses = mappedSet.size;
+          const percentage = cov.totalClauses > 0 ? Math.round((mappedClauses / cov.totalClauses) * 100) : 0;
+          return { ...cov, mappedClauses, percentage };
+        });
+        return { ...prev, documents: updated, coverage };
+      });
+    } catch {
+      // On error, refetch to get accurate state
+      await fetchData();
+    } finally {
+      setTogglingKey(null);
+    }
+  }
+
+  async function handleExport() {
+    if (!data) return;
+    setExporting(true);
+    try {
+      const XLSX = await import('xlsx');
+      const clauses = data.clauses[activeTab] ?? [];
+      const documents = data.documents;
+
+      const docClauseIds = new Map<string, Set<string>>(
+        documents.map((d: MatrixDocument) => [d.id, new Set(d.clauseIds)])
+      );
+
+      // Header row: Clause | Title | doc1 | doc2 ...
+      const header = ['Clause', 'Title', ...documents.map((d: MatrixDocument) => d.documentNumber)];
+
+      const rows = clauses.map((clause: Clause) => {
+        const cells = documents.map((doc: MatrixDocument) => {
+          const docSet = docClauseIds.get(doc.id);
+          return docSet?.has(clause.id) ? '✓' : '';
+        });
+        return [clause.clause, clause.title, ...cells];
+      });
+
+      const ws = XLSX.utils.aoa_to_sheet([header, ...rows]);
+      const wb = XLSX.utils.book_new();
+      XLSX.utils.book_append_sheet(wb, ws, STANDARD_LABELS[activeTab]);
+      XLSX.writeFile(wb, `clause-matrix-${activeTab.toLowerCase().replace('_', '-')}.xlsx`);
+    } catch {
+      // Silent — export failure non-critical
+    } finally {
+      setExporting(false);
+    }
+  }
+
+  // Coverage for active tab
+  const activeCoverage = data?.coverage.find((c: Coverage) => c.standard === activeTab);
+  const activeCoverageBarClass = getCoverageBarClass(activeTab);
+
+  return (
+    <div className="min-h-screen bg-background">
+      {/* ── Hero ── */}
+      <div className="relative overflow-hidden bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white">
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,_rgba(99,102,241,0.15),_transparent_60%)]" />
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_bottom_left,_rgba(16,185,129,0.1),_transparent_60%)]" />
+        <div className="relative px-6 py-10 md:px-10 md:py-12">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+            <div className="flex items-start gap-4">
+              <div className="p-3 rounded-2xl bg-white/10 backdrop-blur-sm border border-white/20 shadow-lg">
+                <BookOpen className="h-7 w-7 text-purple-400" />
+              </div>
+              <div>
+                <div className="flex items-center gap-3 mb-1">
+                  <h1 className="text-2xl md:text-3xl font-bold tracking-tight">
+                    Clause Matrix
+                  </h1>
+                  <Badge className="bg-white/10 text-white border border-white/20 text-xs font-semibold px-2 py-0.5">
+                    ISO Coverage
+                  </Badge>
+                </div>
+                <p className="text-slate-400 text-sm font-medium">
+                  IMS · Standard Clause to Document Mapping
+                </p>
+              </div>
+            </div>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={handleExport}
+              disabled={exporting || loading || !data}
+              className="border-white/20 bg-white/10 text-white hover:bg-white/20 hover:text-white backdrop-blur-sm gap-2"
+            >
+              <Download className="h-4 w-4" />
+              {exporting ? 'Exporting…' : 'Export to Excel'}
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <div className="px-6 py-6 md:px-10 space-y-5 max-w-screen-2xl mx-auto">
+
+        {/* ── Error banner ── */}
+        {error && (
+          <div className="flex items-center gap-3 px-4 py-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">
+            <AlertTriangle className="h-4 w-4 flex-shrink-0" />
+            {error}
+          </div>
+        )}
+
+        {loading ? (
+          <Card className="border shadow-sm">
+            <CardContent className="p-6">
+              <MatrixSkeleton />
+            </CardContent>
+          </Card>
+        ) : (
+          <Tabs value={activeTab} onValueChange={(v: string) => setActiveTab(v as Standard)}>
+            {/* ── Tabs ── */}
+            <TabsList className="mb-5">
+              {STANDARDS.map((std) => {
+                const cov = data?.coverage.find((c: Coverage) => c.standard === std.key);
+                return (
+                  <TabsTrigger key={std.key} value={std.key} className="gap-2">
+                    {std.label}
+                    {cov && (
+                      <span className="text-xs font-medium opacity-70">
+                        {cov.percentage}%
+                      </span>
+                    )}
+                  </TabsTrigger>
+                );
+              })}
+            </TabsList>
+
+            {STANDARDS.map((std) => {
+              const clauses = data?.clauses[std.key] ?? [];
+              const documents = data?.documents ?? [];
+              const cov = data?.coverage.find((c) => c.standard === std.key);
+
+              return (
+                <TabsContent key={std.key} value={std.key} className="space-y-4">
+
+                  {/* ── Summary bar ── */}
+                  {cov && (
+                    <Card className="border shadow-sm">
+                      <CardContent className="p-4">
+                        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+                          <div className="space-y-1.5 flex-1">
+                            <div className="flex items-center justify-between text-sm">
+                              <span className="font-medium text-foreground">
+                                {cov.mappedClauses} of {cov.totalClauses} clauses covered
+                              </span>
+                              <span className={cn(
+                                'font-bold text-base',
+                                cov.percentage >= 80 ? 'text-green-600' :
+                                cov.percentage >= 50 ? 'text-amber-600' : 'text-red-600',
+                              )}>
+                                {cov.percentage}%
+                              </span>
+                            </div>
+                            <Progress
+                              value={cov.percentage}
+                              className={cn('h-2.5 bg-gray-100', std.key === activeTab ? activeCoverageBarClass : '')}
+                            />
+                          </div>
+                          {cov.percentage < 100 && (
+                            <div className="flex items-center gap-1.5 text-xs text-muted-foreground sm:ml-4 flex-shrink-0">
+                              <span className="w-2 h-2 rounded-full bg-red-500 inline-block" />
+                              {cov.totalClauses - cov.mappedClauses} gap{cov.totalClauses - cov.mappedClauses !== 1 ? 's' : ''}
+                            </div>
+                          )}
+                        </div>
+                      </CardContent>
+                    </Card>
+                  )}
+
+                  {/* ── Gap legend ── */}
+                  {(data?.documents.length ?? 0) > 0 && (
+                    <div className="flex items-center gap-4 text-xs text-muted-foreground px-1">
+                      <span className="flex items-center gap-1.5">
+                        <span className="w-3 h-3 rounded bg-green-100 border border-green-300 flex items-center justify-center text-green-700 font-bold text-[10px]">✓</span>
+                        Mapped
+                      </span>
+                      <span className="flex items-center gap-1.5">
+                        <span className="w-3 h-3 rounded bg-muted/30 border border-transparent" />
+                        Not mapped
+                      </span>
+                      <span className="flex items-center gap-1.5">
+                        <span className="w-2 h-2 rounded-full bg-red-500 inline-block" />
+                        Gap — no documents mapped to this clause section
+                      </span>
+                    </div>
+                  )}
+
+                  {/* ── Grid ── */}
+                  <Card className="border shadow-sm">
+                    <CardHeader className="pb-2 border-b">
+                      <CardTitle className="text-sm font-semibold text-muted-foreground">
+                        {STANDARD_LABELS[std.key]} — {clauses.length} clauses · {documents.length} documents
+                      </CardTitle>
+                    </CardHeader>
+                    <CardContent className="p-0">
+                      <StandardGrid
+                        standardKey={std.key}
+                        clauses={clauses}
+                        documents={documents}
+                        onToggle={handleToggle}
+                        togglingKey={togglingKey}
+                      />
+                    </CardContent>
+                  </Card>
+                </TabsContent>
+              );
+            })}
+          </Tabs>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/ims/clause-matrix/_page-client.tsx
+++ b/src/app/ims/clause-matrix/_page-client.tsx
@@ -205,17 +205,17 @@ function StandardGrid({ standardKey, clauses, documents, onToggle, togglingKey }
           </tr>
         </thead>
         <tbody>
-          {topLevelKeys.map((topKey) => {
-            const group = clausesByTop[topKey] ?? [];
+          {topLevelKeys.map((topKey: string) => {
+            const group: Clause[] = clausesByTop[topKey] ?? [];
 
             // Check if this top-level section has zero mapped documents across ALL its clauses
-            const hasAnyMapping = documents.some((doc) => {
+            const hasAnyMapping = documents.some((doc: MatrixDocument) => {
               const docSet = docClauseIds.get(doc.id);
               if (!docSet) return false;
-              return group.some((c) => docSet.has(c.id));
+              return group.some((c: Clause) => docSet.has(c.id));
             });
 
-            return group.map((clause, idx) => {
+            return group.map((clause: Clause, idx: number) => {
               const isFirstInGroup = idx === 0;
               const isGap = isFirstInGroup && !hasAnyMapping;
 
@@ -393,7 +393,7 @@ export function ImsClauseMatrixClient() {
 
       const ws = XLSX.utils.aoa_to_sheet([header, ...rows]);
       const wb = XLSX.utils.book_new();
-      XLSX.utils.book_append_sheet(wb, ws, STANDARD_LABELS[activeTab]);
+      XLSX.utils.book_append_sheet(wb, ws, STANDARD_LABELS[activeTab as Standard]);
       XLSX.writeFile(wb, `clause-matrix-${activeTab.toLowerCase().replace('_', '-')}.xlsx`);
     } catch {
       // Silent — export failure non-critical
@@ -482,9 +482,9 @@ export function ImsClauseMatrixClient() {
             </TabsList>
 
             {STANDARDS.map((std) => {
-              const clauses = data?.clauses[std.key] ?? [];
-              const documents = data?.documents ?? [];
-              const cov = data?.coverage.find((c) => c.standard === std.key);
+              const clauses: Clause[] = data?.clauses[std.key] ?? [];
+              const documents: MatrixDocument[] = data?.documents ?? [];
+              const cov = data?.coverage.find((c: Coverage) => c.standard === std.key);
 
               return (
                 <TabsContent key={std.key} value={std.key} className="space-y-4">

--- a/src/app/ims/clause-matrix/page.tsx
+++ b/src/app/ims/clause-matrix/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from 'next';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { verifySession } from '@/lib/jwt';
+import { ImsClauseMatrixClient } from './_page-client';
+
+export const metadata: Metadata = {
+  title: 'Clause Matrix | IMS | OTS',
+};
+
+export const dynamic = 'force-dynamic';
+
+export default async function ImsClauseMatrixPage() {
+  const store = await cookies();
+  const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+  const session = token ? verifySession(token) : null;
+
+  if (!session) redirect('/login');
+
+  return <ImsClauseMatrixClient />;
+}

--- a/src/app/ims/documents/[id]/_page-client.tsx
+++ b/src/app/ims/documents/[id]/_page-client.tsx
@@ -1,0 +1,489 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import {
+  ArrowLeft, FileText, Clock, User, Building2, Shield, GitBranch,
+  CheckCircle, AlertTriangle, Plus, Eye, Download, RefreshCw,
+  Calendar, Tag, Layers, Send,
+} from 'lucide-react';
+
+type Revision = {
+  id: string; version: string; changeType: string; changeDescription: string | null;
+  status: string; effectiveDate: string | null; fileUrl: string | null;
+  preparedBy: { id: string; name: string } | null;
+  reviewedBy: { id: string; name: string } | null;
+  approvedBy: { id: string; name: string } | null;
+  createdAt: string;
+};
+
+type Recipient = {
+  id: string; userId: string; acknowledgedAt: string | null; acknowledgeMethod: string | null;
+  user: { id: string; name: string };
+};
+
+type Distribution = {
+  id: string; issuedAt: string; notes: string | null; issuedById: string | null;
+  recipients: Recipient[];
+};
+
+type DCR = {
+  id: string; dcrNumber: string; title: string; status: string; priority: string;
+  requestedBy: { id: string; name: string }; createdAt: string;
+};
+
+type Document = {
+  id: string; documentNumber: string; title: string; titleAr: string | null;
+  status: string; currentVersion: string; scope: string | null; purpose: string | null;
+  confidentiality: string; site: string | null; reviewFrequencyDays: number;
+  lastReviewDate: string | null; nextReviewDate: string | null; issuedAt: string | null;
+  fileUrl: string | null; applicableStandards: string[] | null;
+  category: { id: string; name: string; code: string; level: number };
+  department: { id: string; name: string } | null;
+  owner: { id: string; name: string } | null;
+  reviewer: { id: string; name: string } | null;
+  revisions: Revision[];
+  distributions: Distribution[];
+  clauseMappings: { id: string; clause: { standard: string; clause: string; title: string } }[];
+};
+
+function statusBadge(status: string) {
+  const map: Record<string, string> = {
+    DRAFT: 'bg-gray-100 text-gray-700 border-gray-200',
+    UNDER_REVIEW: 'bg-blue-100 text-blue-700 border-blue-200',
+    APPROVED: 'bg-green-100 text-green-700 border-green-200',
+    OBSOLETE: 'bg-red-100 text-red-700 border-red-200',
+    SUPERSEDED: 'bg-slate-100 text-slate-700 border-slate-200',
+  };
+  return <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border ${map[status] ?? 'bg-gray-100 text-gray-700'}`}>{status.replace('_', ' ')}</span>;
+}
+
+function changeTypeBadge(t: string) {
+  const map: Record<string, string> = { MAJOR: 'bg-red-100 text-red-700', MINOR: 'bg-blue-100 text-blue-700', ADMINISTRATIVE: 'bg-gray-100 text-gray-600' };
+  return <span className={`text-xs font-medium px-2 py-0.5 rounded ${map[t] ?? 'bg-gray-100 text-gray-600'}`}>{t}</span>;
+}
+
+function priorityBadge(p: string) {
+  const map: Record<string, string> = { LOW: 'bg-green-100 text-green-700', MEDIUM: 'bg-yellow-100 text-yellow-700', HIGH: 'bg-orange-100 text-orange-700', CRITICAL: 'bg-red-100 text-red-700' };
+  return <span className={`text-xs font-medium px-2 py-0.5 rounded ${map[p] ?? 'bg-gray-100 text-gray-600'}`}>{p}</span>;
+}
+
+function standardBadge(s: string) {
+  const map: Record<string, string> = { ISO_9001: 'bg-green-100 text-green-700', ISO_14001: 'bg-blue-100 text-blue-700', ISO_45001: 'bg-purple-100 text-purple-700' };
+  const label: Record<string, string> = { ISO_9001: '9001', ISO_14001: '14001', ISO_45001: '45001' };
+  return <span key={s} className={`text-xs font-semibold px-2 py-0.5 rounded-full ${map[s] ?? 'bg-gray-100 text-gray-600'}`}>ISO {label[s] ?? s}</span>;
+}
+
+function relTime(d: string) {
+  const diff = Date.now() - new Date(d).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+export default function ImsDocumentDetailClient({ documentId }: { documentId: string }) {
+  const router = useRouter();
+  const [doc, setDoc] = useState<Document | null>(null);
+  const [dcrs, setDcrs] = useState<DCR[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+
+  // Revision dialog
+  const [revDialog, setRevDialog] = useState(false);
+  const [revForm, setRevForm] = useState({ version: '', changeType: 'MINOR', changeDescription: '', fileUrl: '' });
+  const [revSaving, setRevSaving] = useState(false);
+
+  // Distribution dialog
+  const [distDialog, setDistDialog] = useState(false);
+  const [allUsers, setAllUsers] = useState<{ id: string; name: string }[]>([]);
+  const [selectedUsers, setSelectedUsers] = useState<string[]>([]);
+  const [distNotes, setDistNotes] = useState('');
+  const [distSaving, setDistSaving] = useState(false);
+
+  const fetchDoc = useCallback(async () => {
+    const [docRes, dcrRes, meRes] = await Promise.all([
+      fetch(`/api/ims/documents/${documentId}`),
+      fetch(`/api/ims/change-requests?documentId=${documentId}`),
+      fetch('/api/auth/me').catch(() => null),
+    ]);
+    if (docRes.ok) setDoc(await docRes.json());
+    if (dcrRes.ok) setDcrs(await dcrRes.json());
+    if (meRes?.ok) { const me = await meRes.json(); setCurrentUserId(me.id); }
+    setLoading(false);
+  }, [documentId]);
+
+  useEffect(() => { fetchDoc(); }, [fetchDoc]);
+
+  const saveRevision = async () => {
+    setRevSaving(true);
+    await fetch(`/api/ims/documents/${documentId}/revisions`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(revForm),
+    });
+    setRevDialog(false);
+    setRevForm({ version: '', changeType: 'MINOR', changeDescription: '', fileUrl: '' });
+    fetchDoc();
+    setRevSaving(false);
+  };
+
+  const saveDistribution = async () => {
+    setDistSaving(true);
+    await fetch(`/api/ims/documents/${documentId}/distributions`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userIds: selectedUsers, notes: distNotes }),
+    });
+    setDistDialog(false);
+    setSelectedUsers([]);
+    setDistNotes('');
+    fetchDoc();
+    setDistSaving(false);
+  };
+
+  const acknowledge = async (distId: string) => {
+    await fetch(`/api/ims/documents/${documentId}/distributions/${distId}/acknowledge`, { method: 'POST' });
+    fetchDoc();
+  };
+
+  const openDistDialog = async () => {
+    const res = await fetch('/api/users');
+    if (res.ok) { const users = await res.json(); setAllUsers(users); }
+    setDistDialog(true);
+  };
+
+  if (loading) {
+    return (
+      <div className="p-6 space-y-4">
+        {[...Array(3)].map((_, i) => (
+          <div key={i} className="h-24 bg-muted animate-pulse rounded-xl" />
+        ))}
+      </div>
+    );
+  }
+
+  if (!doc) {
+    return (
+      <div className="p-6 text-center">
+        <FileText className="mx-auto size-12 text-muted-foreground mb-3" />
+        <p className="text-muted-foreground">Document not found.</p>
+        <Button variant="outline" className="mt-4" onClick={() => router.push('/ims/documents')}>Back to Registry</Button>
+      </div>
+    );
+  }
+
+  const overdue = doc.nextReviewDate && new Date(doc.nextReviewDate) < new Date();
+  const overdueDays = overdue && doc.nextReviewDate
+    ? Math.floor((Date.now() - new Date(doc.nextReviewDate).getTime()) / 86_400_000)
+    : 0;
+
+  return (
+    <div className="p-6 space-y-6">
+      {/* Header */}
+      <div className="flex items-center gap-4">
+        <Button variant="ghost" size="sm" onClick={() => router.push('/ims/documents')}>
+          <ArrowLeft className="size-4 mr-1" /> Document Registry
+        </Button>
+      </div>
+
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <div className="flex items-center gap-3 mb-1">
+            <span className="font-mono text-sm font-semibold text-muted-foreground">{doc.documentNumber}</span>
+            {statusBadge(doc.status)}
+            <Badge variant="outline">v{doc.currentVersion}</Badge>
+            {overdue && <Badge className="bg-red-100 text-red-700 border-red-200">{overdueDays}d overdue</Badge>}
+          </div>
+          <h1 className="text-2xl font-bold text-foreground">{doc.title}</h1>
+          {doc.titleAr && <p className="text-sm text-muted-foreground mt-0.5" dir="rtl">{doc.titleAr}</p>}
+          <div className="flex items-center gap-2 mt-2 flex-wrap">
+            {(doc.applicableStandards ?? []).map(s => standardBadge(s))}
+          </div>
+        </div>
+        <div className="flex gap-2 shrink-0">
+          {doc.fileUrl && (
+            <Button variant="outline" size="sm" asChild>
+              <a href={doc.fileUrl} target="_blank" rel="noreferrer"><Download className="size-4 mr-1" />Download</a>
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <Tabs defaultValue="overview">
+        <TabsList>
+          <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="revisions">Revisions ({doc.revisions.length})</TabsTrigger>
+          <TabsTrigger value="distribution">Distribution ({doc.distributions.length})</TabsTrigger>
+          <TabsTrigger value="changes">Change History ({dcrs.length})</TabsTrigger>
+        </TabsList>
+
+        {/* ── Overview ── */}
+        <TabsContent value="overview" className="mt-4">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <Card>
+              <CardHeader><CardTitle className="text-base">Document Metadata</CardTitle></CardHeader>
+              <CardContent>
+                <dl className="grid grid-cols-2 gap-x-4 gap-y-3 text-sm">
+                  {[
+                    ['Category', doc.category ? `${doc.category.code} — ${doc.category.name}` : '—'],
+                    ['Department', doc.department?.name ?? '—'],
+                    ['Owner', doc.owner?.name ?? '—'],
+                    ['Reviewer', doc.reviewer?.name ?? '—'],
+                    ['Site', doc.site ?? '—'],
+                    ['Confidentiality', doc.confidentiality],
+                    ['Review Frequency', `${doc.reviewFrequencyDays} days`],
+                    ['Last Review', doc.lastReviewDate ? new Date(doc.lastReviewDate).toLocaleDateString() : '—'],
+                    ['Next Review', doc.nextReviewDate ? new Date(doc.nextReviewDate).toLocaleDateString() : '—'],
+                    ['Issued', doc.issuedAt ? new Date(doc.issuedAt).toLocaleDateString() : '—'],
+                  ].map(([label, value]) => (
+                    <>
+                      <dt className="text-muted-foreground font-medium">{label}</dt>
+                      <dd className={label === 'Next Review' && overdue ? 'text-red-600 font-semibold' : ''}>{value}</dd>
+                    </>
+                  ))}
+                </dl>
+
+                {/* Clause mappings */}
+                {doc.clauseMappings.length > 0 && (
+                  <div className="mt-4 pt-4 border-t">
+                    <p className="text-xs font-semibold text-muted-foreground mb-2">ISO Clause Mappings ({doc.clauseMappings.length})</p>
+                    <div className="flex flex-wrap gap-1">
+                      {doc.clauseMappings.map(m => (
+                        <span key={m.id} className="text-xs bg-muted px-2 py-0.5 rounded font-mono">
+                          {m.clause.standard.replace('ISO_', '')} §{m.clause.clause}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+
+            <div className="space-y-4">
+              {doc.purpose && (
+                <Card>
+                  <CardHeader><CardTitle className="text-base">Purpose</CardTitle></CardHeader>
+                  <CardContent><p className="text-sm text-muted-foreground whitespace-pre-wrap">{doc.purpose}</p></CardContent>
+                </Card>
+              )}
+              {doc.scope && (
+                <Card>
+                  <CardHeader><CardTitle className="text-base">Scope</CardTitle></CardHeader>
+                  <CardContent><p className="text-sm text-muted-foreground whitespace-pre-wrap">{doc.scope}</p></CardContent>
+                </Card>
+              )}
+              <Card>
+                <CardHeader><CardTitle className="text-base flex items-center gap-2"><GitBranch className="size-4" />Workflow</CardTitle></CardHeader>
+                <CardContent>
+                  <Button variant="outline" size="sm" asChild className="w-full">
+                    <Link href="/workflow/my-approvals"><CheckCircle className="size-4 mr-2" />View My Approvals</Link>
+                  </Button>
+                </CardContent>
+              </Card>
+            </div>
+          </div>
+        </TabsContent>
+
+        {/* ── Revisions ── */}
+        <TabsContent value="revisions" className="mt-4">
+          <div className="flex justify-between items-center mb-4">
+            <h3 className="font-semibold">Revision History</h3>
+            <Button size="sm" onClick={() => setRevDialog(true)}><Plus className="size-4 mr-1" />Create Revision</Button>
+          </div>
+          {doc.revisions.length === 0 ? (
+            <div className="text-center py-12 text-muted-foreground">
+              <Clock className="mx-auto size-10 mb-2 opacity-40" />
+              <p>No revisions yet.</p>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {[...doc.revisions].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()).map(rev => (
+                <Card key={rev.id}>
+                  <CardContent className="pt-4">
+                    <div className="flex items-start justify-between gap-4">
+                      <div className="flex items-center gap-2">
+                        <Badge variant="outline" className="font-mono">v{rev.version}</Badge>
+                        {changeTypeBadge(rev.changeType)}
+                        {statusBadge(rev.status)}
+                      </div>
+                      <span className="text-xs text-muted-foreground shrink-0">{relTime(rev.createdAt)}</span>
+                    </div>
+                    {rev.changeDescription && <p className="text-sm text-muted-foreground mt-2">{rev.changeDescription}</p>}
+                    <div className="flex flex-wrap gap-x-4 gap-y-1 mt-2 text-xs text-muted-foreground">
+                      {rev.preparedBy && <span>Prepared: {rev.preparedBy.name}</span>}
+                      {rev.reviewedBy && <span>Reviewed: {rev.reviewedBy.name}</span>}
+                      {rev.approvedBy && <span>Approved: {rev.approvedBy.name}</span>}
+                      {rev.effectiveDate && <span>Effective: {new Date(rev.effectiveDate).toLocaleDateString()}</span>}
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+        </TabsContent>
+
+        {/* ── Distribution ── */}
+        <TabsContent value="distribution" className="mt-4">
+          <div className="flex justify-between items-center mb-4">
+            <h3 className="font-semibold">Distribution Records</h3>
+            <Button size="sm" onClick={openDistDialog}><Send className="size-4 mr-1" />Issue Distribution</Button>
+          </div>
+          {doc.distributions.length === 0 ? (
+            <div className="text-center py-12 text-muted-foreground">
+              <Send className="mx-auto size-10 mb-2 opacity-40" />
+              <p>No distributions issued yet.</p>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {[...doc.distributions].sort((a, b) => new Date(b.issuedAt).getTime() - new Date(a.issuedAt).getTime()).map(dist => (
+                <Card key={dist.id}>
+                  <CardHeader className="pb-2">
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm font-medium">Issued {new Date(dist.issuedAt).toLocaleDateString()}</span>
+                      <span className="text-xs text-muted-foreground">{dist.recipients.length} recipients</span>
+                    </div>
+                    {dist.notes && <p className="text-xs text-muted-foreground">{dist.notes}</p>}
+                  </CardHeader>
+                  <CardContent>
+                    <div className="space-y-2">
+                      {dist.recipients.map(r => (
+                        <div key={r.id} className="flex items-center justify-between text-sm">
+                          <div className="flex items-center gap-2">
+                            <User className="size-3.5 text-muted-foreground" />
+                            <span>{r.user.name}</span>
+                          </div>
+                          {r.acknowledgedAt ? (
+                            <span className="flex items-center gap-1 text-green-600 text-xs">
+                              <CheckCircle className="size-3" />{new Date(r.acknowledgedAt).toLocaleDateString()}
+                            </span>
+                          ) : r.userId === currentUserId ? (
+                            <Button size="sm" variant="outline" className="h-6 text-xs" onClick={() => acknowledge(dist.id)}>
+                              Acknowledge
+                            </Button>
+                          ) : (
+                            <Badge className="bg-amber-100 text-amber-700 border-amber-200 text-xs">Pending</Badge>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+        </TabsContent>
+
+        {/* ── Change History ── */}
+        <TabsContent value="changes" className="mt-4">
+          <h3 className="font-semibold mb-4">Linked Change Requests</h3>
+          {dcrs.length === 0 ? (
+            <div className="text-center py-12 text-muted-foreground">
+              <AlertTriangle className="mx-auto size-10 mb-2 opacity-40" />
+              <p>No change requests linked to this document.</p>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {dcrs.map(dcr => (
+                <Link key={dcr.id} href={`/ims/change-requests/${dcr.id}`}>
+                  <Card className="hover:bg-muted/40 transition-colors cursor-pointer">
+                    <CardContent className="pt-4 flex items-center justify-between gap-4">
+                      <div>
+                        <span className="font-mono text-sm font-semibold">{dcr.dcrNumber}</span>
+                        <p className="text-sm text-muted-foreground mt-0.5">{dcr.title}</p>
+                        <span className="text-xs text-muted-foreground">by {dcr.requestedBy.name} · {relTime(dcr.createdAt)}</span>
+                      </div>
+                      <div className="flex gap-2 shrink-0">
+                        {priorityBadge(dcr.priority)}
+                        {statusBadge(dcr.status)}
+                      </div>
+                    </CardContent>
+                  </Card>
+                </Link>
+              ))}
+            </div>
+          )}
+        </TabsContent>
+      </Tabs>
+
+      {/* Create Revision Dialog */}
+      <Dialog open={revDialog} onOpenChange={setRevDialog}>
+        <DialogContent>
+          <DialogHeader><DialogTitle>Create Revision</DialogTitle></DialogHeader>
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label>Version *</Label>
+                <Input placeholder="e.g. 2.0" value={revForm.version} onChange={e => setRevForm(f => ({ ...f, version: e.target.value }))} />
+              </div>
+              <div>
+                <Label>Change Type</Label>
+                <Select value={revForm.changeType} onValueChange={v => setRevForm(f => ({ ...f, changeType: v }))}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="MINOR">Minor</SelectItem>
+                    <SelectItem value="MAJOR">Major</SelectItem>
+                    <SelectItem value="ADMINISTRATIVE">Administrative</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+            <div>
+              <Label>Change Description</Label>
+              <Textarea rows={3} value={revForm.changeDescription} onChange={e => setRevForm(f => ({ ...f, changeDescription: e.target.value }))} />
+            </div>
+            <div>
+              <Label>File URL (optional)</Label>
+              <Input placeholder="https://..." value={revForm.fileUrl} onChange={e => setRevForm(f => ({ ...f, fileUrl: e.target.value }))} />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setRevDialog(false)}>Cancel</Button>
+            <Button onClick={saveRevision} disabled={revSaving || !revForm.version}>{revSaving ? 'Saving…' : 'Create'}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Issue Distribution Dialog */}
+      <Dialog open={distDialog} onOpenChange={setDistDialog}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader><DialogTitle>Issue Distribution</DialogTitle></DialogHeader>
+          <div className="space-y-4">
+            <div>
+              <Label>Recipients</Label>
+              <div className="mt-1 max-h-48 overflow-y-auto border rounded-md p-2 space-y-1">
+                {allUsers.map(u => (
+                  <label key={u.id} className="flex items-center gap-2 text-sm cursor-pointer hover:bg-muted/40 px-2 py-1 rounded">
+                    <input
+                      type="checkbox"
+                      checked={selectedUsers.includes(u.id)}
+                      onChange={e => setSelectedUsers(prev => e.target.checked ? [...prev, u.id] : prev.filter(id => id !== u.id))}
+                    />
+                    {u.name}
+                  </label>
+                ))}
+              </div>
+              <p className="text-xs text-muted-foreground mt-1">{selectedUsers.length} selected</p>
+            </div>
+            <div>
+              <Label>Notes (optional)</Label>
+              <Textarea rows={2} value={distNotes} onChange={e => setDistNotes(e.target.value)} />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDistDialog(false)}>Cancel</Button>
+            <Button onClick={saveDistribution} disabled={distSaving || selectedUsers.length === 0}>{distSaving ? 'Issuing…' : 'Issue'}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/app/ims/documents/[id]/page.tsx
+++ b/src/app/ims/documents/[id]/page.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from 'next';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { verifySession } from '@/lib/jwt';
+import ImsDocumentDetailClient from './_page-client';
+
+export const metadata: Metadata = { title: 'Document Detail | IMS | OTS' };
+export const dynamic = 'force-dynamic';
+
+export default async function ImsDocumentDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const store = await cookies();
+  const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+  const session = token ? verifySession(token) : null;
+  if (!session) redirect('/login');
+
+  return <ImsDocumentDetailClient documentId={id} />;
+}

--- a/src/app/ims/documents/_page-client.tsx
+++ b/src/app/ims/documents/_page-client.tsx
@@ -1,0 +1,655 @@
+'use client';
+
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import Link from 'next/link';
+import {
+  FileText,
+  Eye,
+  Plus,
+  Search,
+  X,
+  ChevronLeft,
+  ChevronRight,
+  AlertTriangle,
+  Clock,
+} from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Skeleton } from '@/components/ui/skeleton';
+import { cn } from '@/lib/utils';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type Category = {
+  id: string;
+  code: string;
+  name: string;
+  nameAr: string | null;
+  level: number;
+};
+
+type Department = {
+  id: string;
+  name: string;
+};
+
+type Document = {
+  id: string;
+  documentNumber: string;
+  title: string;
+  titleAr: string | null;
+  status: string;
+  currentVersion: string;
+  nextReviewDate: string | null;
+  lastReviewDate: string | null;
+  reviewFrequencyDays: number;
+  applicableStandards: string | null;
+  overdueDays: number | null;
+  category: { id: string; code: string; name: string; nameAr: string | null } | null;
+  department: { id: string; name: string } | null;
+  owner: { id: string; name: string } | null;
+  reviewer: { id: string; name: string } | null;
+};
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const PAGE_SIZE = 25;
+
+const STATUS_OPTIONS = [
+  { value: 'ALL', label: 'All Statuses' },
+  { value: 'DRAFT', label: 'Draft' },
+  { value: 'UNDER_REVIEW', label: 'Under Review' },
+  { value: 'APPROVED', label: 'Approved' },
+  { value: 'OBSOLETE', label: 'Obsolete' },
+  { value: 'SUPERSEDED', label: 'Superseded' },
+];
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function statusBadgeClass(status: string): string {
+  const map: Record<string, string> = {
+    DRAFT:        'bg-gray-100 text-gray-700 border-gray-200',
+    UNDER_REVIEW: 'bg-blue-100 text-blue-700 border-blue-200',
+    APPROVED:     'bg-green-100 text-green-700 border-green-200',
+    OBSOLETE:     'bg-red-100 text-red-700 border-red-200',
+    SUPERSEDED:   'bg-slate-100 text-slate-600 border-slate-200',
+  };
+  return map[status] ?? 'bg-gray-100 text-gray-600 border-gray-200';
+}
+
+function statusLabel(status: string): string {
+  const map: Record<string, string> = {
+    DRAFT:        'Draft',
+    UNDER_REVIEW: 'Under Review',
+    APPROVED:     'Approved',
+    OBSOLETE:     'Obsolete',
+    SUPERSEDED:   'Superseded',
+  };
+  return map[status] ?? status;
+}
+
+function categoryBadgeClass(level: number): string {
+  const map: Record<number, string> = {
+    1: 'bg-purple-100 text-purple-700 border-purple-200',
+    2: 'bg-blue-100 text-blue-700 border-blue-200',
+    3: 'bg-cyan-100 text-cyan-700 border-cyan-200',
+    4: 'bg-green-100 text-green-700 border-green-200',
+    5: 'bg-orange-100 text-orange-700 border-orange-200',
+    6: 'bg-gray-100 text-gray-600 border-gray-200',
+  };
+  return map[level] ?? 'bg-gray-100 text-gray-600 border-gray-200';
+}
+
+function parseStandards(raw: string | null): string[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return raw
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+}
+
+function standardBadgeClass(std: string): string {
+  if (std.includes('9001')) return 'bg-green-100 text-green-700 border-green-200';
+  if (std.includes('14001')) return 'bg-blue-100 text-blue-700 border-blue-200';
+  if (std.includes('45001')) return 'bg-purple-100 text-purple-700 border-purple-200';
+  return 'bg-gray-100 text-gray-600 border-gray-200';
+}
+
+function standardShortLabel(std: string): string {
+  if (std.includes('9001')) return '9001';
+  if (std.includes('14001')) return '14001';
+  if (std.includes('45001')) return '45001';
+  return std;
+}
+
+function reviewDateCell(nextReviewDate: string | null, overdueDays: number | null) {
+  if (!nextReviewDate) {
+    return <span className="text-muted-foreground text-xs">—</span>;
+  }
+
+  const date = new Date(nextReviewDate);
+  const formatted = date.toLocaleDateString('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  });
+
+  if (overdueDays != null && overdueDays > 0) {
+    return (
+      <div className="flex flex-col gap-0.5">
+        <span className="text-red-600 font-semibold text-xs">{formatted}</span>
+        <span className="text-red-500 text-xs font-medium">{overdueDays}d overdue</span>
+      </div>
+    );
+  }
+
+  const now = new Date();
+  const daysUntil = Math.floor((date.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
+  if (daysUntil <= 30) {
+    return (
+      <div className="flex flex-col gap-0.5">
+        <span className="text-amber-600 font-medium text-xs">{formatted}</span>
+        <span className="text-amber-500 text-xs">in {daysUntil}d</span>
+      </div>
+    );
+  }
+
+  return <span className="text-xs text-muted-foreground">{formatted}</span>;
+}
+
+// ─── Skeleton ─────────────────────────────────────────────────────────────────
+
+function TableSkeleton() {
+  return (
+    <div className="space-y-2">
+      {Array.from({ length: 8 }).map((_, i) => (
+        <Skeleton key={i} className="h-14 w-full rounded" />
+      ))}
+    </div>
+  );
+}
+
+// ─── Empty State ──────────────────────────────────────────────────────────────
+
+function EmptyState() {
+  return (
+    <div className="flex flex-col items-center justify-center py-20 text-center">
+      <div className="p-5 rounded-2xl bg-slate-100 dark:bg-slate-800 mb-4">
+        <FileText className="h-10 w-10 text-slate-400" />
+      </div>
+      <h3 className="text-base font-semibold text-foreground mb-1">No documents found</h3>
+      <p className="text-sm text-muted-foreground max-w-xs">
+        Try adjusting your filters or search query, or create a new document.
+      </p>
+    </div>
+  );
+}
+
+// ─── Main Component ───────────────────────────────────────────────────────────
+
+export function ImsDocumentsClient() {
+  const [documents, setDocuments] = useState<Document[]>([]);
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [departments, setDepartments] = useState<Department[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Filters
+  const [search, setSearch] = useState('');
+  const [categoryId, setCategoryId] = useState('ALL');
+  const [status, setStatus] = useState('ALL');
+  const [departmentId, setDepartmentId] = useState('ALL');
+  const [overdueOnly, setOverdueOnly] = useState(false);
+
+  // Pagination
+  const [page, setPage] = useState(1);
+
+  // ─── Fetch filters ──────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    Promise.all([
+      fetch('/api/ims/categories').then((r) => r.json()),
+      fetch('/api/departments').then((r) => r.json()),
+    ]).then(([cats, deps]) => {
+      setCategories(Array.isArray(cats) ? cats : []);
+      setDepartments(Array.isArray(deps) ? deps : []);
+    }).catch(() => {
+      // Non-critical; filters will be empty
+    });
+  }, []);
+
+  // ─── Fetch documents ────────────────────────────────────────────────────────
+
+  const fetchDocuments = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      if (search) params.set('search', search);
+      if (categoryId && categoryId !== 'ALL') params.set('categoryId', categoryId);
+      if (status && status !== 'ALL') params.set('status', status);
+      if (departmentId && departmentId !== 'ALL') params.set('departmentId', departmentId);
+      if (overdueOnly) params.set('overdue', 'true');
+
+      const res = await fetch(`/api/ims/documents?${params.toString()}`);
+      if (!res.ok) throw new Error('Failed to fetch documents');
+      const data = await res.json() as Document[];
+      setDocuments(Array.isArray(data) ? data : []);
+      setPage(1);
+    } catch {
+      setError('Failed to load documents. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  }, [search, categoryId, status, departmentId, overdueOnly]);
+
+  useEffect(() => {
+    fetchDocuments();
+  }, [fetchDocuments]);
+
+  // ─── Clear filters ──────────────────────────────────────────────────────────
+
+  function clearFilters() {
+    setSearch('');
+    setCategoryId('ALL');
+    setStatus('ALL');
+    setDepartmentId('ALL');
+    setOverdueOnly(false);
+  }
+
+  const hasActiveFilters =
+    search !== '' ||
+    categoryId !== 'ALL' ||
+    status !== 'ALL' ||
+    departmentId !== 'ALL' ||
+    overdueOnly;
+
+  // ─── Pagination ─────────────────────────────────────────────────────────────
+
+  const totalPages = Math.max(1, Math.ceil(documents.length / PAGE_SIZE));
+  const paginatedDocs = useMemo(
+    () => documents.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE),
+    [documents, page],
+  );
+
+  // ─── Render ──────────────────────────────────────────────────────────────────
+
+  return (
+    <div className="min-h-screen bg-background">
+      {/* ── Hero ── */}
+      <div className="relative overflow-hidden bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white">
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,_rgba(99,102,241,0.15),_transparent_60%)]" />
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_bottom_left,_rgba(16,185,129,0.1),_transparent_60%)]" />
+        <div className="relative px-6 py-10 md:px-10 md:py-12">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+            <div className="flex items-start gap-4">
+              <div className="p-3 rounded-2xl bg-white/10 backdrop-blur-sm border border-white/20 shadow-lg">
+                <FileText className="h-7 w-7 text-blue-400" />
+              </div>
+              <div>
+                <div className="flex items-center gap-3 mb-1">
+                  <h1 className="text-2xl md:text-3xl font-bold tracking-tight">
+                    Document Registry
+                  </h1>
+                  {!loading && (
+                    <Badge className="bg-white/10 text-white border border-white/20 text-xs font-semibold px-2 py-0.5">
+                      {documents.length} doc{documents.length !== 1 ? 's' : ''}
+                    </Badge>
+                  )}
+                </div>
+                <p className="text-slate-400 text-sm font-medium">
+                  IMS · Controlled Document Register
+                </p>
+              </div>
+            </div>
+            <Link href="/ims/documents/new">
+              <Button
+                size="sm"
+                className="bg-blue-600 hover:bg-blue-700 text-white border-0 gap-2 shadow-sm"
+              >
+                <Plus className="h-4 w-4" />
+                New Document
+              </Button>
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      <div className="px-6 py-6 md:px-10 space-y-5 max-w-screen-2xl mx-auto">
+
+        {/* ── Error banner ── */}
+        {error && (
+          <div className="flex items-center gap-3 px-4 py-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">
+            <AlertTriangle className="h-4 w-4 flex-shrink-0" />
+            {error}
+          </div>
+        )}
+
+        {/* ── Filters ── */}
+        <Card className="border shadow-sm">
+          <CardContent className="p-4">
+            <div className="flex flex-wrap gap-3 items-center">
+              {/* Search */}
+              <div className="relative flex-1 min-w-[200px] max-w-xs">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                <Input
+                  placeholder="Search title or doc number…"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  className="pl-9 h-9 text-sm"
+                />
+              </div>
+
+              {/* Category */}
+              <Select value={categoryId} onValueChange={setCategoryId}>
+                <SelectTrigger className="h-9 text-sm w-[180px]">
+                  <SelectValue placeholder="All Categories" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="ALL">All Categories</SelectItem>
+                  {categories.map((cat) => (
+                    <SelectItem key={cat.id} value={cat.id}>
+                      <span className="font-mono text-xs mr-1.5 text-muted-foreground">{cat.code}</span>
+                      {cat.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              {/* Status */}
+              <Select value={status} onValueChange={setStatus}>
+                <SelectTrigger className="h-9 text-sm w-[160px]">
+                  <SelectValue placeholder="All Statuses" />
+                </SelectTrigger>
+                <SelectContent>
+                  {STATUS_OPTIONS.map((opt) => (
+                    <SelectItem key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              {/* Department */}
+              <Select value={departmentId} onValueChange={setDepartmentId}>
+                <SelectTrigger className="h-9 text-sm w-[180px]">
+                  <SelectValue placeholder="All Departments" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="ALL">All Departments</SelectItem>
+                  {departments.map((dep) => (
+                    <SelectItem key={dep.id} value={dep.id}>
+                      {dep.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              {/* Overdue Only toggle */}
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setOverdueOnly((v) => !v)}
+                className={cn(
+                  'h-9 gap-1.5 text-sm font-medium border',
+                  overdueOnly
+                    ? 'bg-red-50 text-red-700 border-red-300 hover:bg-red-100 hover:text-red-700 dark:bg-red-950/30 dark:text-red-400 dark:border-red-800'
+                    : 'text-muted-foreground hover:text-foreground',
+                )}
+              >
+                <Clock className="h-3.5 w-3.5" />
+                Overdue Only
+              </Button>
+
+              {/* Clear */}
+              {hasActiveFilters && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={clearFilters}
+                  className="h-9 gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+                >
+                  <X className="h-3.5 w-3.5" />
+                  Clear
+                </Button>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* ── Table ── */}
+        <Card className="border shadow-sm">
+          <CardContent className="p-0">
+            {loading ? (
+              <div className="p-6">
+                <TableSkeleton />
+              </div>
+            ) : documents.length === 0 ? (
+              <EmptyState />
+            ) : (
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow className="border-b bg-muted/30">
+                      <TableHead className="text-xs font-semibold text-muted-foreground uppercase tracking-wide whitespace-nowrap pl-4">
+                        Doc #
+                      </TableHead>
+                      <TableHead className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                        Title
+                      </TableHead>
+                      <TableHead className="text-xs font-semibold text-muted-foreground uppercase tracking-wide whitespace-nowrap hidden md:table-cell">
+                        Category
+                      </TableHead>
+                      <TableHead className="text-xs font-semibold text-muted-foreground uppercase tracking-wide whitespace-nowrap">
+                        Status
+                      </TableHead>
+                      <TableHead className="text-xs font-semibold text-muted-foreground uppercase tracking-wide whitespace-nowrap hidden lg:table-cell">
+                        Ver.
+                      </TableHead>
+                      <TableHead className="text-xs font-semibold text-muted-foreground uppercase tracking-wide whitespace-nowrap hidden lg:table-cell">
+                        Owner
+                      </TableHead>
+                      <TableHead className="text-xs font-semibold text-muted-foreground uppercase tracking-wide whitespace-nowrap hidden md:table-cell">
+                        Next Review
+                      </TableHead>
+                      <TableHead className="text-xs font-semibold text-muted-foreground uppercase tracking-wide whitespace-nowrap hidden xl:table-cell">
+                        Standards
+                      </TableHead>
+                      <TableHead className="w-12" />
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {paginatedDocs.map((doc) => {
+                      const isOverdue = doc.overdueDays != null && doc.overdueDays > 0;
+                      const standards = parseStandards(doc.applicableStandards);
+
+                      return (
+                        <TableRow
+                          key={doc.id}
+                          className={cn(
+                            'hover:bg-muted/40 transition-colors',
+                            isOverdue && [
+                              'bg-red-50 dark:bg-red-950/20',
+                              'border-l-4 border-l-red-500',
+                            ],
+                          )}
+                        >
+                          {/* Doc Number */}
+                          <TableCell className="pl-4 whitespace-nowrap">
+                            <Link
+                              href={`/ims/documents/${doc.id}`}
+                              className="font-mono text-xs font-bold text-slate-700 dark:text-slate-300 hover:text-blue-600 dark:hover:text-blue-400 hover:underline transition-colors"
+                            >
+                              {doc.documentNumber}
+                            </Link>
+                          </TableCell>
+
+                          {/* Title */}
+                          <TableCell className="max-w-[240px]">
+                            <div>
+                              <Link
+                                href={`/ims/documents/${doc.id}`}
+                                className="text-sm font-medium text-foreground hover:underline hover:text-blue-600 dark:hover:text-blue-400 line-clamp-1"
+                              >
+                                {doc.title}
+                              </Link>
+                              {doc.titleAr && (
+                                <p className="text-xs text-muted-foreground line-clamp-1 mt-0.5 text-right" dir="rtl">
+                                  {doc.titleAr}
+                                </p>
+                              )}
+                            </div>
+                          </TableCell>
+
+                          {/* Category */}
+                          <TableCell className="hidden md:table-cell whitespace-nowrap">
+                            {doc.category ? (
+                              <Badge
+                                variant="outline"
+                                className={cn(
+                                  'text-xs font-medium',
+                                  categoryBadgeClass(
+                                    // We need the level — fetch from categories list
+                                    categories.find((c) => c.id === doc.category?.id)?.level ?? 1,
+                                  ),
+                                )}
+                              >
+                                {doc.category.code}
+                              </Badge>
+                            ) : (
+                              <span className="text-muted-foreground text-xs">—</span>
+                            )}
+                          </TableCell>
+
+                          {/* Status */}
+                          <TableCell className="whitespace-nowrap">
+                            <Badge
+                              variant="outline"
+                              className={cn('text-xs font-medium', statusBadgeClass(doc.status))}
+                            >
+                              {statusLabel(doc.status)}
+                            </Badge>
+                          </TableCell>
+
+                          {/* Version */}
+                          <TableCell className="hidden lg:table-cell whitespace-nowrap">
+                            <span className="text-xs text-muted-foreground font-mono">
+                              v{doc.currentVersion}
+                            </span>
+                          </TableCell>
+
+                          {/* Owner */}
+                          <TableCell className="hidden lg:table-cell whitespace-nowrap">
+                            <span className="text-xs text-muted-foreground">
+                              {doc.owner?.name ?? '—'}
+                            </span>
+                          </TableCell>
+
+                          {/* Next Review */}
+                          <TableCell className="hidden md:table-cell whitespace-nowrap">
+                            {reviewDateCell(doc.nextReviewDate, doc.overdueDays)}
+                          </TableCell>
+
+                          {/* Standards */}
+                          <TableCell className="hidden xl:table-cell">
+                            <div className="flex gap-1 flex-wrap">
+                              {standards.length === 0 ? (
+                                <span className="text-muted-foreground text-xs">—</span>
+                              ) : (
+                                standards.map((std) => (
+                                  <Badge
+                                    key={std}
+                                    variant="outline"
+                                    className={cn('text-xs font-semibold px-1.5 py-0', standardBadgeClass(std))}
+                                  >
+                                    {standardShortLabel(std)}
+                                  </Badge>
+                                ))
+                              )}
+                            </div>
+                          </TableCell>
+
+                          {/* Action */}
+                          <TableCell className="text-right pr-4">
+                            <Link href={`/ims/documents/${doc.id}`}>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                className="h-7 w-7 p-0 text-muted-foreground hover:text-foreground"
+                              >
+                                <Eye className="h-3.5 w-3.5" />
+                                <span className="sr-only">View</span>
+                              </Button>
+                            </Link>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* ── Pagination ── */}
+        {!loading && documents.length > 0 && (
+          <div className="flex items-center justify-between text-sm text-muted-foreground py-2">
+            <span>
+              Showing {Math.min((page - 1) * PAGE_SIZE + 1, documents.length)}–
+              {Math.min(page * PAGE_SIZE, documents.length)} of {documents.length}
+            </span>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page <= 1}
+                onClick={() => setPage((p) => p - 1)}
+                className="h-8 gap-1"
+              >
+                <ChevronLeft className="h-3.5 w-3.5" />
+                Prev
+              </Button>
+              <span className="text-xs font-medium px-2">
+                {page} / {totalPages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page >= totalPages}
+                onClick={() => setPage((p) => p + 1)}
+                className="h-8 gap-1"
+              >
+                Next
+                <ChevronRight className="h-3.5 w-3.5" />
+              </Button>
+            </div>
+          </div>
+        )}
+
+      </div>
+    </div>
+  );
+}

--- a/src/app/ims/documents/page.tsx
+++ b/src/app/ims/documents/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from 'next';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { verifySession } from '@/lib/jwt';
+import { ImsDocumentsClient } from './_page-client';
+
+export const metadata: Metadata = {
+  title: 'Document Registry | IMS | OTS',
+};
+
+export const dynamic = 'force-dynamic';
+
+export default async function ImsDocumentsPage() {
+  const store = await cookies();
+  const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+  const session = token ? verifySession(token) : null;
+
+  if (!session) redirect('/login');
+
+  return <ImsDocumentsClient />;
+}

--- a/src/app/ims/layout.tsx
+++ b/src/app/ims/layout.tsx
@@ -1,0 +1,3 @@
+export default function ImsLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/ims/page.tsx
+++ b/src/app/ims/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from 'next';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { verifySession } from '@/lib/jwt';
+import { ImsDashboardClient } from './_page-client';
+
+export const metadata: Metadata = {
+  title: 'IMS Dashboard | OTS',
+};
+
+export const dynamic = 'force-dynamic';
+
+export default async function ImsDashboardPage() {
+  const store = await cookies();
+  const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+  const session = token ? verifySession(token) : null;
+
+  if (!session) redirect('/login');
+
+  return <ImsDashboardClient />;
+}

--- a/src/app/ims/review-calendar/_page-client.tsx
+++ b/src/app/ims/review-calendar/_page-client.tsx
@@ -1,0 +1,376 @@
+'use client';
+
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  CalendarCheck,
+  AlertTriangle,
+  RefreshCw,
+  Clock,
+} from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { cn } from '@/lib/utils';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type ReviewDoc = {
+  id: string;
+  documentNumber: string;
+  title: string;
+  status: string;
+  nextReviewDate: string;
+  lastReviewDate: string | null;
+  reviewFrequencyDays: number;
+  overdueDays: number | null;
+  category: { id: string; code: string; name: string } | null;
+  owner: { id: string; name: string } | null;
+  department: { id: string; name: string } | null;
+};
+
+type MonthGroup = {
+  month: string; // "YYYY-MM"
+  documents: ReviewDoc[];
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function formatMonthLabel(monthKey: string): string {
+  const [year, month] = monthKey.split('-');
+  const date = new Date(parseInt(year, 10), parseInt(month, 10) - 1, 1);
+  return date.toLocaleDateString('en-GB', { month: 'long', year: 'numeric' });
+}
+
+function daysUntil(dateStr: string): number {
+  const date = new Date(dateStr);
+  const now = new Date();
+  return Math.floor((date.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
+}
+
+function statusBadgeClass(status: string): string {
+  const map: Record<string, string> = {
+    DRAFT:        'bg-gray-100 text-gray-700 border-gray-200',
+    UNDER_REVIEW: 'bg-blue-100 text-blue-700 border-blue-200',
+    APPROVED:     'bg-green-100 text-green-700 border-green-200',
+    OBSOLETE:     'bg-red-100 text-red-700 border-red-200',
+    SUPERSEDED:   'bg-slate-100 text-slate-600 border-slate-200',
+  };
+  return map[status] ?? 'bg-gray-100 text-gray-600 border-gray-200';
+}
+
+function statusLabel(status: string): string {
+  const map: Record<string, string> = {
+    DRAFT:        'Draft',
+    UNDER_REVIEW: 'Under Review',
+    APPROVED:     'Approved',
+    OBSOLETE:     'Obsolete',
+    SUPERSEDED:   'Superseded',
+  };
+  return map[status] ?? status;
+}
+
+// ─── Skeletons ────────────────────────────────────────────────────────────────
+
+function CalendarSkeleton() {
+  return (
+    <div className="space-y-8">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div key={i} className="space-y-3">
+          <Skeleton className="h-6 w-36 rounded" />
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+            {Array.from({ length: 4 }).map((_, j) => (
+              <Skeleton key={j} className="h-28 w-full rounded-lg" />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ─── Document Card ────────────────────────────────────────────────────────────
+
+interface DocCardProps {
+  doc: ReviewDoc;
+  onClick: () => void;
+}
+
+function DocCard({ doc, onClick }: DocCardProps) {
+  const isOverdue = doc.overdueDays != null && doc.overdueDays > 0;
+  const days = isOverdue ? doc.overdueDays! : daysUntil(doc.nextReviewDate);
+  const isSoon = !isOverdue && days <= 30;
+
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        'w-full text-left p-4 rounded-lg border transition-all hover:shadow-md',
+        isOverdue
+          ? 'bg-red-50 border-red-200 hover:border-red-400 dark:bg-red-950/20 dark:border-red-800'
+          : isSoon
+            ? 'bg-amber-50 border-amber-200 hover:border-amber-400 dark:bg-amber-950/20 dark:border-amber-800'
+            : 'bg-card border-border hover:border-slate-400',
+      )}
+    >
+      {/* Doc number + status */}
+      <div className="flex items-start justify-between gap-2 mb-2">
+        <span className="font-mono text-xs font-bold text-slate-600 dark:text-slate-400 truncate">
+          {doc.documentNumber}
+        </span>
+        <Badge
+          variant="outline"
+          className={cn('text-xs font-medium flex-shrink-0', statusBadgeClass(doc.status))}
+        >
+          {statusLabel(doc.status)}
+        </Badge>
+      </div>
+
+      {/* Title */}
+      <p className="text-sm font-semibold text-foreground line-clamp-2 mb-2 leading-snug">
+        {doc.title}
+      </p>
+
+      {/* Owner */}
+      {doc.owner && (
+        <p className="text-xs text-muted-foreground mb-2 truncate">
+          {doc.owner.name}
+        </p>
+      )}
+
+      {/* Days indicator */}
+      <div className={cn(
+        'text-xs font-semibold flex items-center gap-1',
+        isOverdue ? 'text-red-600' : isSoon ? 'text-amber-600' : 'text-green-600',
+      )}>
+        <Clock className="h-3 w-3 flex-shrink-0" />
+        {isOverdue
+          ? `${days} day${days !== 1 ? 's' : ''} overdue`
+          : days === 0
+            ? 'Due today'
+            : `Due in ${days} day${days !== 1 ? 's' : ''}`}
+      </div>
+    </button>
+  );
+}
+
+// ─── Main Component ───────────────────────────────────────────────────────────
+
+export function ImsReviewCalendarClient() {
+  const router = useRouter();
+  const [groups, setGroups] = useState<MonthGroup[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [overdueOnly, setOverdueOnly] = useState(false);
+
+  const fetchData = useCallback(async (isRefresh = false) => {
+    if (isRefresh) setRefreshing(true);
+    else setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/ims/review-calendar?months=6');
+      if (!res.ok) throw new Error('Failed to fetch review calendar');
+      const data = await res.json() as MonthGroup[];
+      setGroups(Array.isArray(data) ? data : []);
+    } catch {
+      setError('Failed to load review calendar. Please try again.');
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  // Filtered groups
+  const filteredGroups = useMemo(() => {
+    if (!overdueOnly) return groups;
+    return groups
+      .map((g: MonthGroup) => ({
+        ...g,
+        documents: g.documents.filter((d: ReviewDoc) => d.overdueDays != null && d.overdueDays > 0),
+      }))
+      .filter((g: MonthGroup) => g.documents.length > 0);
+  }, [groups, overdueOnly]);
+
+  // Summary stats
+  const totalDocs = useMemo(
+    () => groups.reduce((sum: number, g: MonthGroup) => sum + g.documents.length, 0),
+    [groups]
+  );
+  const overdueDocs = useMemo(
+    () =>
+      groups.reduce(
+        (sum: number, g: MonthGroup) =>
+          sum + g.documents.filter((d: ReviewDoc) => d.overdueDays != null && d.overdueDays > 0).length,
+        0
+      ),
+    [groups]
+  );
+
+  return (
+    <div className="min-h-screen bg-background">
+      {/* ── Hero ── */}
+      <div className="relative overflow-hidden bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white">
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,_rgba(99,102,241,0.15),_transparent_60%)]" />
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_bottom_left,_rgba(16,185,129,0.1),_transparent_60%)]" />
+        <div className="relative px-6 py-10 md:px-10 md:py-12">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+            <div className="flex items-start gap-4">
+              <div className="p-3 rounded-2xl bg-white/10 backdrop-blur-sm border border-white/20 shadow-lg">
+                <CalendarCheck className="h-7 w-7 text-green-400" />
+              </div>
+              <div>
+                <div className="flex items-center gap-3 mb-1">
+                  <h1 className="text-2xl md:text-3xl font-bold tracking-tight">
+                    Review Calendar
+                  </h1>
+                  {!loading && (
+                    <Badge className="bg-white/10 text-white border border-white/20 text-xs font-semibold px-2 py-0.5">
+                      Next 6 months
+                    </Badge>
+                  )}
+                </div>
+                <p className="text-slate-400 text-sm font-medium">
+                  IMS · Upcoming Document Reviews
+                </p>
+              </div>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => fetchData(true)}
+              disabled={refreshing}
+              className="border-white/20 bg-white/10 text-white hover:bg-white/20 hover:text-white backdrop-blur-sm gap-2"
+            >
+              <RefreshCw className={cn('h-4 w-4', refreshing && 'animate-spin')} />
+              Refresh
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <div className="px-6 py-6 md:px-10 space-y-6 max-w-screen-2xl mx-auto">
+
+        {/* ── Error banner ── */}
+        {error && (
+          <div className="flex items-center gap-3 px-4 py-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">
+            <AlertTriangle className="h-4 w-4 flex-shrink-0" />
+            {error}
+          </div>
+        )}
+
+        {/* ── Summary strip + filter ── */}
+        {!loading && (
+          <div className="flex flex-wrap items-center gap-4">
+            {/* Stats */}
+            <div className="flex items-center gap-3">
+              <div className="flex items-center gap-1.5 text-sm">
+                <span className="font-semibold text-foreground">{totalDocs}</span>
+                <span className="text-muted-foreground">upcoming review{totalDocs !== 1 ? 's' : ''}</span>
+              </div>
+              {overdueDocs > 0 && (
+                <>
+                  <span className="text-muted-foreground">·</span>
+                  <div className="flex items-center gap-1.5 text-sm">
+                    <span className="font-semibold text-red-600">{overdueDocs}</span>
+                    <span className="text-muted-foreground">overdue</span>
+                  </div>
+                </>
+              )}
+            </div>
+
+            {/* Overdue Only toggle */}
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setOverdueOnly((v) => !v)}
+              className={cn(
+                'h-9 gap-1.5 text-sm font-medium border',
+                overdueOnly
+                  ? 'bg-red-50 text-red-700 border-red-300 hover:bg-red-100 hover:text-red-700'
+                  : 'text-muted-foreground hover:text-foreground',
+              )}
+            >
+              <AlertTriangle className="h-3.5 w-3.5" />
+              Show overdue only
+            </Button>
+          </div>
+        )}
+
+        {/* ── Content ── */}
+        {loading ? (
+          <CalendarSkeleton />
+        ) : filteredGroups.length === 0 && !overdueOnly ? (
+          /* Empty state — no reviews scheduled */
+          <div className="flex flex-col items-center justify-center py-24 text-center">
+            <div className="p-5 rounded-2xl bg-green-50 mb-4 border border-green-100">
+              <CalendarCheck className="h-10 w-10 text-green-500" />
+            </div>
+            <h3 className="text-base font-semibold text-foreground mb-1">
+              No document reviews scheduled in the next 6 months
+            </h3>
+            <p className="text-sm text-muted-foreground max-w-sm">
+              All documents are either up to date or have no review date set.
+            </p>
+          </div>
+        ) : filteredGroups.length === 0 && overdueOnly ? (
+          /* Empty state — no overdue */
+          <div className="flex flex-col items-center justify-center py-24 text-center">
+            <div className="p-5 rounded-2xl bg-green-50 mb-4 border border-green-100">
+              <CalendarCheck className="h-10 w-10 text-green-500" />
+            </div>
+            <h3 className="text-base font-semibold text-foreground mb-1">No overdue reviews</h3>
+            <p className="text-sm text-muted-foreground">All scheduled reviews are on track.</p>
+          </div>
+        ) : (
+          /* Timeline */
+          <div className="space-y-8">
+            {filteredGroups.map((group) => (
+              <div key={group.month}>
+                {/* Month header */}
+                <div className="flex items-center gap-3 mb-4">
+                  <h2 className="text-base font-bold text-foreground">
+                    {formatMonthLabel(group.month)}
+                  </h2>
+                  <div className="flex items-center gap-2">
+                    <Badge variant="outline" className="text-xs font-medium bg-slate-100 text-slate-600 border-slate-200">
+                      {group.documents.length} doc{group.documents.length !== 1 ? 's' : ''}
+                    </Badge>
+                    {(() => {
+                      const overdueInMonth = group.documents.filter(
+                        (d) => d.overdueDays != null && d.overdueDays > 0
+                      ).length;
+                      return overdueInMonth > 0 ? (
+                        <Badge variant="outline" className="text-xs font-semibold bg-red-100 text-red-700 border-red-200">
+                          {overdueInMonth} overdue
+                        </Badge>
+                      ) : null;
+                    })()}
+                  </div>
+                  <div className="flex-1 h-px bg-border" />
+                </div>
+
+                {/* Document cards grid */}
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+                  {group.documents.map((doc) => (
+                    <DocCard
+                      key={doc.id}
+                      doc={doc}
+                      onClick={() => router.push(`/ims/documents/${doc.id}`)}
+                    />
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+      </div>
+    </div>
+  );
+}

--- a/src/app/ims/review-calendar/_page-client.tsx
+++ b/src/app/ims/review-calendar/_page-client.tsx
@@ -288,7 +288,7 @@ export function ImsReviewCalendarClient() {
             <Button
               variant="outline"
               size="sm"
-              onClick={() => setOverdueOnly((v) => !v)}
+              onClick={() => setOverdueOnly((v: boolean) => !v)}
               className={cn(
                 'h-9 gap-1.5 text-sm font-medium border',
                 overdueOnly
@@ -330,7 +330,7 @@ export function ImsReviewCalendarClient() {
         ) : (
           /* Timeline */
           <div className="space-y-8">
-            {filteredGroups.map((group) => (
+            {filteredGroups.map((group: MonthGroup) => (
               <div key={group.month}>
                 {/* Month header */}
                 <div className="flex items-center gap-3 mb-4">
@@ -343,7 +343,7 @@ export function ImsReviewCalendarClient() {
                     </Badge>
                     {(() => {
                       const overdueInMonth = group.documents.filter(
-                        (d) => d.overdueDays != null && d.overdueDays > 0
+                        (d: ReviewDoc) => d.overdueDays != null && d.overdueDays > 0
                       ).length;
                       return overdueInMonth > 0 ? (
                         <Badge variant="outline" className="text-xs font-semibold bg-red-100 text-red-700 border-red-200">
@@ -357,11 +357,11 @@ export function ImsReviewCalendarClient() {
 
                 {/* Document cards grid */}
                 <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                  {group.documents.map((doc) => (
+                  {group.documents.map((doc: ReviewDoc) => (
                     <DocCard
                       key={doc.id}
                       doc={doc}
-                      onClick={() => router.push(`/ims/documents/${doc.id}`)}
+                      onClick={() => { void router.push(`/ims/documents/${doc.id}`); }}
                     />
                   ))}
                 </div>

--- a/src/app/ims/review-calendar/page.tsx
+++ b/src/app/ims/review-calendar/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from 'next';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { verifySession } from '@/lib/jwt';
+import { ImsReviewCalendarClient } from './_page-client';
+
+export const metadata: Metadata = {
+  title: 'Review Calendar | IMS | OTS',
+};
+
+export const dynamic = 'force-dynamic';
+
+export default async function ImsReviewCalendarPage() {
+  const store = await cookies();
+  const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+  const session = token ? verifySession(token) : null;
+
+  if (!session) redirect('/login');
+
+  return <ImsReviewCalendarClient />;
+}

--- a/src/app/ims/risks/[id]/_page-client.tsx
+++ b/src/app/ims/risks/[id]/_page-client.tsx
@@ -1,0 +1,395 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { ArrowLeft, Plus, AlertTriangle, CheckCircle, TrendingDown, TrendingUp, Minus, ShieldAlert } from 'lucide-react';
+
+type Assessment = { id: string; likelihood: number; severity: number; riskLevel: number; riskRating: string; assessmentType: string; existingControls: string | null; recommendations: string | null; assessedBy: { name: string } | null; createdAt: string; };
+type Treatment = { id: string; treatmentType: string; description: string | null; status: string; effectiveness: string | null; targetDate: string | null; completedDate: string | null; responsible: { id: string; name: string } | null; notes: string | null; };
+type Hazard = { id: string; hazardType: string; hazardDescription: string | null; location: string | null; affectedPersonnel: string | null; controlHierarchy: string; controlMeasures: string | null; };
+type Risk = {
+  id: string; riskNumber: string; title: string; titleAr: string | null; type: string; category: string; status: string;
+  description: string | null; source: string | null; applicableStandards: string[] | null;
+  currentLikelihood: number; currentSeverity: number; currentRiskLevel: number; currentRiskRating: string;
+  reviewFrequencyDays: number; nextReviewDate: string | null; lastReviewDate: string | null;
+  owner: { id: string; name: string } | null; department: { id: string; name: string } | null;
+  assessments: Assessment[]; treatments: Treatment[]; hazards: Hazard[];
+};
+
+function ratingBadge(r: string, large = false) {
+  const map: Record<string, string> = { LOW: 'bg-green-100 text-green-700 border-green-300', MEDIUM: 'bg-yellow-100 text-yellow-700 border-yellow-300', HIGH: 'bg-orange-100 text-orange-700 border-orange-300', CRITICAL: 'bg-red-100 text-red-700 border-red-300' };
+  return <span className={`inline-flex items-center border font-bold rounded-full ${large ? 'px-4 py-1 text-sm' : 'px-2.5 py-0.5 text-xs'} ${map[r] ?? 'bg-gray-100 text-gray-700 border-gray-200'}`}>{r}</span>;
+}
+
+function statusBadge(s: string) {
+  const map: Record<string, string> = { PLANNED: 'bg-gray-100 text-gray-600', IN_PROGRESS: 'bg-blue-100 text-blue-700', COMPLETED: 'bg-green-100 text-green-700', OVERDUE: 'bg-red-100 text-red-700', CANCELLED: 'bg-slate-100 text-slate-500' };
+  return <span className={`text-xs px-2 py-0.5 rounded font-medium ${map[s] ?? 'bg-gray-100 text-gray-600'}`}>{s.replace('_',' ')}</span>;
+}
+
+function controlBadge(c: string) {
+  const map: Record<string, string> = { ELIMINATION: 'bg-green-100 text-green-700', SUBSTITUTION: 'bg-teal-100 text-teal-700', ENGINEERING: 'bg-blue-100 text-blue-700', ADMINISTRATIVE: 'bg-orange-100 text-orange-700', PPE: 'bg-red-100 text-red-700' };
+  return <span className={`text-xs px-2 py-0.5 rounded font-medium ${map[c] ?? 'bg-gray-100 text-gray-600'}`}>{c}</span>;
+}
+
+const TREATMENT_TYPES_RISK = ['AVOID','MITIGATE','TRANSFER','ACCEPT'];
+const TREATMENT_TYPES_OPP = ['EXPLOIT','SHARE','ENHANCE','ACCEPT'];
+const HAZARD_TYPES = ['PHYSICAL','CHEMICAL','BIOLOGICAL','ERGONOMIC','PSYCHOSOCIAL','MECHANICAL','ELECTRICAL','ENVIRONMENTAL'];
+const CONTROL_HIERARCHIES = ['ELIMINATION','SUBSTITUTION','ENGINEERING','ADMINISTRATIVE','PPE'];
+
+export default function ImsRiskDetailClient({ riskId }: { riskId: string }) {
+  const router = useRouter();
+  const [risk, setRisk] = useState<Risk | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [users, setUsers] = useState<{ id: string; name: string }[]>([]);
+
+  const [assDialog, setAssDialog] = useState(false);
+  const [assForm, setAssForm] = useState({ likelihood: '1', severity: '1', assessmentType: 'PERIODIC', existingControls: '', recommendations: '' });
+  const [assSaving, setAssSaving] = useState(false);
+
+  const [treatDialog, setTreatDialog] = useState(false);
+  const [treatForm, setTreatForm] = useState({ treatmentType: '', description: '', responsibleId: '', targetDate: '', status: 'PLANNED' });
+  const [treatSaving, setTreatSaving] = useState(false);
+
+  const [hazardDialog, setHazardDialog] = useState(false);
+  const [hazardForm, setHazardForm] = useState({ hazardType: 'PHYSICAL', hazardDescription: '', location: '', affectedPersonnel: '', controlHierarchy: 'ENGINEERING', controlMeasures: '' });
+  const [hazardSaving, setHazardSaving] = useState(false);
+
+  const fetchRisk = useCallback(async () => {
+    const res = await fetch(`/api/ims/risks/${riskId}`);
+    if (res.ok) setRisk(await res.json());
+    setLoading(false);
+  }, [riskId]);
+
+  useEffect(() => { fetchRisk(); }, [fetchRisk]);
+
+  const openTreatDialog = async () => {
+    const res = await fetch('/api/users'); if (res.ok) setUsers(await res.json());
+    setTreatDialog(true);
+  };
+
+  const saveAssessment = async () => {
+    setAssSaving(true);
+    await fetch(`/api/ims/risks/${riskId}/assessments`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ likelihood: parseInt(assForm.likelihood), severity: parseInt(assForm.severity), assessmentType: assForm.assessmentType, existingControls: assForm.existingControls || null, recommendations: assForm.recommendations || null }),
+    });
+    setAssDialog(false); fetchRisk(); setAssSaving(false);
+  };
+
+  const saveTreatment = async () => {
+    setTreatSaving(true);
+    await fetch(`/api/ims/risks/${riskId}/treatments`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...treatForm, responsibleId: treatForm.responsibleId || null, targetDate: treatForm.targetDate || null }),
+    });
+    setTreatDialog(false); fetchRisk(); setTreatSaving(false);
+  };
+
+  const saveHazard = async () => {
+    setHazardSaving(true);
+    await fetch(`/api/ims/risks/${riskId}/hazards`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...hazardForm }),
+    });
+    setHazardDialog(false); fetchRisk(); setHazardSaving(false);
+  };
+
+  const previewRating = (l: number, s: number) => { const lv = l*s; if (lv<=4) return 'LOW'; if (lv<=9) return 'MEDIUM'; if (lv<=15) return 'HIGH'; return 'CRITICAL'; };
+
+  if (loading) return <div className="p-6 space-y-4">{[...Array(3)].map((_,i)=><div key={i} className="h-24 bg-muted animate-pulse rounded-xl" />)}</div>;
+  if (!risk) return <div className="p-6 text-center text-muted-foreground"><AlertTriangle className="mx-auto size-10 mb-2 opacity-40" /><p>Risk not found.</p></div>;
+
+  const sorted = [...risk.assessments].sort((a,b)=>new Date(b.createdAt).getTime()-new Date(a.createdAt).getTime());
+  const has45001 = risk.applicableStandards?.includes('ISO_45001');
+  const treatTypes = risk.type === 'OPPORTUNITY' ? TREATMENT_TYPES_OPP : TREATMENT_TYPES_RISK;
+  const ratingBarWidth = Math.round((risk.currentRiskLevel / 25) * 100);
+  const ratingColor = { LOW: 'bg-green-500', MEDIUM: 'bg-yellow-500', HIGH: 'bg-orange-500', CRITICAL: 'bg-red-500' }[risk.currentRiskRating] ?? 'bg-gray-400';
+
+  return (
+    <div className="p-6 space-y-6">
+      <Button variant="ghost" size="sm" onClick={()=>router.push('/ims/risks')}><ArrowLeft className="size-4 mr-1" />Risk Register</Button>
+
+      <div className="flex items-start justify-between gap-4 flex-wrap">
+        <div>
+          <div className="flex items-center gap-3 mb-1">
+            <span className="font-mono text-sm font-bold text-muted-foreground">{risk.riskNumber}</span>
+            <span className={`text-xs border rounded-full px-2.5 py-0.5 font-medium ${risk.type==='RISK'?'border-red-400 text-red-600':'border-green-400 text-green-600'}`}>{risk.type}</span>
+            {ratingBadge(risk.currentRiskRating, true)}
+          </div>
+          <h1 className="text-2xl font-bold">{risk.title}</h1>
+          {risk.titleAr && <p className="text-sm text-muted-foreground mt-0.5" dir="rtl">{risk.titleAr}</p>}
+        </div>
+      </div>
+
+      <Tabs defaultValue="overview">
+        <TabsList>
+          <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="assessments">Assessments ({risk.assessments.length})</TabsTrigger>
+          <TabsTrigger value="treatments">Treatments ({risk.treatments.length})</TabsTrigger>
+          {has45001 && <TabsTrigger value="hazards">Hazards ({risk.hazards.length})</TabsTrigger>}
+        </TabsList>
+
+        {/* Overview */}
+        <TabsContent value="overview" className="mt-4">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <Card>
+              <CardHeader><CardTitle className="text-base">Metadata</CardTitle></CardHeader>
+              <CardContent>
+                <dl className="grid grid-cols-2 gap-x-4 gap-y-3 text-sm">
+                  {[['Category', risk.category.replace('_',' ')],['Status', risk.status.replace('_',' ')],['Owner', risk.owner?.name??'—'],['Department', risk.department?.name??'—'],['Source', risk.source??'—'],['Review Every', `${risk.reviewFrequencyDays} days`],['Last Review', risk.lastReviewDate?new Date(risk.lastReviewDate).toLocaleDateString():'—'],['Next Review', risk.nextReviewDate?new Date(risk.nextReviewDate).toLocaleDateString():'—']].map(([k,v])=>(
+                    <><dt className="text-muted-foreground font-medium">{k}</dt><dd>{v}</dd></>
+                  ))}
+                </dl>
+                {risk.applicableStandards && (
+                  <div className="mt-4 pt-4 border-t flex gap-2 flex-wrap">
+                    {risk.applicableStandards.map(s=>(
+                      <span key={s} className={`text-xs font-bold px-2 py-0.5 rounded-full ${s==='ISO_9001'?'bg-green-100 text-green-700':s==='ISO_14001'?'bg-blue-100 text-blue-700':'bg-purple-100 text-purple-700'}`}>ISO {s.replace('ISO_','')}</span>
+                    ))}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+            <div className="space-y-4">
+              <Card>
+                <CardHeader><CardTitle className="text-base">Current Risk Score</CardTitle></CardHeader>
+                <CardContent>
+                  <div className="text-center mb-4">
+                    <p className="text-4xl font-black text-foreground">{risk.currentRiskLevel}<span className="text-lg font-normal text-muted-foreground">/25</span></p>
+                    <p className="text-sm text-muted-foreground mt-1">{risk.currentLikelihood} likelihood × {risk.currentSeverity} severity</p>
+                    <div className="mt-3">{ratingBadge(risk.currentRiskRating, true)}</div>
+                  </div>
+                  <div className="w-full bg-muted rounded-full h-3">
+                    <div className={`h-3 rounded-full transition-all ${ratingColor}`} style={{ width: `${ratingBarWidth}%` }} />
+                  </div>
+                  <p className="text-xs text-muted-foreground text-center mt-1">{ratingBarWidth}% of maximum risk level</p>
+                </CardContent>
+              </Card>
+              {risk.description && (
+                <Card><CardHeader><CardTitle className="text-base">Description</CardTitle></CardHeader>
+                  <CardContent><p className="text-sm text-muted-foreground whitespace-pre-wrap">{risk.description}</p></CardContent>
+                </Card>
+              )}
+            </div>
+          </div>
+        </TabsContent>
+
+        {/* Assessments */}
+        <TabsContent value="assessments" className="mt-4">
+          <div className="flex justify-between items-center mb-4">
+            <h3 className="font-semibold">Assessment History</h3>
+            <Button size="sm" onClick={()=>setAssDialog(true)}><Plus className="size-4 mr-1" />Add Assessment</Button>
+          </div>
+          {sorted.length === 0 ? (
+            <div className="text-center py-12 text-muted-foreground"><ShieldAlert className="mx-auto size-10 mb-2 opacity-40" /><p>No assessments yet.</p></div>
+          ) : (
+            <div className="space-y-3">
+              {sorted.map((a, idx) => {
+                const prev = sorted[idx+1];
+                const trend = prev ? (a.riskLevel > prev.riskLevel ? 'up' : a.riskLevel < prev.riskLevel ? 'down' : 'same') : null;
+                const typeColor: Record<string,string> = { INITIAL:'bg-purple-100 text-purple-700', PERIODIC:'bg-blue-100 text-blue-700', TRIGGERED:'bg-orange-100 text-orange-700', POST_TREATMENT:'bg-green-100 text-green-700' };
+                return (
+                  <Card key={a.id}>
+                    <CardContent className="pt-4">
+                      <div className="flex items-center justify-between gap-4 flex-wrap">
+                        <div className="flex items-center gap-2">
+                          <span className={`text-xs px-2 py-0.5 rounded font-medium ${typeColor[a.assessmentType]??'bg-gray-100 text-gray-600'}`}>{a.assessmentType.replace('_',' ')}</span>
+                          {ratingBadge(a.riskRating)}
+                          {trend === 'up' && <span className="flex items-center gap-0.5 text-xs text-red-600 font-medium"><TrendingUp className="size-3" />Increased</span>}
+                          {trend === 'down' && <span className="flex items-center gap-0.5 text-xs text-green-600 font-medium"><TrendingDown className="size-3" />Decreased</span>}
+                          {trend === 'same' && <span className="flex items-center gap-0.5 text-xs text-muted-foreground"><Minus className="size-3" />Unchanged</span>}
+                        </div>
+                        <span className="text-xs text-muted-foreground">{a.assessedBy?.name} · {new Date(a.createdAt).toLocaleDateString()}</span>
+                      </div>
+                      <p className="text-sm font-mono text-muted-foreground mt-1">{a.likelihood} × {a.severity} = {a.riskLevel}</p>
+                      {a.existingControls && <p className="text-sm mt-2"><span className="font-medium">Controls:</span> {a.existingControls}</p>}
+                      {a.recommendations && <p className="text-sm mt-1"><span className="font-medium">Recommendations:</span> {a.recommendations}</p>}
+                    </CardContent>
+                  </Card>
+                );
+              })}
+            </div>
+          )}
+        </TabsContent>
+
+        {/* Treatments */}
+        <TabsContent value="treatments" className="mt-4">
+          <div className="flex justify-between items-center mb-4">
+            <h3 className="font-semibold">Treatment Actions</h3>
+            <Button size="sm" onClick={openTreatDialog}><Plus className="size-4 mr-1" />Add Treatment</Button>
+          </div>
+          {risk.treatments.length === 0 ? (
+            <div className="text-center py-12 text-muted-foreground"><CheckCircle className="mx-auto size-10 mb-2 opacity-40" /><p>No treatments yet.</p></div>
+          ) : (
+            <div className="space-y-3">
+              {risk.treatments.map(t => {
+                const overdueT = t.targetDate && new Date(t.targetDate) < new Date() && !['COMPLETED','CANCELLED'].includes(t.status);
+                return (
+                  <Card key={t.id}>
+                    <CardContent className="pt-4">
+                      <div className="flex items-start justify-between gap-4">
+                        <div className="flex-1">
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <span className="text-xs font-bold px-2 py-0.5 bg-slate-100 text-slate-700 rounded">{t.treatmentType}</span>
+                            {statusBadge(t.status)}
+                            {t.effectiveness && <span className={`text-xs px-2 py-0.5 rounded font-medium ${t.effectiveness==='EFFECTIVE'?'bg-green-100 text-green-700':t.effectiveness==='PARTIALLY_EFFECTIVE'?'bg-yellow-100 text-yellow-700':'bg-red-100 text-red-700'}`}>{t.effectiveness.replace('_',' ')}</span>}
+                          </div>
+                          {t.description && <p className="text-sm mt-2 text-muted-foreground">{t.description}</p>}
+                          <div className="flex gap-4 mt-2 text-xs text-muted-foreground flex-wrap">
+                            {t.responsible && <span>Responsible: {t.responsible.name}</span>}
+                            {t.targetDate && <span className={overdueT ? 'text-red-600 font-semibold' : ''}>Target: {new Date(t.targetDate).toLocaleDateString()}{overdueT && ' (OVERDUE)'}</span>}
+                            {t.completedDate && <span>Completed: {new Date(t.completedDate).toLocaleDateString()}</span>}
+                          </div>
+                        </div>
+                      </div>
+                    </CardContent>
+                  </Card>
+                );
+              })}
+            </div>
+          )}
+        </TabsContent>
+
+        {/* Hazards */}
+        {has45001 && (
+          <TabsContent value="hazards" className="mt-4">
+            <div className="flex justify-between items-center mb-4">
+              <h3 className="font-semibold">Hazard Identification (ISO 45001)</h3>
+              <Button size="sm" onClick={()=>setHazardDialog(true)}><Plus className="size-4 mr-1" />Add Hazard</Button>
+            </div>
+            {risk.hazards.length === 0 ? (
+              <div className="text-center py-12 text-muted-foreground"><AlertTriangle className="mx-auto size-10 mb-2 opacity-40" /><p>No hazards identified.</p></div>
+            ) : (
+              <div className="space-y-3">
+                {risk.hazards.map(h => (
+                  <Card key={h.id}>
+                    <CardContent className="pt-4">
+                      <div className="flex items-start gap-3 flex-wrap">
+                        <span className="text-xs font-bold px-2 py-0.5 bg-slate-100 text-slate-700 rounded">{h.hazardType}</span>
+                        {controlBadge(h.controlHierarchy)}
+                      </div>
+                      {h.hazardDescription && <p className="text-sm mt-2">{h.hazardDescription}</p>}
+                      <div className="flex gap-4 mt-2 text-xs text-muted-foreground flex-wrap">
+                        {h.location && <span>Location: {h.location}</span>}
+                        {h.affectedPersonnel && <span>Affected: {h.affectedPersonnel}</span>}
+                      </div>
+                      {h.controlMeasures && <p className="text-sm mt-2 text-muted-foreground"><span className="font-medium">Controls:</span> {h.controlMeasures}</p>}
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            )}
+          </TabsContent>
+        )}
+      </Tabs>
+
+      {/* Assessment Dialog */}
+      <Dialog open={assDialog} onOpenChange={setAssDialog}>
+        <DialogContent>
+          <DialogHeader><DialogTitle>Add Assessment</DialogTitle></DialogHeader>
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div><Label>Likelihood (1-5)</Label>
+                <Select value={assForm.likelihood} onValueChange={v=>setAssForm(f=>({...f,likelihood:v}))}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>{[1,2,3,4,5].map(n=><SelectItem key={n} value={String(n)}>{n}</SelectItem>)}</SelectContent>
+                </Select>
+              </div>
+              <div><Label>Severity (1-5)</Label>
+                <Select value={assForm.severity} onValueChange={v=>setAssForm(f=>({...f,severity:v}))}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>{[1,2,3,4,5].map(n=><SelectItem key={n} value={String(n)}>{n}</SelectItem>)}</SelectContent>
+                </Select>
+              </div>
+            </div>
+            <div className="flex items-center gap-3 p-3 rounded-lg bg-muted">
+              <span className="text-sm text-muted-foreground">Rating:</span>
+              {ratingBadge(previewRating(parseInt(assForm.likelihood),parseInt(assForm.severity)))}
+              <span className="text-sm font-mono text-muted-foreground">{parseInt(assForm.likelihood)*parseInt(assForm.severity)}/25</span>
+            </div>
+            <div><Label>Assessment Type</Label>
+              <Select value={assForm.assessmentType} onValueChange={v=>setAssForm(f=>({...f,assessmentType:v}))}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>{['INITIAL','PERIODIC','TRIGGERED','POST_TREATMENT'].map(t=><SelectItem key={t} value={t}>{t.replace('_',' ')}</SelectItem>)}</SelectContent>
+              </Select>
+            </div>
+            <div><Label>Existing Controls</Label><Textarea rows={2} value={assForm.existingControls} onChange={e=>setAssForm(f=>({...f,existingControls:e.target.value}))} /></div>
+            <div><Label>Recommendations</Label><Textarea rows={2} value={assForm.recommendations} onChange={e=>setAssForm(f=>({...f,recommendations:e.target.value}))} /></div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={()=>setAssDialog(false)}>Cancel</Button>
+            <Button onClick={saveAssessment} disabled={assSaving}>{assSaving?'Saving…':'Add Assessment'}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Treatment Dialog */}
+      <Dialog open={treatDialog} onOpenChange={setTreatDialog}>
+        <DialogContent>
+          <DialogHeader><DialogTitle>Add Treatment</DialogTitle></DialogHeader>
+          <div className="space-y-4">
+            <div><Label>Treatment Type</Label>
+              <Select value={treatForm.treatmentType} onValueChange={v=>setTreatForm(f=>({...f,treatmentType:v}))}>
+                <SelectTrigger><SelectValue placeholder="Select type" /></SelectTrigger>
+                <SelectContent>{treatTypes.map(t=><SelectItem key={t} value={t}>{t}</SelectItem>)}</SelectContent>
+              </Select>
+            </div>
+            <div><Label>Description</Label><Textarea rows={2} value={treatForm.description} onChange={e=>setTreatForm(f=>({...f,description:e.target.value}))} /></div>
+            <div><Label>Responsible</Label>
+              <Select value={treatForm.responsibleId} onValueChange={v=>setTreatForm(f=>({...f,responsibleId:v}))}>
+                <SelectTrigger><SelectValue placeholder="Select person" /></SelectTrigger>
+                <SelectContent>{users.map(u=><SelectItem key={u.id} value={u.id}>{u.name}</SelectItem>)}</SelectContent>
+              </Select>
+            </div>
+            <div><Label>Target Date</Label><Input type="date" value={treatForm.targetDate} onChange={e=>setTreatForm(f=>({...f,targetDate:e.target.value}))} /></div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={()=>setTreatDialog(false)}>Cancel</Button>
+            <Button onClick={saveTreatment} disabled={treatSaving||!treatForm.treatmentType}>{treatSaving?'Saving…':'Add Treatment'}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Hazard Dialog */}
+      <Dialog open={hazardDialog} onOpenChange={setHazardDialog}>
+        <DialogContent>
+          <DialogHeader><DialogTitle>Add Hazard (ISO 45001)</DialogTitle></DialogHeader>
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div><Label>Hazard Type</Label>
+                <Select value={hazardForm.hazardType} onValueChange={v=>setHazardForm(f=>({...f,hazardType:v}))}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>{HAZARD_TYPES.map(t=><SelectItem key={t} value={t}>{t}</SelectItem>)}</SelectContent>
+                </Select>
+              </div>
+              <div><Label>Control Hierarchy</Label>
+                <Select value={hazardForm.controlHierarchy} onValueChange={v=>setHazardForm(f=>({...f,controlHierarchy:v}))}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>{CONTROL_HIERARCHIES.map(c=><SelectItem key={c} value={c}>{c}</SelectItem>)}</SelectContent>
+                </Select>
+              </div>
+            </div>
+            <div><Label>Description</Label><Textarea rows={2} value={hazardForm.hazardDescription} onChange={e=>setHazardForm(f=>({...f,hazardDescription:e.target.value}))} /></div>
+            <div className="grid grid-cols-2 gap-4">
+              <div><Label>Location</Label><Input value={hazardForm.location} onChange={e=>setHazardForm(f=>({...f,location:e.target.value}))} /></div>
+              <div><Label>Affected Personnel</Label><Input value={hazardForm.affectedPersonnel} onChange={e=>setHazardForm(f=>({...f,affectedPersonnel:e.target.value}))} /></div>
+            </div>
+            <div><Label>Control Measures</Label><Textarea rows={2} value={hazardForm.controlMeasures} onChange={e=>setHazardForm(f=>({...f,controlMeasures:e.target.value}))} /></div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={()=>setHazardDialog(false)}>Cancel</Button>
+            <Button onClick={saveHazard} disabled={hazardSaving}>{hazardSaving?'Saving…':'Add Hazard'}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/app/ims/risks/[id]/page.tsx
+++ b/src/app/ims/risks/[id]/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from 'next';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { verifySession } from '@/lib/jwt';
+import ImsRiskDetailClient from './_page-client';
+
+export const metadata: Metadata = { title: 'Risk Detail | IMS | OTS' };
+export const dynamic = 'force-dynamic';
+
+export default async function ImsRiskDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const store = await cookies();
+  const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+  const session = token ? verifySession(token) : null;
+  if (!session) redirect('/login');
+  return <ImsRiskDetailClient riskId={id} />;
+}

--- a/src/app/ims/risks/_page-client.tsx
+++ b/src/app/ims/risks/_page-client.tsx
@@ -1,0 +1,323 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import Link from 'next/link';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { AlertTriangle, Plus, Search, RefreshCw, TrendingUp, Shield } from 'lucide-react';
+
+type Risk = {
+  id: string; riskNumber: string; title: string; type: string; category: string;
+  status: string; currentLikelihood: number; currentSeverity: number; currentRiskLevel: number;
+  currentRiskRating: string; ownerId: string | null; nextReviewDate: string | null;
+  applicableStandards: string[] | null;
+  owner: { id: string; name: string } | null;
+  department: { id: string; name: string } | null;
+};
+
+const CATEGORIES = ['STRATEGIC','OPERATIONAL','FINANCIAL','COMPLIANCE','ENVIRONMENTAL','HEALTH_SAFETY','TECHNICAL','SUPPLY_CHAIN'];
+
+function ratingBadge(r: string) {
+  const map: Record<string, string> = {
+    LOW: 'bg-green-100 text-green-700 border-green-200',
+    MEDIUM: 'bg-yellow-100 text-yellow-700 border-yellow-200',
+    HIGH: 'bg-orange-100 text-orange-700 border-orange-200',
+    CRITICAL: 'bg-red-100 text-red-700 border-red-200 animate-pulse',
+  };
+  return <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold border ${map[r] ?? 'bg-gray-100 text-gray-700'}`}>{r}</span>;
+}
+
+function typeBadge(t: string) {
+  return t === 'RISK'
+    ? <span className="text-xs border border-red-400 text-red-600 px-2 py-0.5 rounded-full font-medium">Risk</span>
+    : <span className="text-xs border border-green-400 text-green-600 px-2 py-0.5 rounded-full font-medium">Opportunity</span>;
+}
+
+function statusBadge(s: string) {
+  const map: Record<string, string> = {
+    OPEN: 'bg-blue-100 text-blue-700', UNDER_TREATMENT: 'bg-amber-100 text-amber-700',
+    TREATED: 'bg-green-100 text-green-700', ACCEPTED: 'bg-slate-100 text-slate-600',
+    CLOSED: 'bg-gray-100 text-gray-500', MONITORING: 'bg-purple-100 text-purple-700',
+  };
+  return <span className={`text-xs px-2 py-0.5 rounded font-medium ${map[s] ?? 'bg-gray-100 text-gray-600'}`}>{s.replace('_',' ')}</span>;
+}
+
+export default function ImsRisksClient() {
+  const [risks, setRisks] = useState<Risk[]>([]);
+  const [filtered, setFiltered] = useState<Risk[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState('');
+  const [typeF, setTypeF] = useState('all');
+  const [ratingF, setRatingF] = useState('all');
+  const [statusF, setStatusF] = useState('all');
+  const [dialog, setDialog] = useState(false);
+  const [users, setUsers] = useState<{ id: string; name: string }[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [form, setForm] = useState({
+    title: '', type: 'RISK', category: 'OPERATIONAL', description: '', source: '',
+    applicableStandards: [] as string[], ownerId: '', reviewFrequencyDays: '90',
+    likelihood: '1', severity: '1',
+  });
+
+  const fetchRisks = useCallback(async () => {
+    setLoading(true);
+    const res = await fetch('/api/ims/risks');
+    if (res.ok) setRisks(await res.json());
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { fetchRisks(); }, [fetchRisks]);
+
+  useEffect(() => {
+    let r = [...risks];
+    if (search) r = r.filter(x => x.title.toLowerCase().includes(search.toLowerCase()) || x.riskNumber.includes(search));
+    if (typeF !== 'all') r = r.filter(x => x.type === typeF);
+    if (ratingF !== 'all') r = r.filter(x => x.currentRiskRating === ratingF);
+    if (statusF !== 'all') r = r.filter(x => x.status === statusF);
+    setFiltered(r);
+  }, [risks, search, typeF, ratingF, statusF]);
+
+  const openDialog = async () => {
+    const res = await fetch('/api/users');
+    if (res.ok) setUsers(await res.json());
+    setDialog(true);
+  };
+
+  const toggleStandard = (s: string) => {
+    setForm(f => ({
+      ...f,
+      applicableStandards: f.applicableStandards.includes(s)
+        ? f.applicableStandards.filter(x => x !== s)
+        : [...f.applicableStandards, s],
+    }));
+  };
+
+  const previewRating = (l: number, s: number) => {
+    const lvl = l * s;
+    if (lvl <= 4) return 'LOW';
+    if (lvl <= 9) return 'MEDIUM';
+    if (lvl <= 15) return 'HIGH';
+    return 'CRITICAL';
+  };
+
+  const save = async () => {
+    setSaving(true);
+    const res = await fetch('/api/ims/risks', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: form.title, type: form.type, category: form.category,
+        description: form.description, source: form.source,
+        applicableStandards: form.applicableStandards.length ? form.applicableStandards : null,
+        ownerId: form.ownerId || null,
+        reviewFrequencyDays: parseInt(form.reviewFrequencyDays),
+      }),
+    });
+    if (res.ok) {
+      const risk = await res.json();
+      await fetch(`/api/ims/risks/${risk.id}/assessments`, {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          likelihood: parseInt(form.likelihood), severity: parseInt(form.severity),
+          assessmentType: 'INITIAL',
+        }),
+      });
+    }
+    setDialog(false);
+    setForm({ title: '', type: 'RISK', category: 'OPERATIONAL', description: '', source: '', applicableStandards: [], ownerId: '', reviewFrequencyDays: '90', likelihood: '1', severity: '1' });
+    fetchRisks();
+    setSaving(false);
+  };
+
+  const summary = { LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0 };
+  risks.filter(r => r.type === 'RISK').forEach(r => { (summary as Record<string,number>)[r.currentRiskRating]++; });
+
+  return (
+    <div className="p-6 space-y-6">
+      {/* Hero */}
+      <div className="rounded-2xl bg-gradient-to-br from-red-950 to-orange-900 p-6 text-white relative overflow-hidden">
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,_var(--tw-gradient-stops))] from-red-800/30 via-transparent to-transparent" />
+        <div className="relative flex items-start justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <div className="p-3 rounded-xl bg-white/10 backdrop-blur-sm">
+              <AlertTriangle className="size-7 text-red-200" />
+            </div>
+            <div>
+              <h1 className="text-2xl font-bold">Risk & Opportunity Register</h1>
+              <p className="text-red-200 text-sm mt-0.5">ISO 9001/14001/45001 — Clause 6.1</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-3">
+            <div className="flex gap-2 flex-wrap">
+              {Object.entries(summary).map(([k, v]) => (
+                <span key={k} className={`text-xs font-bold px-2.5 py-1 rounded-full ${k==='CRITICAL'?'bg-red-500':k==='HIGH'?'bg-orange-500':k==='MEDIUM'?'bg-yellow-500':'bg-green-500'} text-white`}>
+                  {v} {k}
+                </span>
+              ))}
+            </div>
+            <Button size="sm" variant="secondary" onClick={fetchRisks}><RefreshCw className="size-4" /></Button>
+            <Button size="sm" onClick={openDialog} className="bg-white text-red-900 hover:bg-red-50"><Plus className="size-4 mr-1" />New Risk</Button>
+          </div>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-wrap gap-3 items-center">
+        <div className="relative flex-1 min-w-48">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
+          <Input className="pl-9" placeholder="Search risks…" value={search} onChange={e => setSearch(e.target.value)} />
+        </div>
+        <Select value={typeF} onValueChange={setTypeF}><SelectTrigger className="w-36"><SelectValue placeholder="Type" /></SelectTrigger>
+          <SelectContent><SelectItem value="all">All Types</SelectItem><SelectItem value="RISK">Risks</SelectItem><SelectItem value="OPPORTUNITY">Opportunities</SelectItem></SelectContent>
+        </Select>
+        <Select value={ratingF} onValueChange={setRatingF}><SelectTrigger className="w-36"><SelectValue placeholder="Rating" /></SelectTrigger>
+          <SelectContent><SelectItem value="all">All Ratings</SelectItem>{['LOW','MEDIUM','HIGH','CRITICAL'].map(r => <SelectItem key={r} value={r}>{r}</SelectItem>)}</SelectContent>
+        </Select>
+        <Select value={statusF} onValueChange={setStatusF}><SelectTrigger className="w-44"><SelectValue placeholder="Status" /></SelectTrigger>
+          <SelectContent><SelectItem value="all">All Statuses</SelectItem>{['OPEN','UNDER_TREATMENT','TREATED','ACCEPTED','MONITORING','CLOSED'].map(s => <SelectItem key={s} value={s}>{s.replace('_',' ')}</SelectItem>)}</SelectContent>
+        </Select>
+        {(search || typeF!=='all' || ratingF!=='all' || statusF!=='all') && (
+          <Button variant="ghost" size="sm" onClick={() => { setSearch(''); setTypeF('all'); setRatingF('all'); setStatusF('all'); }}>Clear</Button>
+        )}
+        <span className="text-sm text-muted-foreground ml-auto">{filtered.length} items</span>
+      </div>
+
+      {/* Table */}
+      {loading ? (
+        <div className="space-y-2">{[...Array(5)].map((_,i) => <div key={i} className="h-14 bg-muted animate-pulse rounded-lg" />)}</div>
+      ) : filtered.length === 0 ? (
+        <div className="text-center py-16 text-muted-foreground">
+          <Shield className="mx-auto size-12 mb-3 opacity-30" />
+          <p className="font-medium">No risks found</p>
+        </div>
+      ) : (
+        <div className="rounded-lg border overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/50 border-b">
+              <tr>
+                {['Risk Number','Type','Title','Rating','L×S','Owner','Next Review','Status'].map(h => (
+                  <th key={h} className="text-left px-4 py-3 text-xs font-semibold text-muted-foreground uppercase tracking-wide">{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {filtered.map(r => {
+                const overdue = r.nextReviewDate && new Date(r.nextReviewDate) < new Date();
+                return (
+                  <tr key={r.id} className="hover:bg-muted/30 transition-colors">
+                    <td className="px-4 py-3">
+                      <Link href={`/ims/risks/${r.id}`} className="font-mono font-bold text-primary hover:underline">{r.riskNumber}</Link>
+                    </td>
+                    <td className="px-4 py-3">{typeBadge(r.type)}</td>
+                    <td className="px-4 py-3">
+                      <Link href={`/ims/risks/${r.id}`} className="font-medium hover:underline">{r.title}</Link>
+                      <p className="text-xs text-muted-foreground">{r.category.replace('_',' ')}</p>
+                    </td>
+                    <td className="px-4 py-3">{ratingBadge(r.currentRiskRating)}</td>
+                    <td className="px-4 py-3 text-muted-foreground font-mono text-xs">{r.currentLikelihood}×{r.currentSeverity}={r.currentRiskLevel}</td>
+                    <td className="px-4 py-3 text-muted-foreground">{r.owner?.name ?? '—'}</td>
+                    <td className={`px-4 py-3 text-xs ${overdue ? 'text-red-600 font-semibold' : 'text-muted-foreground'}`}>
+                      {r.nextReviewDate ? new Date(r.nextReviewDate).toLocaleDateString() : '—'}
+                    </td>
+                    <td className="px-4 py-3">{statusBadge(r.status)}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* New Risk Dialog */}
+      <Dialog open={dialog} onOpenChange={setDialog}>
+        <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+          <DialogHeader><DialogTitle>New Risk / Opportunity</DialogTitle></DialogHeader>
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label>Title *</Label>
+                <Input value={form.title} onChange={e => setForm(f=>({...f,title:e.target.value}))} placeholder="Risk title" />
+              </div>
+              <div>
+                <Label>Type</Label>
+                <Select value={form.type} onValueChange={v=>setForm(f=>({...f,type:v}))}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent><SelectItem value="RISK">Risk</SelectItem><SelectItem value="OPPORTUNITY">Opportunity</SelectItem></SelectContent>
+                </Select>
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label>Category</Label>
+                <Select value={form.category} onValueChange={v=>setForm(f=>({...f,category:v}))}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>{CATEGORIES.map(c=><SelectItem key={c} value={c}>{c.replace('_',' ')}</SelectItem>)}</SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Label>Owner</Label>
+                <Select value={form.ownerId} onValueChange={v=>setForm(f=>({...f,ownerId:v}))}>
+                  <SelectTrigger><SelectValue placeholder="Select owner" /></SelectTrigger>
+                  <SelectContent>{users.map(u=><SelectItem key={u.id} value={u.id}>{u.name}</SelectItem>)}</SelectContent>
+                </Select>
+              </div>
+            </div>
+            <div>
+              <Label>Description</Label>
+              <Textarea rows={2} value={form.description} onChange={e=>setForm(f=>({...f,description:e.target.value}))} />
+            </div>
+            <div>
+              <Label>Source</Label>
+              <Input value={form.source} onChange={e=>setForm(f=>({...f,source:e.target.value}))} placeholder="e.g. Internal audit, customer feedback…" />
+            </div>
+            <div>
+              <Label>Applicable Standards</Label>
+              <div className="flex gap-3 mt-1">
+                {['ISO_9001','ISO_14001','ISO_45001'].map(s => (
+                  <label key={s} className="flex items-center gap-1.5 text-sm cursor-pointer">
+                    <input type="checkbox" checked={form.applicableStandards.includes(s)} onChange={()=>toggleStandard(s)} />
+                    {s.replace('ISO_','ISO ')}
+                  </label>
+                ))}
+              </div>
+            </div>
+            <div className="grid grid-cols-3 gap-4">
+              <div>
+                <Label>Likelihood (1-5)</Label>
+                <Select value={form.likelihood} onValueChange={v=>setForm(f=>({...f,likelihood:v}))}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>{[1,2,3,4,5].map(n=><SelectItem key={n} value={String(n)}>{n}</SelectItem>)}</SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Label>Severity (1-5)</Label>
+                <Select value={form.severity} onValueChange={v=>setForm(f=>({...f,severity:v}))}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>{[1,2,3,4,5].map(n=><SelectItem key={n} value={String(n)}>{n}</SelectItem>)}</SelectContent>
+                </Select>
+              </div>
+              <div className="flex flex-col justify-end">
+                <Label>Initial Rating</Label>
+                <div className="mt-1">{ratingBadge(previewRating(parseInt(form.likelihood), parseInt(form.severity)))}</div>
+                <p className="text-xs text-muted-foreground mt-0.5">{form.likelihood}×{form.severity}={parseInt(form.likelihood)*parseInt(form.severity)}</p>
+              </div>
+            </div>
+            <div>
+              <Label>Review Frequency (days)</Label>
+              <Input type="number" value={form.reviewFrequencyDays} onChange={e=>setForm(f=>({...f,reviewFrequencyDays:e.target.value}))} />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={()=>setDialog(false)}>Cancel</Button>
+            <Button onClick={save} disabled={saving||!form.title}>{saving?'Saving…':'Create Risk'}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/app/ims/risks/matrix/_page-client.tsx
+++ b/src/app/ims/risks/matrix/_page-client.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { RefreshCw, Grid3X3 } from 'lucide-react';
+
+type MatrixRisk = { id: string; riskNumber: string; title: string; type: string; status: string };
+type Cell = { likelihood: number; severity: number; riskLevel: number; riskRating: string; risks: MatrixRisk[] };
+type MatrixData = { cells: Cell[]; summary: Record<string, number>; total: number };
+
+const STANDARDS = [
+  { key: 'all', label: 'All Standards' },
+  { key: 'ISO_9001', label: 'ISO 9001' },
+  { key: 'ISO_14001', label: 'ISO 14001' },
+  { key: 'ISO_45001', label: 'ISO 45001' },
+];
+
+function cellColor(rating: string) {
+  return { LOW: 'bg-green-100 hover:bg-green-200 border-green-200', MEDIUM: 'bg-yellow-100 hover:bg-yellow-200 border-yellow-200', HIGH: 'bg-orange-100 hover:bg-orange-200 border-orange-200', CRITICAL: 'bg-red-100 hover:bg-red-200 border-red-200' }[rating] ?? 'bg-gray-100 border-gray-200';
+}
+
+function ratingBadge(r: string) {
+  const map: Record<string, string> = { LOW: 'bg-green-100 text-green-700', MEDIUM: 'bg-yellow-100 text-yellow-700', HIGH: 'bg-orange-100 text-orange-700', CRITICAL: 'bg-red-100 text-red-700' };
+  return <span className={`text-xs font-bold px-2 py-0.5 rounded ${map[r]}`}>{r}</span>;
+}
+
+export default function ImsRiskMatrixClient() {
+  const [data, setData] = useState<MatrixData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [standard, setStandard] = useState('all');
+  const [selected, setSelected] = useState<Cell | null>(null);
+
+  const fetchMatrix = async (std: string) => {
+    setLoading(true);
+    const url = std === 'all' ? '/api/ims/risks/matrix' : `/api/ims/risks/matrix?standard=${std}`;
+    const res = await fetch(url);
+    if (res.ok) setData(await res.json());
+    setLoading(false);
+  };
+
+  useEffect(() => { fetchMatrix(standard); }, [standard]);
+
+  const getCell = (likelihood: number, severity: number) =>
+    data?.cells.find(c => c.likelihood === likelihood && c.severity === severity);
+
+  return (
+    <div className="p-6 space-y-6">
+      {/* Hero */}
+      <div className="rounded-2xl bg-gradient-to-br from-slate-900 to-slate-700 p-6 text-white relative overflow-hidden">
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_bottom_left,_var(--tw-gradient-stops))] from-orange-800/30 via-transparent to-transparent" />
+        <div className="relative flex items-start justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <div className="p-3 rounded-xl bg-white/10"><Grid3X3 className="size-7 text-slate-200" /></div>
+            <div>
+              <h1 className="text-2xl font-bold">Risk Matrix</h1>
+              <p className="text-slate-300 text-sm mt-0.5">5 × 5 Likelihood × Severity heat map</p>
+            </div>
+          </div>
+          <Button size="sm" variant="secondary" onClick={() => fetchMatrix(standard)}><RefreshCw className="size-4" /></Button>
+        </div>
+      </div>
+
+      {/* Standard filter + summary */}
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="flex rounded-lg border overflow-hidden">
+          {STANDARDS.map(s => (
+            <button key={s.key} onClick={() => { setStandard(s.key); setSelected(null); }}
+              className={`px-4 py-2 text-sm font-medium transition-colors ${standard === s.key ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'}`}>
+              {s.label}
+            </button>
+          ))}
+        </div>
+        {data && (
+          <div className="flex gap-2 ml-auto">
+            {Object.entries(data.summary).map(([k, v]) => (
+              <span key={k} className={`text-xs font-bold px-3 py-1.5 rounded-full ${k==='CRITICAL'?'bg-red-100 text-red-700':k==='HIGH'?'bg-orange-100 text-orange-700':k==='MEDIUM'?'bg-yellow-100 text-yellow-700':'bg-green-100 text-green-700'}`}>
+                {v} {k}
+              </span>
+            ))}
+            <span className="text-xs text-muted-foreground self-center ml-2">{data.total} total</span>
+          </div>
+        )}
+      </div>
+
+      {/* Matrix */}
+      {loading ? (
+        <div className="h-80 bg-muted animate-pulse rounded-xl" />
+      ) : (
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex gap-2">
+              {/* Y-axis label */}
+              <div className="flex items-center justify-center w-6">
+                <span className="text-xs text-muted-foreground font-medium -rotate-90 whitespace-nowrap">Severity ↑</span>
+              </div>
+              <div className="flex-1">
+                {/* Grid rows: severity 5 down to 1 */}
+                {[5, 4, 3, 2, 1].map(severity => (
+                  <div key={severity} className="flex gap-1 mb-1 items-center">
+                    <div className="w-6 text-center text-xs font-bold text-muted-foreground">{severity}</div>
+                    {[1, 2, 3, 4, 5].map(likelihood => {
+                      const cell = getCell(likelihood, severity);
+                      const count = cell?.risks.length ?? 0;
+                      const rating = cell?.riskRating ?? 'LOW';
+                      const isSelected = selected?.likelihood === likelihood && selected?.severity === severity;
+                      return (
+                        <button key={likelihood}
+                          onClick={() => setSelected(cell && count > 0 ? (isSelected ? null : cell) : null)}
+                          className={`flex-1 aspect-square min-h-[56px] rounded-lg border text-center flex flex-col items-center justify-center transition-all ${cellColor(rating)} ${count > 0 ? 'cursor-pointer' : 'cursor-default'} ${isSelected ? 'ring-2 ring-offset-1 ring-primary' : ''}`}>
+                          {count > 0 && <span className="text-lg font-black text-foreground/80">{count}</span>}
+                          <span className="text-[10px] font-semibold text-foreground/50">{likelihood * severity}</span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                ))}
+                {/* X-axis */}
+                <div className="flex gap-1 mt-1 ml-7">
+                  {[1, 2, 3, 4, 5].map(l => (
+                    <div key={l} className="flex-1 text-center text-xs font-bold text-muted-foreground">{l}</div>
+                  ))}
+                </div>
+                <p className="text-center text-xs text-muted-foreground mt-1">Likelihood →</p>
+              </div>
+            </div>
+
+            {/* Legend */}
+            <div className="flex gap-3 mt-4 justify-center flex-wrap">
+              {[['LOW','bg-green-100 border-green-200'],['MEDIUM','bg-yellow-100 border-yellow-200'],['HIGH','bg-orange-100 border-orange-200'],['CRITICAL','bg-red-100 border-red-200']].map(([label, cls]) => (
+                <div key={label} className={`flex items-center gap-1.5 text-xs font-medium px-3 py-1 rounded-full border ${cls}`}>
+                  <span>{label}</span>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Selected cell detail */}
+      {selected && selected.risks.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base flex items-center gap-2">
+              Risks at Likelihood {selected.likelihood} × Severity {selected.severity} = {selected.riskLevel}
+              {ratingBadge(selected.riskRating)}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2">
+              {selected.risks.map(r => (
+                <Link key={r.id} href={`/ims/risks/${r.id}`}
+                  className="flex items-center justify-between p-3 rounded-lg border hover:bg-muted/40 transition-colors">
+                  <div>
+                    <span className="font-mono text-sm font-bold">{r.riskNumber}</span>
+                    <span className="ml-3 text-sm">{r.title}</span>
+                  </div>
+                  <div className="flex gap-2">
+                    <span className={`text-xs border rounded-full px-2 py-0.5 font-medium ${r.type==='RISK'?'border-red-400 text-red-600':'border-green-400 text-green-600'}`}>{r.type}</span>
+                    <span className="text-xs bg-muted px-2 py-0.5 rounded">{r.status}</span>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/app/ims/risks/matrix/page.tsx
+++ b/src/app/ims/risks/matrix/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { verifySession } from '@/lib/jwt';
+import ImsRiskMatrixClient from './_page-client';
+
+export const metadata: Metadata = { title: 'Risk Matrix | IMS | OTS' };
+export const dynamic = 'force-dynamic';
+
+export default async function ImsRiskMatrixPage() {
+  const store = await cookies();
+  const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+  const session = token ? verifySession(token) : null;
+  if (!session) redirect('/login');
+  return <ImsRiskMatrixClient />;
+}

--- a/src/app/ims/risks/page.tsx
+++ b/src/app/ims/risks/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from 'next';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { verifySession } from '@/lib/jwt';
+import { ImsRisksClient } from './_page-client';
+
+export const metadata: Metadata = {
+  title: 'Risk Register | IMS | OTS',
+};
+
+export const dynamic = 'force-dynamic';
+
+export default async function ImsRisksPage() {
+  const store = await cookies();
+  const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+  const session = token ? verifySession(token) : null;
+
+  if (!session) redirect('/login');
+
+  return <ImsRisksClient />;
+}

--- a/src/app/ims/risks/treatments/_page-client.tsx
+++ b/src/app/ims/risks/treatments/_page-client.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import Link from 'next/link';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { RefreshCw, CheckCircle, AlertTriangle, Clock } from 'lucide-react';
+
+type Treatment = {
+  id: string; treatmentType: string; description: string | null;
+  status: string; effectiveness: string | null;
+  targetDate: string | null; completedDate: string | null;
+  responsible: { id: string; name: string } | null;
+};
+
+type RiskWithTreatments = {
+  id: string; riskNumber: string; title: string; currentRiskRating: string; type: string;
+  treatments: Treatment[];
+};
+
+type FlatTreatment = Treatment & { riskId: string; riskNumber: string; riskTitle: string; riskRating: string };
+
+function statusBadge(s: string) {
+  const map: Record<string, string> = { PLANNED: 'bg-gray-100 text-gray-600', IN_PROGRESS: 'bg-blue-100 text-blue-700', COMPLETED: 'bg-green-100 text-green-700', OVERDUE: 'bg-red-100 text-red-700', CANCELLED: 'bg-slate-100 text-slate-500' };
+  return <span className={`text-xs px-2 py-0.5 rounded font-medium ${map[s] ?? 'bg-gray-100 text-gray-600'}`}>{s.replace('_',' ')}</span>;
+}
+
+function ratingBadge(r: string) {
+  const map: Record<string, string> = { LOW: 'bg-green-100 text-green-700', MEDIUM: 'bg-yellow-100 text-yellow-700', HIGH: 'bg-orange-100 text-orange-700', CRITICAL: 'bg-red-100 text-red-700' };
+  return <span className={`text-xs px-2 py-0.5 rounded font-bold ${map[r] ?? 'bg-gray-100 text-gray-600'}`}>{r}</span>;
+}
+
+export default function ImsRiskTreatmentsClient() {
+  const [allTreatments, setAllTreatments] = useState<FlatTreatment[]>([]);
+  const [filtered, setFiltered] = useState<FlatTreatment[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [statusF, setStatusF] = useState('all');
+  const [overdueOnly, setOverdueOnly] = useState(false);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    const res = await fetch('/api/ims/risks');
+    if (!res.ok) { setLoading(false); return; }
+    const risks: RiskWithTreatments[] = await res.json();
+
+    // For risks that have treatments, fetch them
+    const risksWithCount = risks.filter((r: RiskWithTreatments & { _count?: { treatments: number } }) =>
+      (r as RiskWithTreatments & { _count?: { treatments: number } })._count?.treatments ?? 0 > 0
+    );
+
+    const treatmentFetches = await Promise.all(
+      risksWithCount.map(async r => {
+        const tr = await fetch(`/api/ims/risks/${r.id}/treatments`);
+        if (!tr.ok) return [];
+        const treatments: Treatment[] = await tr.json();
+        return treatments.map(t => ({
+          ...t,
+          riskId: r.id,
+          riskNumber: r.riskNumber,
+          riskTitle: r.title,
+          riskRating: r.currentRiskRating,
+        }));
+      })
+    );
+
+    const flat = treatmentFetches.flat();
+    setAllTreatments(flat);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { fetchData(); }, [fetchData]);
+
+  useEffect(() => {
+    const now = new Date();
+    let f = [...allTreatments];
+    if (statusF !== 'all') f = f.filter(t => t.status === statusF);
+    if (overdueOnly) f = f.filter(t => t.targetDate && new Date(t.targetDate) < now && !['COMPLETED','CANCELLED'].includes(t.status));
+    setFiltered(f);
+  }, [allTreatments, statusF, overdueOnly]);
+
+  const now = new Date();
+  const overdueCount = allTreatments.filter(t => t.targetDate && new Date(t.targetDate) < now && !['COMPLETED','CANCELLED'].includes(t.status)).length;
+  const completedCount = allTreatments.filter(t => t.status === 'COMPLETED').length;
+
+  return (
+    <div className="p-6 space-y-6">
+      {/* Hero */}
+      <div className="rounded-2xl bg-gradient-to-br from-emerald-950 to-teal-900 p-6 text-white relative overflow-hidden">
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,_var(--tw-gradient-stops))] from-teal-700/30 via-transparent to-transparent" />
+        <div className="relative flex items-start justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <div className="p-3 rounded-xl bg-white/10"><CheckCircle className="size-7 text-emerald-200" /></div>
+            <div>
+              <h1 className="text-2xl font-bold">Risk Treatments Tracker</h1>
+              <p className="text-emerald-200 text-sm mt-0.5">All treatment actions across the risk register</p>
+            </div>
+          </div>
+          <Button size="sm" variant="secondary" onClick={fetchData}><RefreshCw className="size-4" /></Button>
+        </div>
+        <div className="relative flex gap-4 mt-4">
+          <div className="bg-white/10 rounded-lg px-4 py-2 text-center">
+            <p className="text-2xl font-black">{allTreatments.length}</p>
+            <p className="text-xs text-emerald-200">Total</p>
+          </div>
+          <div className="bg-white/10 rounded-lg px-4 py-2 text-center">
+            <p className="text-2xl font-black text-green-300">{completedCount}</p>
+            <p className="text-xs text-emerald-200">Completed</p>
+          </div>
+          <div className={`rounded-lg px-4 py-2 text-center ${overdueCount > 0 ? 'bg-red-500/30' : 'bg-white/10'}`}>
+            <p className="text-2xl font-black text-red-300">{overdueCount}</p>
+            <p className="text-xs text-emerald-200">Overdue</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-wrap gap-3 items-center">
+        <Select value={statusF} onValueChange={setStatusF}>
+          <SelectTrigger className="w-44"><SelectValue placeholder="Status" /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Statuses</SelectItem>
+            {['PLANNED','IN_PROGRESS','COMPLETED','OVERDUE','CANCELLED'].map(s => <SelectItem key={s} value={s}>{s.replace('_',' ')}</SelectItem>)}
+          </SelectContent>
+        </Select>
+        <Button variant={overdueOnly ? 'destructive' : 'outline'} size="sm" onClick={() => setOverdueOnly(o => !o)}>
+          <Clock className="size-4 mr-1.5" />{overdueOnly ? 'Showing Overdue' : 'Overdue Only'}
+        </Button>
+        {(statusF !== 'all' || overdueOnly) && (
+          <Button variant="ghost" size="sm" onClick={() => { setStatusF('all'); setOverdueOnly(false); }}>Clear</Button>
+        )}
+        <span className="text-sm text-muted-foreground ml-auto">{filtered.length} treatments</span>
+      </div>
+
+      {/* List */}
+      {loading ? (
+        <div className="space-y-2">{[...Array(5)].map((_,i) => <div key={i} className="h-20 bg-muted animate-pulse rounded-lg" />)}</div>
+      ) : filtered.length === 0 ? (
+        <div className="text-center py-16 text-muted-foreground">
+          <AlertTriangle className="mx-auto size-12 mb-3 opacity-30" />
+          <p className="font-medium">{overdueOnly ? 'No overdue treatments' : 'No treatments found'}</p>
+        </div>
+      ) : (
+        <div className="rounded-lg border overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/50 border-b">
+              <tr>
+                {['Risk','Rating','Type','Description','Responsible','Target Date','Status','Effectiveness'].map(h => (
+                  <th key={h} className="text-left px-4 py-3 text-xs font-semibold text-muted-foreground uppercase tracking-wide">{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {filtered.map(t => {
+                const overdue = t.targetDate && new Date(t.targetDate) < now && !['COMPLETED','CANCELLED'].includes(t.status);
+                return (
+                  <tr key={t.id} className={`hover:bg-muted/30 transition-colors ${overdue ? 'bg-red-50/50' : ''}`}>
+                    <td className="px-4 py-3">
+                      <Link href={`/ims/risks/${t.riskId}`} className="font-mono text-xs font-bold text-primary hover:underline">{t.riskNumber}</Link>
+                      <p className="text-xs text-muted-foreground truncate max-w-[140px]">{t.riskTitle}</p>
+                    </td>
+                    <td className="px-4 py-3">{ratingBadge(t.riskRating)}</td>
+                    <td className="px-4 py-3"><span className="text-xs font-medium bg-slate-100 text-slate-700 px-2 py-0.5 rounded">{t.treatmentType}</span></td>
+                    <td className="px-4 py-3"><p className="text-xs text-muted-foreground truncate max-w-[180px]">{t.description ?? '—'}</p></td>
+                    <td className="px-4 py-3 text-xs text-muted-foreground">{t.responsible?.name ?? '—'}</td>
+                    <td className={`px-4 py-3 text-xs ${overdue ? 'text-red-600 font-semibold' : 'text-muted-foreground'}`}>
+                      {t.targetDate ? new Date(t.targetDate).toLocaleDateString() : '—'}
+                      {overdue && <span className="block text-red-500">OVERDUE</span>}
+                    </td>
+                    <td className="px-4 py-3">{statusBadge(t.status)}</td>
+                    <td className="px-4 py-3">
+                      {t.effectiveness ? (
+                        <span className={`text-xs px-2 py-0.5 rounded font-medium ${t.effectiveness==='EFFECTIVE'?'bg-green-100 text-green-700':t.effectiveness==='PARTIALLY_EFFECTIVE'?'bg-yellow-100 text-yellow-700':'bg-red-100 text-red-700'}`}>
+                          {t.effectiveness.replace('_',' ')}
+                        </span>
+                      ) : '—'}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/ims/risks/treatments/page.tsx
+++ b/src/app/ims/risks/treatments/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { verifySession } from '@/lib/jwt';
+import ImsRiskTreatmentsClient from './_page-client';
+
+export const metadata: Metadata = { title: 'Treatments Tracker | IMS | OTS' };
+export const dynamic = 'force-dynamic';
+
+export default async function ImsRiskTreatmentsPage() {
+  const store = await cookies();
+  const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+  const session = token ? verifySession(token) : null;
+  if (!session) redirect('/login');
+  return <ImsRiskTreatmentsClient />;
+}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -74,6 +74,13 @@ import {
   UserCircle2,
   Handshake,
   Gift,
+  ShieldCheck,
+  FileBarChart2,
+  GitPullRequest,
+  Grid3X3,
+  CalendarRange,
+  AlertCircle,
+  TrendingDown,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useState, useEffect, useLayoutEffect } from 'react';
@@ -229,6 +236,20 @@ const navigationSections: NavigationSection[] = [
     icon: Handshake,
     items: [
       { name: 'Overview', href: '/business-development', icon: Handshake, newSince: '2026-04-24' },
+    ],
+  },
+  {
+    name: 'IMS',
+    icon: ShieldCheck,
+    items: [
+      { name: 'IMS Dashboard', href: '/ims', icon: LayoutDashboard, newSince: '2026-04-27' },
+      { name: 'Document Registry', href: '/ims/documents', icon: FileText, newSince: '2026-04-27' },
+      { name: 'Change Requests', href: '/ims/change-requests', icon: GitPullRequest, newSince: '2026-04-27' },
+      { name: 'Clause Matrix', href: '/ims/clause-matrix', icon: Grid3X3, newSince: '2026-04-27' },
+      { name: 'Review Calendar', href: '/ims/review-calendar', icon: CalendarRange, newSince: '2026-04-27' },
+      { name: 'Risk Register', href: '/ims/risks', icon: AlertCircle, newSince: '2026-04-27' },
+      { name: 'Risk Matrix', href: '/ims/risks/matrix', icon: TrendingDown, newSince: '2026-04-27' },
+      { name: 'Treatments Tracker', href: '/ims/risks/treatments', icon: FileBarChart2, newSince: '2026-04-27' },
     ],
   },
   {

--- a/src/lib/navigation-permissions.ts
+++ b/src/lib/navigation-permissions.ts
@@ -228,6 +228,17 @@ export const NAVIGATION_PERMISSIONS: NavigationPermissionMap = {
   '/workflow/definitions': ['workflow.definitions.view', 'workflow.definitions.manage'],
   '/workflow/my-approvals': ['workflow.my-approvals.view'],
   '/workflow/guide': null, // Public — anyone logged in can read the guide
+
+  // IMS
+  '/ims': ['ims.view', 'ims.dashboard.view'],
+  '/ims/documents': ['ims.documents.view', 'ims.documents.manage'],
+  '/ims/documents/new': ['ims.documents.manage'],
+  '/ims/change-requests': ['ims.dcr.view', 'ims.dcr.manage'],
+  '/ims/clause-matrix': ['ims.clauses.view', 'ims.clauses.manage'],
+  '/ims/review-calendar': ['ims.documents.view', 'ims.documents.manage'],
+  '/ims/risks': ['ims.risks.view', 'ims.risks.manage'],
+  '/ims/risks/matrix': ['ims.risks.view'],
+  '/ims/risks/treatments': ['ims.risks.treat', 'ims.risks.manage'],
 };
 
 // Helper function to check if user has permission to access a route

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -446,6 +446,27 @@ export const PERMISSIONS: PermissionCategory[] = [
       { id: 'bd.requests.manage', name: 'Manage BD Requests', description: 'Create, update, and delete BD company requests', category: 'business_development' },
     ],
   },
+  {
+    id: 'ims',
+    name: 'IMS',
+    permissions: [
+      { id: 'ims.view', name: 'View IMS Module', description: 'View IMS module', category: 'ims' },
+      { id: 'ims.documents.view', name: 'View IMS Documents', description: 'View documents', category: 'ims' },
+      { id: 'ims.documents.manage', name: 'Manage IMS Documents', description: 'Create/edit/delete documents', category: 'ims' },
+      { id: 'ims.revisions.view', name: 'View Revisions', description: 'View revisions', category: 'ims' },
+      { id: 'ims.revisions.manage', name: 'Manage Revisions', description: 'Manage revisions', category: 'ims' },
+      { id: 'ims.revisions.approve', name: 'Approve Revisions', description: 'Approve revisions (QMR permission)', category: 'ims' },
+      { id: 'ims.dcr.view', name: 'View Change Requests', description: 'View change requests', category: 'ims' },
+      { id: 'ims.dcr.manage', name: 'Manage Change Requests', description: 'Manage change requests', category: 'ims' },
+      { id: 'ims.clauses.view', name: 'View Clause Matrix', description: 'View clause matrix', category: 'ims' },
+      { id: 'ims.clauses.manage', name: 'Manage Clause Mappings', description: 'Manage clause mappings', category: 'ims' },
+      { id: 'ims.risks.view', name: 'View Risk Register', description: 'View risk register', category: 'ims' },
+      { id: 'ims.risks.manage', name: 'Manage Risks', description: 'Create/edit risks', category: 'ims' },
+      { id: 'ims.risks.assess', name: 'Add Risk Assessments', description: 'Add risk assessments', category: 'ims' },
+      { id: 'ims.risks.treat', name: 'Manage Risk Treatments', description: 'Manage risk treatments', category: 'ims' },
+      { id: 'ims.dashboard.view', name: 'View IMS Dashboard', description: 'View IMS dashboard', category: 'ims' },
+    ],
+  },
 ];
 
 // Flatten all permissions for easy lookup
@@ -718,6 +739,19 @@ export const DEFAULT_ROLE_PERMISSIONS: Record<string, string[]> = {
     'workflow.instances.start',
     'workflow.instances.cancel',
     'workflow.my-approvals.view',
+    // IMS
+    'ims.view',
+    'ims.documents.view',
+    'ims.revisions.view',
+    'ims.revisions.approve',
+    'ims.dcr.view',
+    'ims.dcr.manage',
+    'ims.clauses.view',
+    'ims.risks.view',
+    'ims.risks.manage',
+    'ims.risks.assess',
+    'ims.risks.treat',
+    'ims.dashboard.view',
   ],
   Engineer: [
     // Basic Access
@@ -799,6 +833,15 @@ export const DEFAULT_ROLE_PERMISSIONS: Record<string, string[]> = {
     'hr.violations.viewOwn',
     'hr.letters.viewOwn',
     'hr.contracts.viewOwn',
+    // IMS
+    'ims.view',
+    'ims.documents.view',
+    'ims.revisions.view',
+    'ims.dcr.view',
+    'ims.dcr.manage',
+    'ims.clauses.view',
+    'ims.risks.view',
+    'ims.dashboard.view',
   ],
   Operator: [
     // Basic Access
@@ -911,5 +954,21 @@ export const DEFAULT_ROLE_PERMISSIONS: Record<string, string[]> = {
     'hr.violations.viewOwn',
     'hr.letters.viewOwn',
     'hr.contracts.viewOwn',
+    // IMS
+    'ims.view',
+    'ims.documents.view',
+    'ims.documents.manage',
+    'ims.revisions.view',
+    'ims.revisions.manage',
+    'ims.revisions.approve',
+    'ims.dcr.view',
+    'ims.dcr.manage',
+    'ims.clauses.view',
+    'ims.clauses.manage',
+    'ims.risks.view',
+    'ims.risks.manage',
+    'ims.risks.assess',
+    'ims.risks.treat',
+    'ims.dashboard.view',
   ],
 };

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -9,8 +9,8 @@ const { version: pkgVersion } = require('../../package.json') as { version: stri
 
 export const APP_VERSION = {
   version: pkgVersion,
-  date: 'April 24, 2026',
-  type: 'major' as const, // 20.0.0 — Business Development module
+  date: 'April 27, 2026',
+  type: 'major' as const, // 22.0.0 — IMS module
   name: 'Hexa Steel Operation Tracking System',
 };
 


### PR DESCRIPTION
- Prisma: add 11 IMS models (ImsCategory, ImsDocument, ImsRevision, ImsDistribution,
  ImsDistributionRecipient, ImsChangeRequest, ImsClause, ImsClauseMapping, ImsRisk,
  ImsRiskAssessment, ImsRiskTreatment, ImsHazardIdentification) with User/Department relations
- SQL migration: add_ims_module.sql — idempotent stored-procedure pattern for all 11 tables
- Permissions: 15 IMS permissions across ims.documents, ims.revisions, ims.dcr, ims.clauses,
  ims.risks, ims.dashboard; added to Admin, CEO, Manager, Engineer, Document Controller roles
- Navigation: IMS sidebar section (8 items) + 9 nav-permission route mappings
- API routes: /api/ims/documents, /api/ims/documents/[id], revisions, distributions,
  acknowledge, change-requests, categories, clauses, clause-matrix, review-calendar, dashboard

https://claude.ai/code/session_01DSk1fuqBa7u5pCcweaStBW