### PR TITLE
fix: resolve FK constraint crashing workflow step replacement (22.0.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [22.0.3] - 2026-04-28
+
+### Workflow Step Replacement Fix
+
+#### Fixed
+- **"Failed to replace workflow steps"** — `WorkflowStepInstance.stepId` FK was `RESTRICT`, causing `deleteMany` on `WorkflowStep` to fail with a FK constraint violation whenever the workflow had been used (completed step instances existed). Added migration `fix_workflow_step_fk_cascade.sql` to change FK to `ON DELETE CASCADE`; updated Prisma schema to match.
+- **In-progress guard** — API route now returns `409` with a clear message when IN_PROGRESS workflow instances exist, instead of silently attempting an operation that would corrupt in-flight state.
+
+#### Changed
+- Version bumped to **22.0.3**
+
+---
+
 ## [22.0.2] - 2026-04-28
 
 ### IMS Sidebar, Workflow Fix & Seed Repair

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexa-steel-ots",
-  "version": "22.0.2",
+  "version": "22.0.3",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/prisma/manual_migrations/fix_workflow_step_fk_cascade.sql
+++ b/prisma/manual_migrations/fix_workflow_step_fk_cascade.sql
@@ -1,0 +1,24 @@
+-- Fix FK on WorkflowStepInstance.stepId: change RESTRICT → CASCADE so that
+-- replacing workflow steps does not fail when historical step instances exist.
+
+DROP PROCEDURE IF EXISTS fix_wfsi_step_fk_cascade;
+DELIMITER $$
+CREATE PROCEDURE fix_wfsi_step_fk_cascade()
+BEGIN
+  -- Only run if the old RESTRICT FK still exists
+  IF EXISTS (
+    SELECT 1 FROM information_schema.TABLE_CONSTRAINTS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME   = 'WorkflowStepInstance'
+      AND CONSTRAINT_NAME = 'fk_wfsi_step'
+      AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+  ) THEN
+    ALTER TABLE `WorkflowStepInstance` DROP FOREIGN KEY `fk_wfsi_step`;
+    ALTER TABLE `WorkflowStepInstance`
+      ADD CONSTRAINT `fk_wfsi_step` FOREIGN KEY (`stepId`)
+        REFERENCES `WorkflowStep`(`id`) ON DELETE CASCADE;
+  END IF;
+END$$
+DELIMITER ;
+CALL fix_wfsi_step_fk_cascade();
+DROP PROCEDURE IF EXISTS fix_wfsi_step_fk_cascade;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5996,7 +5996,7 @@ model WorkflowStepInstance {
   instanceId        String           @db.Char(36)
   instance          WorkflowInstance @relation(fields: [instanceId], references: [id], onDelete: Cascade)
   stepId            String           @db.Char(36)
-  step              WorkflowStep     @relation(fields: [stepId], references: [id])
+  step              WorkflowStep     @relation(fields: [stepId], references: [id], onDelete: Cascade)
   sequence          Int
   status            String           @default("PENDING") @db.VarChar(20)
   resolvedApprovers Json?

--- a/src/app/api/workflow/definitions/[id]/steps/route.ts
+++ b/src/app/api/workflow/definitions/[id]/steps/route.ts
@@ -33,9 +33,16 @@ export const PUT = withApiContext(async (req, session, ctx) => {
     const definition = await prisma.workflowDefinition.findFirst({ where: { id, deletedAt: null } });
     if (!definition) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 
-    const hasInFlight = await prisma.workflowInstance.count({
+    const inFlightCount = await prisma.workflowInstance.count({
       where: { definitionId: id, status: 'IN_PROGRESS' },
     });
+
+    if (inFlightCount > 0) {
+      return NextResponse.json(
+        { error: 'Cannot replace steps while workflow instances are in progress. Cancel or complete them first.' },
+        { status: 409 },
+      );
+    }
 
     await prisma.$transaction([
       prisma.workflowStep.deleteMany({ where: { definitionId: id } }),
@@ -53,9 +60,6 @@ export const PUT = withApiContext(async (req, session, ctx) => {
           },
         })
       ),
-      ...(hasInFlight
-        ? [prisma.workflowDefinition.update({ where: { id }, data: { version: { increment: 1 } } })]
-        : []),
     ]);
 
     const updated = await prisma.workflowDefinition.findUnique({


### PR DESCRIPTION
WorkflowStepInstance.stepId referenced WorkflowStep with no ON DELETE
clause, so MySQL defaulted to RESTRICT. Any workflow that had been used
(completed step instances still in the DB) caused deleteMany to throw a
FK constraint violation, surfaced as "Failed to replace workflow steps".

- Migration: drop fk_wfsi_step and recreate with ON DELETE CASCADE so
  completed step instances are cleaned up atomically with their step
- Prisma schema: onDelete: Cascade on WorkflowStepInstance.step relation
- API route: block with 409 when IN_PROGRESS instances exist instead of
  attempting a delete that would orphan in-flight step data