### PR TITLE
feat: add Meetings module (v22.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [22.1.0] - 2026-04-28
+
+### Meetings Module
+
+#### Added
+- **Meetings module** — full end-to-end module to record and control all company meetings across every department
+- **Meeting categories** (dropdown): Sales, Operations, Project, Management Review, HR, Quality & Safety, Board, Client, Supplier, Planning, Other (with free-text override) — enables reporting by type (e.g. "20 sales meetings this year")
+- **Schedule form** — subject, category, date/time, duration, location, department, agenda, attendees (multi-select from OTS users), linked OTS tasks for discussion, and optional Google Meet link generation
+- **Meeting detail sheet** — full read view with attendee RSVP status, linked tasks, agenda, minutes, and decisions; organiser can edit or cancel the meeting
+- **Post-meeting minutes editor** — organiser records minutes and key decisions after the meeting and marks it Completed
+- **Inline RSVP** — attendees can accept or decline directly from the meeting card without opening the detail view
+- **KPI strip** — total meetings this year, completed count, upcoming count, and top-category breakdown
+- **Filters** — filter by category and status with live text search
+- **Google Calendar integration** — optional Meet link auto-generation via Google Calendar API (service account); graceful no-op when `GOOGLE_CALENDAR_CREDENTIALS` is not configured
+- **Permissions**: `meetings.view`, `meetings.view_all`, `meetings.create`, `meetings.edit`, `meetings.edit_all`, `meetings.delete`, `meetings.record_minutes`
+- **Navigation** — Meetings section added to sidebar with "New" badge
+- **Database** — three new tables: `Meeting`, `MeetingAttendee`, `MeetingTask`; migration at `prisma/manual_migrations/add_meetings_module.sql`
+- **New env vars**: `GOOGLE_CALENDAR_CREDENTIALS` (service-account JSON), `GOOGLE_CALENDAR_IMPERSONATE_EMAIL`
+
+#### Changed
+- Version bumped to **22.1.0**
+
+---
+
 ## [22.0.2] - 2026-04-28
 
 ### IMS Sidebar, Workflow Fix & Seed Repair

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexa-steel-ots",
-  "version": "22.0.2",
+  "version": "22.1.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/prisma/manual_migrations/add_meetings_module.sql
+++ b/prisma/manual_migrations/add_meetings_module.sql
@@ -1,0 +1,114 @@
+-- 22.1.0 — Meetings Module
+-- Tracks all company meetings: sales, operations, project, HR, management review, etc.
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- Meeting
+-- ──────────────────────────────────────────────────────────────────────────────
+DROP PROCEDURE IF EXISTS create_meeting;
+DELIMITER $$
+CREATE PROCEDURE create_meeting()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'Meeting'
+  ) THEN
+    CREATE TABLE Meeting (
+      id             CHAR(36)     NOT NULL PRIMARY KEY,
+      category       VARCHAR(50)  NOT NULL,
+      categoryCustom VARCHAR(150) NULL,
+      subject        VARCHAR(255) NOT NULL,
+      status         VARCHAR(30)  NOT NULL DEFAULT 'scheduled',
+      scheduledAt    DATETIME(3)  NOT NULL,
+      endsAt         DATETIME(3)  NOT NULL,
+      location       VARCHAR(255) NULL,
+      meetLink       VARCHAR(500) NULL,
+      googleEventId  VARCHAR(255) NULL,
+      agenda         TEXT         NULL,
+      minutes        TEXT         NULL,
+      decisions      TEXT         NULL,
+      isPrivate      TINYINT(1)   NOT NULL DEFAULT 0,
+      organizerId    CHAR(36)     NOT NULL,
+      departmentId   CHAR(36)     NULL,
+      createdById    CHAR(36)     NOT NULL,
+      updatedById    CHAR(36)     NULL,
+      deletedAt      DATETIME(3)  NULL,
+      deletedById    CHAR(36)     NULL,
+      createdAt      DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+      updatedAt      DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+      INDEX idx_meeting_category    (category),
+      INDEX idx_meeting_status      (status),
+      INDEX idx_meeting_scheduledAt (scheduledAt),
+      INDEX idx_meeting_organizerId (organizerId),
+      INDEX idx_meeting_deptId      (departmentId),
+      INDEX idx_meeting_deletedAt   (deletedAt),
+      CONSTRAINT fk_meeting_organizer   FOREIGN KEY (organizerId)  REFERENCES User(id),
+      CONSTRAINT fk_meeting_department  FOREIGN KEY (departmentId) REFERENCES Department(id),
+      CONSTRAINT fk_meeting_createdBy   FOREIGN KEY (createdById)  REFERENCES User(id),
+      CONSTRAINT fk_meeting_updatedBy   FOREIGN KEY (updatedById)  REFERENCES User(id),
+      CONSTRAINT fk_meeting_deletedBy   FOREIGN KEY (deletedById)  REFERENCES User(id)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+  END IF;
+END$$
+DELIMITER ;
+CALL create_meeting();
+DROP PROCEDURE IF EXISTS create_meeting;
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- MeetingAttendee
+-- ──────────────────────────────────────────────────────────────────────────────
+DROP PROCEDURE IF EXISTS create_meeting_attendee;
+DELIMITER $$
+CREATE PROCEDURE create_meeting_attendee()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'MeetingAttendee'
+  ) THEN
+    CREATE TABLE MeetingAttendee (
+      id         CHAR(36)    NOT NULL PRIMARY KEY,
+      meetingId  CHAR(36)    NOT NULL,
+      userId     CHAR(36)    NOT NULL,
+      status     VARCHAR(30) NOT NULL DEFAULT 'invited',
+      isRequired TINYINT(1)  NOT NULL DEFAULT 1,
+      createdAt  DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+      updatedAt  DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+      UNIQUE KEY uq_meeting_attendee (meetingId, userId),
+      INDEX idx_ma_meetingId (meetingId),
+      INDEX idx_ma_userId    (userId),
+      CONSTRAINT fk_ma_meeting FOREIGN KEY (meetingId) REFERENCES Meeting(id) ON DELETE CASCADE,
+      CONSTRAINT fk_ma_user    FOREIGN KEY (userId)    REFERENCES User(id)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+  END IF;
+END$$
+DELIMITER ;
+CALL create_meeting_attendee();
+DROP PROCEDURE IF EXISTS create_meeting_attendee;
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- MeetingTask
+-- ──────────────────────────────────────────────────────────────────────────────
+DROP PROCEDURE IF EXISTS create_meeting_task;
+DELIMITER $$
+CREATE PROCEDURE create_meeting_task()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'MeetingTask'
+  ) THEN
+    CREATE TABLE MeetingTask (
+      id        CHAR(36)    NOT NULL PRIMARY KEY,
+      meetingId CHAR(36)    NOT NULL,
+      taskId    CHAR(36)    NOT NULL,
+      notes     TEXT        NULL,
+      createdAt DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+      UNIQUE KEY uq_meeting_task (meetingId, taskId),
+      INDEX idx_mt_meetingId (meetingId),
+      INDEX idx_mt_taskId    (taskId),
+      CONSTRAINT fk_mt_meeting FOREIGN KEY (meetingId) REFERENCES Meeting(id) ON DELETE CASCADE,
+      CONSTRAINT fk_mt_task    FOREIGN KEY (taskId)    REFERENCES Task(id)    ON DELETE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+  END IF;
+END$$
+DELIMITER ;
+CALL create_meeting_task();
+DROP PROCEDURE IF EXISTS create_meeting_task;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,6 +44,7 @@ model Department {
   circulationRecipients HrCirculationRecipient[] @relation("DepartmentCirculationRecipients")
   imsDocuments          ImsDocument[]            @relation("ImsDepartmentDocuments")
   imsRisks              ImsRisk[]                @relation("ImsRiskDepartment")
+  meetings              Meeting[]                @relation("MeetingDepartment")
   createdAt             DateTime                 @default(now())
   updatedAt             DateTime                 @updatedAt
 }
@@ -353,6 +354,13 @@ model User {
   ownedImsRisks                  ImsRisk[]                  @relation("ImsRiskOwner")
   imsRiskAssessments             ImsRiskAssessment[]        @relation("ImsRiskAssessor")
   imsRiskTreatments              ImsRiskTreatment[]         @relation("ImsRiskTreatmentResponsible")
+
+  // Meetings back-relations (22.1.0)
+  organizedMeetings    Meeting[]         @relation("MeetingOrganizer")
+  meetingAttendances   MeetingAttendee[] @relation("MeetingAttendees")
+  createdMeetings      Meeting[]         @relation("MeetingCreatedBy")
+  updatedMeetings      Meeting[]         @relation("MeetingUpdatedBy")
+  deletedMeetings      Meeting[]         @relation("MeetingDeletedBy")
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -788,6 +796,7 @@ model Task {
   paymentScheduleLinks     ProjectPaymentSchedule[]
   messages                 TaskMessage[]
   conversationParticipants TaskConversationParticipant[]
+  meetingTasks             MeetingTask[]
 }
 
 model TaskAttachment {
@@ -6343,4 +6352,93 @@ model ImsHazardIdentification {
 
   @@index([riskId])
   @@map("ImsHazardIdentification")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Meetings Module (22.1.0)
+// ─────────────────────────────────────────────────────────────────────────────
+
+model Meeting {
+  id             String  @id @default(uuid()) @db.Char(36)
+  /// Predefined category key: 'sales' | 'operations' | 'project' | 'management_review' | 'hr' | 'quality_safety' | 'board' | 'client' | 'supplier' | 'planning' | 'other'
+  category       String  @db.VarChar(50)
+  /// Free-text label when category = 'other'
+  categoryCustom String? @db.VarChar(150)
+  /// Specific topic / subject of this meeting
+  subject        String  @db.VarChar(255)
+  status         String  @default("scheduled") @db.VarChar(30) // scheduled | in_progress | completed | cancelled
+  scheduledAt    DateTime
+  endsAt         DateTime
+  /// Physical room / address, or null if fully online
+  location       String? @db.VarChar(255)
+  /// Google Meet / Zoom / Teams link
+  meetLink       String? @db.VarChar(500)
+  /// Google Calendar event ID (for sync / cancellation)
+  googleEventId  String? @db.VarChar(255)
+  agenda         String? @db.Text
+  /// Filled after the meeting completes
+  minutes        String? @db.Text
+  /// Key decisions recorded post-meeting
+  decisions      String? @db.Text
+  isPrivate      Boolean @default(false)
+
+  organizerId  String      @db.Char(36)
+  organizer    User        @relation("MeetingOrganizer", fields: [organizerId], references: [id])
+  departmentId String?     @db.Char(36)
+  department   Department? @relation("MeetingDepartment", fields: [departmentId], references: [id])
+
+  attendees MeetingAttendee[]
+  tasks     MeetingTask[]
+
+  createdById String   @db.Char(36)
+  createdBy   User     @relation("MeetingCreatedBy", fields: [createdById], references: [id])
+  updatedById String?  @db.Char(36)
+  updatedBy   User?    @relation("MeetingUpdatedBy", fields: [updatedById], references: [id])
+  deletedAt   DateTime?
+  deletedById String?  @db.Char(36)
+  deletedBy   User?    @relation("MeetingDeletedBy", fields: [deletedById], references: [id])
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@index([category])
+  @@index([status])
+  @@index([scheduledAt])
+  @@index([organizerId])
+  @@index([departmentId])
+  @@index([deletedAt])
+  @@map("Meeting")
+}
+
+model MeetingAttendee {
+  id        String  @id @default(uuid()) @db.Char(36)
+  meetingId String  @db.Char(36)
+  meeting   Meeting @relation(fields: [meetingId], references: [id], onDelete: Cascade)
+  userId    String  @db.Char(36)
+  user      User    @relation("MeetingAttendees", fields: [userId], references: [id])
+  /// invited | accepted | declined | attended | absent
+  status     String  @default("invited") @db.VarChar(30)
+  isRequired Boolean @default(true)
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  @@unique([meetingId, userId])
+  @@index([meetingId])
+  @@index([userId])
+  @@map("MeetingAttendee")
+}
+
+model MeetingTask {
+  id        String  @id @default(uuid()) @db.Char(36)
+  meetingId String  @db.Char(36)
+  meeting   Meeting @relation(fields: [meetingId], references: [id], onDelete: Cascade)
+  taskId    String  @db.Char(36)
+  task      Task    @relation(fields: [taskId], references: [id], onDelete: Cascade)
+  /// Optional discussion note for this specific task in this meeting
+  notes     String? @db.Text
+  createdAt DateTime @default(now())
+
+  @@unique([meetingId, taskId])
+  @@index([meetingId])
+  @@index([taskId])
+  @@map("MeetingTask")
 }

--- a/src/app/api/meetings/[id]/attendees/route.ts
+++ b/src/app/api/meetings/[id]/attendees/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import { updateAttendeeStatus } from '@/lib/services/meeting.service';
+
+const statusSchema = z.object({
+  status: z.enum(['invited', 'accepted', 'declined', 'attended', 'absent']),
+});
+
+export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id: meetingId } = await params;
+  const store = await cookies();
+  const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+  const session = token ? verifySession(token) : null;
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const body = await req.json();
+  const parsed = statusSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 422 });
+  }
+
+  await updateAttendeeStatus(meetingId, session.sub, parsed.data.status);
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/meetings/[id]/route.ts
+++ b/src/app/api/meetings/[id]/route.ts
@@ -1,0 +1,132 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import { getCurrentUserPermissions } from '@/lib/permission-checker';
+import { logActivity } from '@/lib/api-utils';
+import {
+  getMeetingById,
+  updateMeeting,
+  deleteMeeting,
+  MEETING_CATEGORIES,
+} from '@/lib/services/meeting.service';
+
+const CATEGORY_VALUES = MEETING_CATEGORIES.map((c) => c.value) as [string, ...string[]];
+
+const updateSchema = z.object({
+  category: z.enum(CATEGORY_VALUES as [typeof CATEGORY_VALUES[0], ...typeof CATEGORY_VALUES]).optional(),
+  categoryCustom: z.string().max(150).optional().nullable(),
+  subject: z.string().min(2).max(255).optional(),
+  status: z.enum(['scheduled', 'in_progress', 'completed', 'cancelled']).optional(),
+  scheduledAt: z.string().datetime().optional(),
+  endsAt: z.string().datetime().optional(),
+  location: z.string().max(255).optional().nullable(),
+  meetLink: z.string().url().max(500).optional().nullable(),
+  agenda: z.string().optional().nullable(),
+  minutes: z.string().optional().nullable(),
+  decisions: z.string().optional().nullable(),
+  isPrivate: z.boolean().optional(),
+  departmentId: z.string().uuid().optional().nullable(),
+  attendeeIds: z.array(z.string().uuid()).optional(),
+  taskIds: z.array(z.string().uuid()).optional(),
+});
+
+export async function GET(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const store = await cookies();
+  const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+  const session = token ? verifySession(token) : null;
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const userPermissions = await getCurrentUserPermissions();
+  const canViewAll = userPermissions.includes('meetings.view_all');
+
+  const meeting = await getMeetingById(id, session.sub, canViewAll);
+  if (!meeting) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+  return NextResponse.json(meeting);
+}
+
+export async function PUT(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const store = await cookies();
+  const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+  const session = token ? verifySession(token) : null;
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const userPermissions = await getCurrentUserPermissions();
+  const canViewAll = userPermissions.includes('meetings.view_all');
+  const canEditAll = userPermissions.includes('meetings.edit_all');
+  const canEdit = userPermissions.includes('meetings.edit');
+
+  const existing = await getMeetingById(id, session.sub, canViewAll);
+  if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+  const isOrganizer = existing.organizerId === session.sub;
+  if (!canEditAll && !(canEdit && isOrganizer)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const body = await req.json();
+  const parsed = updateSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 422 });
+  }
+
+  const input = parsed.data;
+  const { meeting } = await updateMeeting(id, {
+    ...input,
+    category: input.category as Parameters<typeof updateMeeting>[1]['category'],
+    categoryCustom: input.categoryCustom ?? undefined,
+    location: input.location ?? undefined,
+    meetLink: input.meetLink ?? undefined,
+    agenda: input.agenda ?? undefined,
+    minutes: input.minutes ?? undefined,
+    decisions: input.decisions ?? undefined,
+    departmentId: input.departmentId ?? undefined,
+    scheduledAt: input.scheduledAt ? new Date(input.scheduledAt) : undefined,
+    endsAt: input.endsAt ? new Date(input.endsAt) : undefined,
+    updatedById: session.sub,
+  });
+
+  await logActivity({
+    action: 'UPDATE',
+    entityType: 'Meeting',
+    entityId: id,
+    entityName: meeting.subject,
+    userId: session.sub,
+  });
+
+  return NextResponse.json(meeting);
+}
+
+export async function DELETE(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const store = await cookies();
+  const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+  const session = token ? verifySession(token) : null;
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const userPermissions = await getCurrentUserPermissions();
+  const canViewAll = userPermissions.includes('meetings.view_all');
+  const canDelete = userPermissions.includes('meetings.delete');
+
+  const existing = await getMeetingById(id, session.sub, canViewAll);
+  if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+  if (!canDelete && existing.organizerId !== session.sub) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  await deleteMeeting(id, session.sub);
+
+  await logActivity({
+    action: 'DELETE',
+    entityType: 'Meeting',
+    entityId: id,
+    entityName: existing.subject,
+    userId: session.sub,
+  });
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/meetings/route.ts
+++ b/src/app/api/meetings/route.ts
@@ -1,0 +1,114 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import { getCurrentUserPermissions } from '@/lib/permission-checker';
+import { logActivity } from '@/lib/api-utils';
+import {
+  getMeetings,
+  getMeetingStats,
+  createMeeting,
+  MEETING_CATEGORIES,
+} from '@/lib/services/meeting.service';
+
+const CATEGORY_VALUES = MEETING_CATEGORIES.map((c) => c.value) as [string, ...string[]];
+
+const createSchema = z.object({
+  category: z.enum(CATEGORY_VALUES as [typeof CATEGORY_VALUES[0], ...typeof CATEGORY_VALUES]),
+  categoryCustom: z.string().max(150).optional().nullable(),
+  subject: z.string().min(2).max(255),
+  scheduledAt: z.string().datetime(),
+  endsAt: z.string().datetime(),
+  location: z.string().max(255).optional().nullable(),
+  agenda: z.string().optional().nullable(),
+  isPrivate: z.boolean().optional(),
+  departmentId: z.string().uuid().optional().nullable(),
+  attendeeIds: z.array(z.string().uuid()).min(0),
+  taskIds: z.array(z.string().uuid()).optional(),
+  generateMeetLink: z.boolean().optional(),
+});
+
+export async function GET(req: Request) {
+  const store = await cookies();
+  const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+  const session = token ? verifySession(token) : null;
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const userPermissions = await getCurrentUserPermissions();
+  const canViewAll = userPermissions.includes('meetings.view_all');
+
+  const { searchParams } = new URL(req.url);
+  const mode = searchParams.get('mode');
+
+  if (mode === 'stats') {
+    const year = parseInt(searchParams.get('year') ?? String(new Date().getFullYear()), 10);
+    const stats = await getMeetingStats(session.sub, canViewAll, year);
+    return NextResponse.json(stats);
+  }
+
+  const category = searchParams.get('category') ?? undefined;
+  const status = searchParams.get('status') ?? undefined;
+  const from = searchParams.get('from') ? new Date(searchParams.get('from')!) : undefined;
+  const to = searchParams.get('to') ? new Date(searchParams.get('to')!) : undefined;
+  const page = parseInt(searchParams.get('page') ?? '1', 10);
+  const pageSize = parseInt(searchParams.get('pageSize') ?? '50', 10);
+
+  const result = await getMeetings({
+    userId: session.sub,
+    canViewAll,
+    category,
+    status,
+    from,
+    to,
+    page,
+    pageSize,
+  });
+
+  return NextResponse.json(result);
+}
+
+export async function POST(req: Request) {
+  const store = await cookies();
+  const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+  const session = token ? verifySession(token) : null;
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const userPermissions = await getCurrentUserPermissions();
+  if (!userPermissions.includes('meetings.create')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const body = await req.json();
+  const parsed = createSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 422 });
+  }
+
+  const input = parsed.data;
+  const meeting = await createMeeting({
+    category: input.category as Parameters<typeof createMeeting>[0]['category'],
+    categoryCustom: input.categoryCustom ?? undefined,
+    subject: input.subject,
+    scheduledAt: new Date(input.scheduledAt),
+    endsAt: new Date(input.endsAt),
+    location: input.location ?? undefined,
+    agenda: input.agenda ?? undefined,
+    isPrivate: input.isPrivate ?? false,
+    departmentId: input.departmentId ?? undefined,
+    attendeeIds: input.attendeeIds,
+    taskIds: input.taskIds ?? [],
+    generateMeetLink: input.generateMeetLink ?? false,
+    organizerId: session.sub,
+    createdById: session.sub,
+  });
+
+  await logActivity({
+    action: 'CREATE',
+    entityType: 'Meeting',
+    entityId: meeting.id,
+    entityName: meeting.subject,
+    userId: session.sub,
+  });
+
+  return NextResponse.json(meeting, { status: 201 });
+}

--- a/src/app/meetings/_page-client.tsx
+++ b/src/app/meetings/_page-client.tsx
@@ -1,0 +1,475 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import {
+  Calendar,
+  Plus,
+  Search,
+  Filter,
+  Video,
+  MapPin,
+  Users,
+  Clock,
+  CheckCircle2,
+  XCircle,
+  AlertCircle,
+  BarChart3,
+  RefreshCw,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { useToast } from '@/hooks/use-toast';
+import MeetingFormSheet from '@/components/meetings/meeting-form-sheet';
+import MeetingDetailSheet from '@/components/meetings/meeting-detail-sheet';
+import { MEETING_CATEGORIES } from '@/lib/services/meeting.service';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface Attendee {
+  id: string;
+  userId: string;
+  status: string;
+  isRequired: boolean;
+  user: { id: string; name: string; position: string | null };
+}
+
+interface LinkedTask {
+  id: string;
+  taskId: string;
+  notes: string | null;
+  task: { id: string; title: string; status: string; priority: string };
+}
+
+interface Meeting {
+  id: string;
+  category: string;
+  categoryCustom: string | null;
+  subject: string;
+  status: string;
+  scheduledAt: string;
+  endsAt: string;
+  location: string | null;
+  meetLink: string | null;
+  googleEventId: string | null;
+  agenda: string | null;
+  minutes: string | null;
+  decisions: string | null;
+  isPrivate: boolean;
+  departmentId: string | null;
+  organizerId: string;
+  organizer: { id: string; name: string; position: string | null };
+  department: { id: string; name: string } | null;
+  attendees: Attendee[];
+  tasks: LinkedTask[];
+  createdAt: string;
+}
+
+interface Stats {
+  total: number;
+  byCategory: Record<string, number>;
+  byStatus: Record<string, number>;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const CATEGORY_COLORS: Record<string, string> = {
+  sales: 'bg-emerald-100 text-emerald-700 border-emerald-200',
+  operations: 'bg-blue-100 text-blue-700 border-blue-200',
+  project: 'bg-violet-100 text-violetald-700 border-violet-200',
+  management_review: 'bg-amber-100 text-amber-700 border-amber-200',
+  hr: 'bg-pink-100 text-pink-700 border-pink-200',
+  quality_safety: 'bg-orange-100 text-orange-700 border-orange-200',
+  board: 'bg-slate-100 text-slate-700 border-slate-200',
+  client: 'bg-cyan-100 text-cyan-700 border-cyan-200',
+  supplier: 'bg-lime-100 text-lime-700 border-lime-200',
+  planning: 'bg-indigo-100 text-indigo-700 border-indigo-200',
+  other: 'bg-gray-100 text-gray-600 border-gray-200',
+};
+
+const STATUS_CONFIG: Record<string, { label: string; color: string; icon: React.ReactNode }> = {
+  scheduled: { label: 'Scheduled', color: 'bg-blue-100 text-blue-700', icon: <Clock className="h-3 w-3" /> },
+  in_progress: { label: 'In Progress', color: 'bg-amber-100 text-amber-700', icon: <AlertCircle className="h-3 w-3" /> },
+  completed: { label: 'Completed', color: 'bg-emerald-100 text-emerald-700', icon: <CheckCircle2 className="h-3 w-3" /> },
+  cancelled: { label: 'Cancelled', color: 'bg-red-100 text-red-700', icon: <XCircle className="h-3 w-3" /> },
+};
+
+function getCategoryLabel(meeting: Meeting): string {
+  if (meeting.category === 'other') return meeting.categoryCustom || 'Other';
+  return MEETING_CATEGORIES.find((c) => c.value === meeting.category)?.label ?? meeting.category;
+}
+
+function formatDateTime(iso: string): string {
+  return new Date(iso).toLocaleString('en-SA', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function formatDuration(start: string, end: string): string {
+  const mins = Math.round((new Date(end).getTime() - new Date(start).getTime()) / 60000);
+  if (mins < 60) return `${mins}m`;
+  const h = Math.floor(mins / 60);
+  const m = mins % 60;
+  return m ? `${h}h ${m}m` : `${h}h`;
+}
+
+// ─── KPI Card ─────────────────────────────────────────────────────────────────
+
+function KpiCard({ label, value, sub }: { label: string; value: number | string; sub?: string }) {
+  return (
+    <div className="rounded-xl border bg-white px-5 py-4 shadow-sm">
+      <p className="text-xs font-medium text-slate-500 uppercase tracking-wide">{label}</p>
+      <p className="mt-1 text-2xl font-bold text-slate-800">{value}</p>
+      {sub && <p className="text-xs text-slate-400 mt-0.5">{sub}</p>}
+    </div>
+  );
+}
+
+// ─── Meeting Card ─────────────────────────────────────────────────────────────
+
+function MeetingCard({
+  meeting,
+  onSelect,
+  onRsvp,
+  currentUserId,
+}: {
+  meeting: Meeting;
+  onSelect: (m: Meeting) => void;
+  onRsvp: (meetingId: string, status: 'accepted' | 'declined') => void;
+  currentUserId: string;
+}) {
+  const catLabel = getCategoryLabel(meeting);
+  const catColor = CATEGORY_COLORS[meeting.category] ?? CATEGORY_COLORS.other;
+  const statusCfg = STATUS_CONFIG[meeting.status] ?? STATUS_CONFIG.scheduled;
+  const myAttendance = meeting.attendees.find((a) => a.userId === currentUserId);
+  const isOrganizer = meeting.organizerId === currentUserId;
+  const isPast = new Date(meeting.endsAt) < new Date();
+
+  return (
+    <Card
+      className="cursor-pointer hover:shadow-md transition-shadow border-l-4 group"
+      style={{ borderLeftColor: meeting.status === 'cancelled' ? '#ef4444' : meeting.status === 'completed' ? '#10b981' : '#3b82f6' }}
+      onClick={() => onSelect(meeting)}
+    >
+      <CardHeader className="pb-2 pt-4 px-4">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex flex-wrap gap-1.5">
+            <Badge variant="outline" className={`text-xs border ${catColor}`}>{catLabel}</Badge>
+            <Badge className={`text-xs flex items-center gap-1 ${statusCfg.color} border-0`}>
+              {statusCfg.icon}{statusCfg.label}
+            </Badge>
+            {meeting.isPrivate && <Badge variant="outline" className="text-xs text-slate-400">Private</Badge>}
+          </div>
+          {meeting.meetLink && (
+            <a
+              href={meeting.meetLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={(e) => e.stopPropagation()}
+              className="flex items-center gap-1 text-xs font-medium text-blue-600 hover:text-blue-800 shrink-0"
+            >
+              <Video className="h-3.5 w-3.5" />
+              Join Meet
+            </a>
+          )}
+        </div>
+        <h3 className="font-semibold text-slate-800 text-sm mt-1 leading-snug">{meeting.subject}</h3>
+      </CardHeader>
+      <CardContent className="px-4 pb-4 space-y-2">
+        <div className="flex flex-wrap gap-3 text-xs text-slate-500">
+          <span className="flex items-center gap-1">
+            <Clock className="h-3 w-3" />
+            {formatDateTime(meeting.scheduledAt)}
+            <span className="text-slate-400">· {formatDuration(meeting.scheduledAt, meeting.endsAt)}</span>
+          </span>
+          {meeting.location && (
+            <span className="flex items-center gap-1">
+              <MapPin className="h-3 w-3" />{meeting.location}
+            </span>
+          )}
+          <span className="flex items-center gap-1">
+            <Users className="h-3 w-3" />{meeting.attendees.length} attendees
+          </span>
+        </div>
+        <div className="flex items-center justify-between">
+          <p className="text-xs text-slate-400">
+            Organised by <span className="font-medium text-slate-600">{meeting.organizer.name}</span>
+            {meeting.department && <> · {meeting.department.name}</>}
+          </p>
+          {myAttendance && !isOrganizer && !isPast && meeting.status === 'scheduled' && (
+            <div className="flex gap-1.5" onClick={(e) => e.stopPropagation()}>
+              {myAttendance.status !== 'accepted' && (
+                <Button size="sm" variant="outline" className="h-6 text-xs text-emerald-600 border-emerald-300 hover:bg-emerald-50"
+                  onClick={() => onRsvp(meeting.id, 'accepted')}>Accept</Button>
+              )}
+              {myAttendance.status !== 'declined' && (
+                <Button size="sm" variant="outline" className="h-6 text-xs text-red-600 border-red-300 hover:bg-red-50"
+                  onClick={() => onRsvp(meeting.id, 'declined')}>Decline</Button>
+              )}
+            </div>
+          )}
+          {myAttendance && myAttendance.status === 'accepted' && !isOrganizer && (
+            <Badge className="text-xs bg-emerald-100 text-emerald-700 border-0">Accepted</Badge>
+          )}
+          {myAttendance && myAttendance.status === 'declined' && !isOrganizer && (
+            <Badge className="text-xs bg-red-100 text-red-700 border-0">Declined</Badge>
+          )}
+          {isOrganizer && (
+            <Badge className="text-xs bg-violet-100 text-violet-700 border-0">Organiser</Badge>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Main Page ────────────────────────────────────────────────────────────────
+
+export default function MeetingsPage() {
+  const { toast } = useToast();
+
+  const [meetings, setMeetings] = useState<Meeting[]>([]);
+  const [stats, setStats] = useState<Stats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [currentUserId, setCurrentUserId] = useState('');
+
+  const [search, setSearch] = useState('');
+  const [categoryFilter, setCategoryFilter] = useState('');
+  const [statusFilter, setStatusFilter] = useState('');
+
+  const [showForm, setShowForm] = useState(false);
+  const [selectedMeeting, setSelectedMeeting] = useState<Meeting | null>(null);
+  const [editingMeeting, setEditingMeeting] = useState<Meeting | null>(null);
+
+  const fetchMeetings = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams();
+      if (categoryFilter) params.set('category', categoryFilter);
+      if (statusFilter) params.set('status', statusFilter);
+      params.set('pageSize', '100');
+
+      const [meetRes, statsRes, meRes] = await Promise.all([
+        fetch(`/api/meetings?${params}`),
+        fetch(`/api/meetings?mode=stats&year=${new Date().getFullYear()}`),
+        fetch('/api/auth/me'),
+      ]);
+
+      if (meetRes.ok) {
+        const data = await meetRes.json();
+        setMeetings(data.meetings ?? []);
+      }
+      if (statsRes.ok) setStats(await statsRes.json());
+      if (meRes.ok) {
+        const me = await meRes.json();
+        setCurrentUserId(me.id ?? '');
+      }
+    } catch {
+      toast({ title: 'Error', description: 'Failed to load meetings', variant: 'destructive' });
+    } finally {
+      setLoading(false);
+    }
+  }, [categoryFilter, statusFilter, toast]);
+
+  useEffect(() => { fetchMeetings(); }, [fetchMeetings]);
+
+  const handleRsvp = async (meetingId: string, status: 'accepted' | 'declined') => {
+    const res = await fetch(`/api/meetings/${meetingId}/attendees`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status }),
+    });
+    if (res.ok) {
+      toast({ title: status === 'accepted' ? 'Accepted' : 'Declined', description: 'Your RSVP has been updated.' });
+      fetchMeetings();
+    }
+  };
+
+  const handleFormSuccess = () => {
+    setShowForm(false);
+    setEditingMeeting(null);
+    fetchMeetings();
+  };
+
+  const handleEdit = (meeting: Meeting) => {
+    setSelectedMeeting(null);
+    setEditingMeeting(meeting);
+    setShowForm(true);
+  };
+
+  const handleDelete = async (meetingId: string) => {
+    const res = await fetch(`/api/meetings/${meetingId}`, { method: 'DELETE' });
+    if (res.ok) {
+      toast({ title: 'Meeting cancelled', description: 'The meeting has been removed.' });
+      setSelectedMeeting(null);
+      fetchMeetings();
+    } else {
+      toast({ title: 'Error', description: 'Could not delete meeting.', variant: 'destructive' });
+    }
+  };
+
+  const filtered = meetings.filter((m) => {
+    if (!search) return true;
+    const q = search.toLowerCase();
+    return (
+      m.subject.toLowerCase().includes(q) ||
+      m.organizer.name.toLowerCase().includes(q) ||
+      getCategoryLabel(m).toLowerCase().includes(q)
+    );
+  });
+
+  const topCategory = stats
+    ? Object.entries(stats.byCategory).sort((a, b) => b[1] - a[1])[0]
+    : null;
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-slate-50 to-white">
+      {/* Hero */}
+      <div className="rounded-2xl border bg-gradient-to-br from-violet-600 via-indigo-600 to-blue-600 p-6 m-4 text-white shadow-lg">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <div className="rounded-xl bg-white/20 p-2.5">
+              <Calendar className="h-6 w-6 text-white" />
+            </div>
+            <div>
+              <h1 className="text-2xl font-bold">Meetings</h1>
+              <p className="text-violet-100 text-sm mt-0.5">Schedule, track, and report all company meetings</p>
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <Button variant="ghost" size="sm" className="text-white hover:bg-white/20" onClick={fetchMeetings}>
+              <RefreshCw className="h-4 w-4" />
+            </Button>
+            <Button
+              className="bg-white text-indigo-700 hover:bg-violet-50 font-semibold"
+              onClick={() => { setEditingMeeting(null); setShowForm(true); }}
+            >
+              <Plus className="h-4 w-4 mr-1.5" />
+              Schedule Meeting
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <div className="px-4 pb-8 space-y-5">
+        {/* KPI Strip */}
+        {stats && (
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+            <KpiCard label={`Total ${new Date().getFullYear()}`} value={stats.total} sub="meetings scheduled" />
+            <KpiCard label="Completed" value={stats.byStatus['completed'] ?? 0} sub="meetings held" />
+            <KpiCard label="Scheduled" value={stats.byStatus['scheduled'] ?? 0} sub="upcoming" />
+            {topCategory && (
+              <KpiCard
+                label="Top Category"
+                value={topCategory[1]}
+                sub={MEETING_CATEGORIES.find((c) => c.value === topCategory[0])?.label ?? topCategory[0]}
+              />
+            )}
+          </div>
+        )}
+
+        {/* Filters */}
+        <div className="flex flex-wrap gap-2 items-center">
+          <div className="relative flex-1 min-w-[200px]">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400" />
+            <Input
+              placeholder="Search meetings..."
+              className="pl-9"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+            />
+          </div>
+          <Select value={categoryFilter || 'all'} onValueChange={(v) => setCategoryFilter(v === 'all' ? '' : v)}>
+            <SelectTrigger className="w-[180px]">
+              <Filter className="h-4 w-4 mr-1.5 text-slate-400" />
+              <SelectValue placeholder="All categories" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All categories</SelectItem>
+              {MEETING_CATEGORIES.map((c) => (
+                <SelectItem key={c.value} value={c.value}>{c.label}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select value={statusFilter || 'all'} onValueChange={(v) => setStatusFilter(v === 'all' ? '' : v)}>
+            <SelectTrigger className="w-[150px]">
+              <SelectValue placeholder="All statuses" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All statuses</SelectItem>
+              <SelectItem value="scheduled">Scheduled</SelectItem>
+              <SelectItem value="in_progress">In Progress</SelectItem>
+              <SelectItem value="completed">Completed</SelectItem>
+              <SelectItem value="cancelled">Cancelled</SelectItem>
+            </SelectContent>
+          </Select>
+          {stats && (
+            <div className="flex items-center gap-1.5 text-xs text-slate-500 ml-auto">
+              <BarChart3 className="h-3.5 w-3.5" />
+              {filtered.length} of {meetings.length} meetings
+            </div>
+          )}
+        </div>
+
+        {/* Meeting List */}
+        {loading ? (
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="h-36 rounded-xl bg-slate-100 animate-pulse" />
+            ))}
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-20 text-slate-400">
+            <Calendar className="h-12 w-12 mb-3 opacity-30" />
+            <p className="font-medium">No meetings found</p>
+            <p className="text-sm mt-1">Schedule your first meeting to get started</p>
+            <Button
+              variant="outline"
+              className="mt-4"
+              onClick={() => { setEditingMeeting(null); setShowForm(true); }}
+            >
+              <Plus className="h-4 w-4 mr-1.5" />
+              Schedule Meeting
+            </Button>
+          </div>
+        ) : (
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {filtered.map((m) => (
+              <MeetingCard
+                key={m.id}
+                meeting={m}
+                onSelect={setSelectedMeeting}
+                onRsvp={handleRsvp}
+                currentUserId={currentUserId}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Form Sheet */}
+      <MeetingFormSheet
+        open={showForm}
+        onOpenChange={setShowForm}
+        meeting={editingMeeting}
+        onSuccess={handleFormSuccess}
+      />
+
+      {/* Detail Sheet */}
+      <MeetingDetailSheet
+        meeting={selectedMeeting}
+        open={!!selectedMeeting}
+        onOpenChange={(o) => { if (!o) setSelectedMeeting(null); }}
+        onEdit={handleEdit}
+        onDelete={handleDelete}
+        currentUserId={currentUserId}
+      />
+    </div>
+  );
+}

--- a/src/app/meetings/page.tsx
+++ b/src/app/meetings/page.tsx
@@ -1,0 +1,3 @@
+import type { Metadata } from 'next';
+export const metadata: Metadata = { title: 'Meetings' };
+export { default } from './_page-client';

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -128,6 +128,14 @@ const navigationSections: NavigationSection[] = [
     ],
   },
   {
+    name: 'Meetings',
+    icon: Calendar,
+    items: [
+      { name: 'All Meetings', href: '/meetings', icon: Calendar, newSince: '2026-04-28' },
+      { name: 'Schedule Meeting', href: '/meetings/new', icon: Plus, newSince: '2026-04-28' },
+    ],
+  },
+  {
     name: 'Operations Control',
     icon: AlertTriangle,
     items: [

--- a/src/components/meetings/meeting-detail-sheet.tsx
+++ b/src/components/meetings/meeting-detail-sheet.tsx
@@ -1,0 +1,392 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import { useToast } from '@/hooks/use-toast';
+import {
+  Calendar,
+  Clock,
+  MapPin,
+  Users,
+  Video,
+  FileText,
+  CheckSquare,
+  Edit2,
+  Trash2,
+  CheckCircle2,
+  XCircle,
+  AlertCircle,
+  Loader2,
+  ExternalLink,
+} from 'lucide-react';
+import { MEETING_CATEGORIES } from '@/lib/services/meeting.service';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface Attendee {
+  id: string;
+  userId: string;
+  status: string;
+  isRequired: boolean;
+  user: { id: string; name: string; position: string | null };
+}
+
+interface LinkedTask {
+  id: string;
+  taskId: string;
+  notes: string | null;
+  task: { id: string; title: string; status: string; priority: string };
+}
+
+interface Meeting {
+  id: string;
+  category: string;
+  categoryCustom: string | null;
+  subject: string;
+  status: string;
+  scheduledAt: string;
+  endsAt: string;
+  location: string | null;
+  meetLink: string | null;
+  agenda: string | null;
+  minutes: string | null;
+  decisions: string | null;
+  isPrivate: boolean;
+  organizerId: string;
+  organizer: { id: string; name: string; position: string | null };
+  department: { id: string; name: string } | null;
+  attendees: Attendee[];
+  tasks: LinkedTask[];
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const ATTENDEE_STATUS: Record<string, { label: string; color: string; icon: React.ReactNode }> = {
+  invited: { label: 'Invited', color: 'bg-slate-100 text-slate-600', icon: null },
+  accepted: { label: 'Accepted', color: 'bg-emerald-100 text-emerald-700', icon: <CheckCircle2 className="h-3 w-3" /> },
+  declined: { label: 'Declined', color: 'bg-red-100 text-red-700', icon: <XCircle className="h-3 w-3" /> },
+  attended: { label: 'Attended', color: 'bg-blue-100 text-blue-700', icon: <CheckCircle2 className="h-3 w-3" /> },
+  absent: { label: 'Absent', color: 'bg-orange-100 text-orange-700', icon: <AlertCircle className="h-3 w-3" /> },
+};
+
+const TASK_PRIORITY_COLOR: Record<string, string> = {
+  High: 'bg-red-100 text-red-700',
+  Medium: 'bg-amber-100 text-amber-700',
+  Low: 'bg-slate-100 text-slate-600',
+};
+
+function getCategoryLabel(meeting: Meeting): string {
+  if (meeting.category === 'other') return meeting.categoryCustom || 'Other';
+  return MEETING_CATEGORIES.find((c) => c.value === meeting.category)?.label ?? meeting.category;
+}
+
+function formatDateTime(iso: string): string {
+  return new Date(iso).toLocaleString('en-SA', {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function formatDuration(start: string, end: string): string {
+  const mins = Math.round((new Date(end).getTime() - new Date(start).getTime()) / 60000);
+  if (mins < 60) return `${mins} minutes`;
+  const h = Math.floor(mins / 60);
+  const m = mins % 60;
+  return m ? `${h}h ${m}m` : `${h} hour${h > 1 ? 's' : ''}`;
+}
+
+// ─── Minutes Editor ───────────────────────────────────────────────────────────
+
+function MinutesEditor({ meetingId, initialMinutes, initialDecisions, onSaved }: {
+  meetingId: string;
+  initialMinutes: string | null;
+  initialDecisions: string | null;
+  onSaved: () => void;
+}) {
+  const { toast } = useToast();
+  const [minutes, setMinutes] = useState(initialMinutes ?? '');
+  const [decisions, setDecisions] = useState(initialDecisions ?? '');
+  const [saving, setSaving] = useState(false);
+
+  const save = async () => {
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/meetings/${meetingId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ minutes, decisions, status: 'completed' }),
+      });
+      if (!res.ok) throw new Error();
+      toast({ title: 'Minutes saved', description: 'Meeting minutes and decisions recorded.' });
+      onSaved();
+    } catch {
+      toast({ title: 'Error', description: 'Failed to save minutes.', variant: 'destructive' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3 rounded-lg border border-dashed p-4 bg-amber-50">
+      <p className="text-sm font-semibold text-amber-800 flex items-center gap-1.5">
+        <FileText className="h-4 w-4" /> Record Meeting Minutes
+      </p>
+      <div className="space-y-2">
+        <Label className="text-xs">Minutes / Notes</Label>
+        <Textarea
+          placeholder="Summarise what was discussed..."
+          rows={4}
+          value={minutes}
+          onChange={(e) => setMinutes(e.target.value)}
+          className="bg-white text-sm"
+        />
+      </div>
+      <div className="space-y-2">
+        <Label className="text-xs">Key Decisions</Label>
+        <Textarea
+          placeholder="List the decisions made..."
+          rows={3}
+          value={decisions}
+          onChange={(e) => setDecisions(e.target.value)}
+          className="bg-white text-sm"
+        />
+      </div>
+      <Button size="sm" onClick={save} disabled={saving} className="bg-amber-600 hover:bg-amber-700">
+        {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin mr-1" /> : null}
+        Save & Mark Completed
+      </Button>
+    </div>
+  );
+}
+
+// ─── Main Component ───────────────────────────────────────────────────────────
+
+interface MeetingDetailSheetProps {
+  meeting: Meeting | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onEdit: (meeting: Meeting) => void;
+  onDelete: (id: string) => void;
+  currentUserId: string;
+}
+
+export default function MeetingDetailSheet({
+  meeting,
+  open,
+  onOpenChange,
+  onEdit,
+  onDelete,
+  currentUserId,
+}: MeetingDetailSheetProps) {
+  const [showDelete, setShowDelete] = useState(false);
+  const [showMinutes, setShowMinutes] = useState(false);
+
+  if (!meeting) return null;
+
+  const isOrganizer = meeting.organizerId === currentUserId;
+  const isPast = new Date(meeting.endsAt) < new Date();
+  const canEdit = isOrganizer;
+  const canDelete = isOrganizer;
+  const canRecordMinutes = isOrganizer && (isPast || meeting.status === 'completed');
+
+  const acceptedCount = meeting.attendees.filter((a) => a.status === 'accepted' || a.status === 'attended').length;
+
+  return (
+    <>
+      <Sheet open={open} onOpenChange={onOpenChange}>
+        <SheetContent className="w-full sm:max-w-xl overflow-y-auto" side="right">
+          <SheetHeader className="pb-2">
+            <div className="flex items-start justify-between gap-2">
+              <div className="space-y-1 flex-1">
+                <Badge variant="outline" className="text-xs mb-1">{getCategoryLabel(meeting)}</Badge>
+                <SheetTitle className="text-base leading-snug">{meeting.subject}</SheetTitle>
+              </div>
+              <div className="flex gap-1.5 shrink-0">
+                {canEdit && (
+                  <Button size="icon" variant="ghost" className="h-8 w-8" onClick={() => onEdit(meeting)}>
+                    <Edit2 className="h-4 w-4" />
+                  </Button>
+                )}
+                {canDelete && (
+                  <Button size="icon" variant="ghost" className="h-8 w-8 text-red-500 hover:text-red-700 hover:bg-red-50"
+                    onClick={() => setShowDelete(true)}>
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                )}
+              </div>
+            </div>
+          </SheetHeader>
+
+          <div className="space-y-5 mt-2">
+            {/* Meta */}
+            <div className="space-y-2 text-sm text-slate-600">
+              <div className="flex items-start gap-2">
+                <Calendar className="h-4 w-4 mt-0.5 text-slate-400 shrink-0" />
+                <div>
+                  <p>{formatDateTime(meeting.scheduledAt)}</p>
+                  <p className="text-xs text-slate-400">Duration: {formatDuration(meeting.scheduledAt, meeting.endsAt)}</p>
+                </div>
+              </div>
+              {meeting.location && (
+                <div className="flex items-center gap-2">
+                  <MapPin className="h-4 w-4 text-slate-400 shrink-0" />
+                  <span>{meeting.location}</span>
+                </div>
+              )}
+              {meeting.meetLink && (
+                <div className="flex items-center gap-2">
+                  <Video className="h-4 w-4 text-blue-500 shrink-0" />
+                  <a
+                    href={meeting.meetLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-600 hover:underline flex items-center gap-1 font-medium"
+                  >
+                    Join Google Meet <ExternalLink className="h-3 w-3" />
+                  </a>
+                </div>
+              )}
+              <div className="flex items-center gap-2">
+                <Users className="h-4 w-4 text-slate-400 shrink-0" />
+                <span>{meeting.attendees.length} attendees · {acceptedCount} confirmed</span>
+              </div>
+              {meeting.department && (
+                <p className="text-xs text-slate-400">Department: {meeting.department.name}</p>
+              )}
+            </div>
+
+            {/* Agenda */}
+            {meeting.agenda && (
+              <div className="space-y-1.5">
+                <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Agenda</p>
+                <p className="text-sm text-slate-700 whitespace-pre-wrap rounded-lg bg-slate-50 border p-3">{meeting.agenda}</p>
+              </div>
+            )}
+
+            {/* Minutes (read) */}
+            {meeting.minutes && (
+              <div className="space-y-1.5">
+                <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Minutes</p>
+                <p className="text-sm text-slate-700 whitespace-pre-wrap rounded-lg bg-slate-50 border p-3">{meeting.minutes}</p>
+              </div>
+            )}
+            {meeting.decisions && (
+              <div className="space-y-1.5">
+                <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Key Decisions</p>
+                <p className="text-sm text-slate-700 whitespace-pre-wrap rounded-lg bg-emerald-50 border border-emerald-200 p-3">{meeting.decisions}</p>
+              </div>
+            )}
+
+            {/* Record Minutes */}
+            {canRecordMinutes && !showMinutes && (
+              <Button variant="outline" size="sm" onClick={() => setShowMinutes(true)}
+                className="w-full border-dashed text-amber-700 border-amber-300 hover:bg-amber-50">
+                <FileText className="h-4 w-4 mr-1.5" />
+                {meeting.minutes ? 'Edit Meeting Minutes' : 'Record Meeting Minutes'}
+              </Button>
+            )}
+            {showMinutes && (
+              <MinutesEditor
+                meetingId={meeting.id}
+                initialMinutes={meeting.minutes}
+                initialDecisions={meeting.decisions}
+                onSaved={() => { setShowMinutes(false); onOpenChange(false); }}
+              />
+            )}
+
+            {/* Attendees */}
+            <div className="space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 flex items-center gap-1.5">
+                <Users className="h-3.5 w-3.5" /> Attendees
+              </p>
+              <div className="space-y-1.5">
+                {meeting.attendees.map((a) => {
+                  const cfg = ATTENDEE_STATUS[a.status] ?? ATTENDEE_STATUS.invited;
+                  return (
+                    <div key={a.id} className="flex items-center justify-between rounded-lg border px-3 py-2 bg-white">
+                      <div>
+                        <p className="text-sm font-medium text-slate-700">{a.user.name}</p>
+                        {a.user.position && <p className="text-xs text-slate-400">{a.user.position}</p>}
+                      </div>
+                      <Badge className={`text-xs flex items-center gap-1 border-0 ${cfg.color}`}>
+                        {cfg.icon}{cfg.label}
+                      </Badge>
+                    </div>
+                  );
+                })}
+                {meeting.attendees.length === 0 && (
+                  <p className="text-xs text-slate-400 text-center py-2">No attendees added</p>
+                )}
+              </div>
+            </div>
+
+            {/* Linked Tasks */}
+            {meeting.tasks.length > 0 && (
+              <div className="space-y-2">
+                <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 flex items-center gap-1.5">
+                  <CheckSquare className="h-3.5 w-3.5" /> Tasks for Discussion
+                </p>
+                <div className="space-y-1.5">
+                  {meeting.tasks.map((mt) => (
+                    <div key={mt.id} className="flex items-start justify-between rounded-lg border px-3 py-2 bg-white gap-2">
+                      <p className="text-sm text-slate-700 flex-1">{mt.task.title}</p>
+                      <div className="flex gap-1.5 shrink-0">
+                        <Badge className={`text-xs border-0 ${TASK_PRIORITY_COLOR[mt.task.priority] ?? 'bg-slate-100 text-slate-600'}`}>
+                          {mt.task.priority}
+                        </Badge>
+                        <Badge variant="outline" className="text-xs">{mt.task.status}</Badge>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </SheetContent>
+      </Sheet>
+
+      <AlertDialog open={showDelete} onOpenChange={setShowDelete}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Cancel this meeting?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will remove &ldquo;{meeting.subject}&rdquo; and notify attendees. This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Keep Meeting</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-red-600 hover:bg-red-700"
+              onClick={() => { setShowDelete(false); onDelete(meeting.id); }}
+            >
+              Cancel Meeting
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/src/components/meetings/meeting-form-sheet.tsx
+++ b/src/components/meetings/meeting-form-sheet.tsx
@@ -1,0 +1,459 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from '@/components/ui/sheet';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Badge } from '@/components/ui/badge';
+import { useToast } from '@/hooks/use-toast';
+import { MEETING_CATEGORIES } from '@/lib/services/meeting.service';
+import { Loader2, X, Search, Video } from 'lucide-react';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface User {
+  id: string;
+  name: string;
+  position: string | null;
+  department?: { name: string } | null;
+}
+
+interface Department {
+  id: string;
+  name: string;
+}
+
+interface Task {
+  id: string;
+  title: string;
+  status: string;
+  assignedTo?: { name: string } | null;
+}
+
+interface MeetingFormData {
+  category: string;
+  categoryCustom: string;
+  subject: string;
+  scheduledAt: string;
+  endsAt: string;
+  location: string;
+  agenda: string;
+  departmentId: string;
+  isPrivate: boolean;
+  generateMeetLink: boolean;
+  attendeeIds: string[];
+  taskIds: string[];
+}
+
+const schema = z.object({
+  category: z.string().min(1, 'Category is required'),
+  categoryCustom: z.string().max(150).optional(),
+  subject: z.string().min(2, 'Subject is required').max(255),
+  scheduledAt: z.string().min(1, 'Start date/time is required'),
+  endsAt: z.string().min(1, 'End date/time is required'),
+  location: z.string().max(255).optional(),
+  agenda: z.string().optional(),
+  departmentId: z.string().optional(),
+  isPrivate: z.boolean(),
+  generateMeetLink: z.boolean(),
+  attendeeIds: z.array(z.string()),
+  taskIds: z.array(z.string()),
+});
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function toLocalDatetimeInput(iso: string) {
+  const d = new Date(iso);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function fromLocalDatetimeInput(local: string): string {
+  return new Date(local).toISOString();
+}
+
+// ─── Multi-select with search ──────────────────────────────────────────────────
+
+function MultiSearchSelect<T extends { id: string; name: string; sub?: string }>({
+  label,
+  items,
+  selected,
+  onToggle,
+  placeholder,
+}: {
+  label: string;
+  items: T[];
+  selected: string[];
+  onToggle: (id: string) => void;
+  placeholder: string;
+}) {
+  const [q, setQ] = useState('');
+  const filtered = items.filter((i) => i.name.toLowerCase().includes(q.toLowerCase()));
+  const selectedItems = items.filter((i) => selected.includes(i.id));
+
+  return (
+    <div className="space-y-2">
+      <Label>{label}</Label>
+      {selectedItems.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {selectedItems.map((i) => (
+            <Badge key={i.id} variant="secondary" className="flex items-center gap-1 text-xs">
+              {i.name}
+              <button type="button" onClick={() => onToggle(i.id)}>
+                <X className="h-3 w-3 hover:text-red-500" />
+              </button>
+            </Badge>
+          ))}
+        </div>
+      )}
+      <div className="relative">
+        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-slate-400" />
+        <Input
+          className="pl-8 h-8 text-sm"
+          placeholder={placeholder}
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+        />
+      </div>
+      <div className="max-h-40 overflow-y-auto rounded-md border divide-y text-sm">
+        {filtered.length === 0 && <p className="p-2 text-slate-400 text-xs text-center">No results</p>}
+        {filtered.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            onClick={() => onToggle(item.id)}
+            className={`w-full flex items-center justify-between px-3 py-1.5 text-left hover:bg-slate-50 transition-colors ${selected.includes(item.id) ? 'bg-indigo-50' : ''}`}
+          >
+            <span className="font-medium text-slate-700">{item.name}</span>
+            <div className="flex items-center gap-2">
+              {item.sub && <span className="text-slate-400 text-xs">{item.sub}</span>}
+              {selected.includes(item.id) && <span className="text-indigo-600 text-xs">✓</span>}
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ─── Sheet Component ───────────────────────────────────────────────────────────
+
+interface MeetingFormSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  meeting?: {
+    id: string;
+    category: string;
+    categoryCustom: string | null;
+    subject: string;
+    scheduledAt: string;
+    endsAt: string;
+    location: string | null;
+    agenda: string | null;
+    isPrivate: boolean;
+    departmentId: string | null;
+    meetLink: string | null;
+    attendees: { userId: string }[];
+    tasks: { taskId: string }[];
+  } | null;
+  onSuccess: () => void;
+}
+
+export default function MeetingFormSheet({ open, onOpenChange, meeting, onSuccess }: MeetingFormSheetProps) {
+  const { toast } = useToast();
+  const [users, setUsers] = useState<User[]>([]);
+  const [departments, setDepartments] = useState<Department[]>([]);
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [saving, setSaving] = useState(false);
+
+  const isEdit = !!meeting;
+
+  const { register, handleSubmit, control, watch, setValue, reset, formState: { errors } } = useForm<MeetingFormData>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      category: '',
+      categoryCustom: '',
+      subject: '',
+      scheduledAt: '',
+      endsAt: '',
+      location: '',
+      agenda: '',
+      departmentId: '',
+      isPrivate: false,
+      generateMeetLink: false,
+      attendeeIds: [],
+      taskIds: [],
+    },
+  });
+
+  const category = watch('category');
+  const attendeeIds = watch('attendeeIds');
+  const taskIds = watch('taskIds');
+
+  // Populate form on edit
+  useEffect(() => {
+    if (meeting) {
+      reset({
+        category: meeting.category,
+        categoryCustom: meeting.categoryCustom ?? '',
+        subject: meeting.subject,
+        scheduledAt: toLocalDatetimeInput(meeting.scheduledAt),
+        endsAt: toLocalDatetimeInput(meeting.endsAt),
+        location: meeting.location ?? '',
+        agenda: meeting.agenda ?? '',
+        departmentId: meeting.departmentId ?? '',
+        isPrivate: meeting.isPrivate,
+        generateMeetLink: false,
+        attendeeIds: meeting.attendees.map((a) => a.userId),
+        taskIds: meeting.tasks.map((t) => t.taskId),
+      });
+    } else {
+      reset({
+        category: '',
+        categoryCustom: '',
+        subject: '',
+        scheduledAt: '',
+        endsAt: '',
+        location: '',
+        agenda: '',
+        departmentId: '',
+        isPrivate: false,
+        generateMeetLink: false,
+        attendeeIds: [],
+        taskIds: [],
+      });
+    }
+  }, [meeting, reset, open]);
+
+  // Load reference data
+  useEffect(() => {
+    if (!open) return;
+    Promise.all([
+      fetch('/api/users?status=active&pageSize=200').then((r) => r.json()),
+      fetch('/api/departments').then((r) => r.json()),
+      fetch('/api/tasks?pageSize=200&status=Pending').then((r) => r.json()),
+    ]).then(([u, d, t]) => {
+      setUsers(Array.isArray(u) ? u : []);
+      setDepartments(Array.isArray(d) ? d : []);
+      setTasks(Array.isArray(t) ? t : []);
+    }).catch(() => {});
+  }, [open]);
+
+  const toggleAttendee = (id: string) => {
+    setValue('attendeeIds', attendeeIds.includes(id) ? attendeeIds.filter((x) => x !== id) : [...attendeeIds, id]);
+  };
+
+  const toggleTask = (id: string) => {
+    setValue('taskIds', taskIds.includes(id) ? taskIds.filter((x) => x !== id) : [...taskIds, id]);
+  };
+
+  const onSubmit = async (data: MeetingFormData) => {
+    setSaving(true);
+    try {
+      const payload = {
+        ...data,
+        scheduledAt: fromLocalDatetimeInput(data.scheduledAt),
+        endsAt: fromLocalDatetimeInput(data.endsAt),
+        categoryCustom: data.categoryCustom || null,
+        location: data.location || null,
+        agenda: data.agenda || null,
+        departmentId: data.departmentId || null,
+      };
+
+      const url = isEdit ? `/api/meetings/${meeting!.id}` : '/api/meetings';
+      const method = isEdit ? 'PUT' : 'POST';
+
+      const res = await fetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.error ?? 'Failed to save meeting');
+      }
+
+      toast({ title: isEdit ? 'Meeting updated' : 'Meeting scheduled', description: 'Changes saved successfully.' });
+      onSuccess();
+    } catch (err) {
+      toast({ title: 'Error', description: err instanceof Error ? err.message : 'Failed to save', variant: 'destructive' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const userItems = users.map((u) => ({ id: u.id, name: u.name, sub: u.position ?? undefined }));
+  const taskItems = tasks.map((t) => ({ id: t.id, name: t.title, sub: t.status }));
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="w-full sm:max-w-xl overflow-y-auto" side="right">
+        <SheetHeader className="pb-4">
+          <SheetTitle>{isEdit ? 'Edit Meeting' : 'Schedule Meeting'}</SheetTitle>
+          <SheetDescription>Fill in the details below to {isEdit ? 'update the' : 'schedule a new'} meeting.</SheetDescription>
+        </SheetHeader>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
+          {/* Category */}
+          <div className="space-y-2">
+            <Label htmlFor="category">Meeting Type <span className="text-red-500">*</span></Label>
+            <Controller
+              name="category"
+              control={control}
+              render={({ field }) => (
+                <Select value={field.value} onValueChange={field.onChange}>
+                  <SelectTrigger id="category">
+                    <SelectValue placeholder="Select meeting type..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {MEETING_CATEGORIES.map((c) => (
+                      <SelectItem key={c.value} value={c.value}>{c.label}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            />
+            {errors.category && <p className="text-xs text-red-500">{errors.category.message}</p>}
+          </div>
+
+          {/* Custom category label */}
+          {category === 'other' && (
+            <div className="space-y-2">
+              <Label htmlFor="categoryCustom">Custom Category Name</Label>
+              <Input id="categoryCustom" placeholder="e.g. Board Advisory Session" {...register('categoryCustom')} />
+            </div>
+          )}
+
+          {/* Subject */}
+          <div className="space-y-2">
+            <Label htmlFor="subject">Meeting Subject <span className="text-red-500">*</span></Label>
+            <Input id="subject" placeholder="e.g. Q2 Sales Review — Central Region" {...register('subject')} />
+            {errors.subject && <p className="text-xs text-red-500">{errors.subject.message}</p>}
+          </div>
+
+          {/* Date/time row */}
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-2">
+              <Label htmlFor="scheduledAt">Start Date & Time <span className="text-red-500">*</span></Label>
+              <Input id="scheduledAt" type="datetime-local" {...register('scheduledAt')} />
+              {errors.scheduledAt && <p className="text-xs text-red-500">{errors.scheduledAt.message}</p>}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="endsAt">End Date & Time <span className="text-red-500">*</span></Label>
+              <Input id="endsAt" type="datetime-local" {...register('endsAt')} />
+              {errors.endsAt && <p className="text-xs text-red-500">{errors.endsAt.message}</p>}
+            </div>
+          </div>
+
+          {/* Location */}
+          <div className="space-y-2">
+            <Label htmlFor="location">Location <span className="text-slate-400 font-normal">(optional)</span></Label>
+            <Input id="location" placeholder="e.g. Conference Room A, or leave blank for online-only" {...register('location')} />
+          </div>
+
+          {/* Department */}
+          <div className="space-y-2">
+            <Label>Department <span className="text-slate-400 font-normal">(optional)</span></Label>
+            <Controller
+              name="departmentId"
+              control={control}
+              render={({ field }) => (
+                <Select value={field.value || 'none'} onValueChange={(v) => field.onChange(v === 'none' ? '' : v)}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select department..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">No specific department</SelectItem>
+                    {departments.map((d) => (
+                      <SelectItem key={d.id} value={d.id}>{d.name}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            />
+          </div>
+
+          {/* Attendees */}
+          <MultiSearchSelect
+            label="Attendees"
+            items={userItems}
+            selected={attendeeIds}
+            onToggle={toggleAttendee}
+            placeholder="Search employees..."
+          />
+
+          {/* Linked Tasks */}
+          <MultiSearchSelect
+            label="OTS Tasks for Discussion"
+            items={taskItems}
+            selected={taskIds}
+            onToggle={toggleTask}
+            placeholder="Search tasks..."
+          />
+
+          {/* Agenda */}
+          <div className="space-y-2">
+            <Label htmlFor="agenda">Agenda <span className="text-slate-400 font-normal">(optional)</span></Label>
+            <Textarea id="agenda" placeholder="List agenda items..." rows={4} {...register('agenda')} />
+          </div>
+
+          {/* Toggles */}
+          <div className="space-y-3 rounded-lg border p-4 bg-slate-50">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm font-medium">Private Meeting</p>
+                <p className="text-xs text-slate-500">Only visible to organiser and attendees</p>
+              </div>
+              <Controller
+                name="isPrivate"
+                control={control}
+                render={({ field }) => <Switch checked={field.value} onCheckedChange={field.onChange} />}
+              />
+            </div>
+            {!isEdit && (
+              <div className="flex items-center justify-between border-t pt-3">
+                <div className="flex items-center gap-2">
+                  <Video className="h-4 w-4 text-blue-500" />
+                  <div>
+                    <p className="text-sm font-medium">Generate Google Meet Link</p>
+                    <p className="text-xs text-slate-500">Auto-creates a Meet link via Google Calendar</p>
+                  </div>
+                </div>
+                <Controller
+                  name="generateMeetLink"
+                  control={control}
+                  render={({ field }) => <Switch checked={field.value} onCheckedChange={field.onChange} />}
+                />
+              </div>
+            )}
+          </div>
+
+          {/* Actions */}
+          <div className="flex gap-2 pt-2">
+            <Button type="button" variant="outline" className="flex-1" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" className="flex-1 bg-indigo-600 hover:bg-indigo-700" disabled={saving}>
+              {saving ? <Loader2 className="h-4 w-4 animate-spin mr-1.5" /> : null}
+              {isEdit ? 'Save Changes' : 'Schedule Meeting'}
+            </Button>
+          </div>
+        </form>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -43,6 +43,10 @@ interface EnvConfig {
   ENABLE_RISK_SCHEDULER: string | undefined;
   GOOGLE_SHEETS_CREDENTIALS: string | undefined;
 
+  // Google Calendar — Meetings module Meet link generation
+  GOOGLE_CALENDAR_CREDENTIALS: string | undefined;
+  GOOGLE_CALENDAR_IMPERSONATE_EMAIL: string | undefined;
+
   // Push notifications (VAPID keys)
   VAPID_PUBLIC_KEY: string | undefined;
   VAPID_PRIVATE_KEY: string | undefined;
@@ -117,6 +121,8 @@ function validateEnv(): EnvConfig {
     NEXT_PUBLIC_BASE_PATH: process.env.NEXT_PUBLIC_BASE_PATH,
     ENABLE_RISK_SCHEDULER: process.env.ENABLE_RISK_SCHEDULER,
     GOOGLE_SHEETS_CREDENTIALS: process.env.GOOGLE_SHEETS_CREDENTIALS,
+    GOOGLE_CALENDAR_CREDENTIALS: process.env.GOOGLE_CALENDAR_CREDENTIALS,
+    GOOGLE_CALENDAR_IMPERSONATE_EMAIL: process.env.GOOGLE_CALENDAR_IMPERSONATE_EMAIL,
 
     VAPID_PUBLIC_KEY: process.env.VAPID_PUBLIC_KEY,
     VAPID_PRIVATE_KEY: process.env.VAPID_PRIVATE_KEY,

--- a/src/lib/navigation-permissions.ts
+++ b/src/lib/navigation-permissions.ts
@@ -96,6 +96,10 @@ export const NAVIGATION_PERMISSIONS: NavigationPermissionMap = {
   '/business-planning/departments': ['business.view_dept_plans', 'business.manage_dept_plans'],
   '/business-planning/issues': ['business.view_issues', 'business.manage_issues'],
   
+  // Meetings
+  '/meetings': ['meetings.view'],
+  '/meetings/new': ['meetings.create'],
+
   // Knowledge Center
   '/knowledge-center': ['knowledge.view'],
   '/knowledge-center/new': ['knowledge.create'],

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -212,6 +212,19 @@ export const PERMISSIONS: PermissionCategory[] = [
     ],
   },
   {
+    id: 'meetings',
+    name: 'Meetings',
+    permissions: [
+      { id: 'meetings.view', name: 'View Meetings', description: 'View meetings you are invited to or organised', category: 'meetings' },
+      { id: 'meetings.view_all', name: 'View All Meetings', description: 'View all company meetings regardless of attendance', category: 'meetings' },
+      { id: 'meetings.create', name: 'Schedule Meeting', description: 'Create and schedule new meetings', category: 'meetings' },
+      { id: 'meetings.edit', name: 'Edit Own Meetings', description: 'Edit meetings you organised', category: 'meetings' },
+      { id: 'meetings.edit_all', name: 'Edit Any Meeting', description: 'Edit any meeting regardless of organiser', category: 'meetings' },
+      { id: 'meetings.delete', name: 'Delete Meeting', description: 'Cancel and delete meetings', category: 'meetings' },
+      { id: 'meetings.record_minutes', name: 'Record Minutes', description: 'Add meeting minutes and decisions after a meeting', category: 'meetings' },
+    ],
+  },
+  {
     id: 'product_backlog',
     name: 'Product Backlog & Development',
     permissions: [

--- a/src/lib/services/google-calendar.service.ts
+++ b/src/lib/services/google-calendar.service.ts
@@ -1,0 +1,99 @@
+import { google } from 'googleapis';
+import { env } from '@/lib/env';
+import { logger } from '@/lib/logger';
+
+interface MeetLinkResult {
+  meetLink: string;
+  googleEventId: string;
+  htmlLink: string;
+}
+
+interface CreateEventParams {
+  summary: string;
+  description?: string;
+  startTime: Date;
+  endTime: Date;
+  attendeeEmails?: string[];
+  organizerEmail?: string;
+}
+
+function buildAuth() {
+  const raw = env.GOOGLE_CALENDAR_CREDENTIALS;
+  if (!raw) return null;
+
+  try {
+    const credentials = JSON.parse(raw) as {
+      client_email: string;
+      private_key: string;
+    };
+    const auth = new google.auth.JWT({
+      email: credentials.client_email,
+      key: credentials.private_key,
+      scopes: ['https://www.googleapis.com/auth/calendar'],
+      subject: env.GOOGLE_CALENDAR_IMPERSONATE_EMAIL,
+    });
+    return auth;
+  } catch {
+    logger.warn({ service: 'google-calendar' }, 'Failed to parse GOOGLE_CALENDAR_CREDENTIALS');
+    return null;
+  }
+}
+
+export async function createGoogleMeetLink(params: CreateEventParams): Promise<MeetLinkResult | null> {
+  const auth = buildAuth();
+  if (!auth) {
+    logger.info({ service: 'google-calendar' }, 'Google Calendar not configured — skipping Meet link generation');
+    return null;
+  }
+
+  try {
+    const calendar = google.calendar({ version: 'v3', auth });
+
+    const event = await calendar.events.insert({
+      calendarId: 'primary',
+      conferenceDataVersion: 1,
+      requestBody: {
+        summary: params.summary,
+        description: params.description,
+        start: { dateTime: params.startTime.toISOString(), timeZone: 'Asia/Riyadh' },
+        end: { dateTime: params.endTime.toISOString(), timeZone: 'Asia/Riyadh' },
+        conferenceData: {
+          createRequest: {
+            requestId: `ots-${Date.now()}`,
+            conferenceSolutionKey: { type: 'hangoutsMeet' },
+          },
+        },
+        attendees: (params.attendeeEmails ?? []).map((email) => ({ email })),
+      },
+    });
+
+    const data = event.data;
+    const meetLink = data.conferenceData?.entryPoints?.find((ep) => ep.entryPointType === 'video')?.uri;
+    const googleEventId = data.id;
+    const htmlLink = data.htmlLink;
+
+    if (!meetLink || !googleEventId) {
+      logger.warn({ service: 'google-calendar', eventId: googleEventId }, 'Event created but no Meet link returned');
+      return null;
+    }
+
+    logger.info({ service: 'google-calendar', googleEventId }, 'Google Meet link created');
+    return { meetLink, googleEventId, htmlLink: htmlLink ?? '' };
+  } catch (err) {
+    logger.error({ service: 'google-calendar', err }, 'Failed to create Google Calendar event');
+    return null;
+  }
+}
+
+export async function deleteGoogleCalendarEvent(googleEventId: string): Promise<void> {
+  const auth = buildAuth();
+  if (!auth) return;
+
+  try {
+    const calendar = google.calendar({ version: 'v3', auth });
+    await calendar.events.delete({ calendarId: 'primary', eventId: googleEventId });
+    logger.info({ service: 'google-calendar', googleEventId }, 'Google Calendar event deleted');
+  } catch (err) {
+    logger.warn({ service: 'google-calendar', googleEventId, err }, 'Failed to delete Google Calendar event');
+  }
+}

--- a/src/lib/services/meeting.service.ts
+++ b/src/lib/services/meeting.service.ts
@@ -1,0 +1,336 @@
+import { randomUUID } from 'crypto';
+import prisma from '@/lib/db';
+import { logger } from '@/lib/logger';
+import { createGoogleMeetLink, deleteGoogleCalendarEvent } from './google-calendar.service';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const MEETING_CATEGORIES = [
+  { value: 'sales', label: 'Sales Meeting' },
+  { value: 'operations', label: 'Operations Meeting' },
+  { value: 'project', label: 'Project Meeting' },
+  { value: 'management_review', label: 'Management Review' },
+  { value: 'hr', label: 'HR Meeting' },
+  { value: 'quality_safety', label: 'Quality & Safety Meeting' },
+  { value: 'board', label: 'Board Meeting' },
+  { value: 'client', label: 'Client Meeting' },
+  { value: 'supplier', label: 'Supplier Meeting' },
+  { value: 'planning', label: 'Planning Session' },
+  { value: 'other', label: 'Other' },
+] as const;
+
+export type MeetingCategory = (typeof MEETING_CATEGORIES)[number]['value'];
+export type MeetingStatus = 'scheduled' | 'in_progress' | 'completed' | 'cancelled';
+export type AttendeeStatus = 'invited' | 'accepted' | 'declined' | 'attended' | 'absent';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Input types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface CreateMeetingInput {
+  category: MeetingCategory;
+  categoryCustom?: string;
+  subject: string;
+  scheduledAt: Date;
+  endsAt: Date;
+  location?: string;
+  agenda?: string;
+  isPrivate?: boolean;
+  departmentId?: string;
+  attendeeIds: string[];
+  taskIds?: string[];
+  generateMeetLink?: boolean;
+  organizerId: string;
+  createdById: string;
+}
+
+export interface UpdateMeetingInput {
+  category?: MeetingCategory;
+  categoryCustom?: string;
+  subject?: string;
+  status?: MeetingStatus;
+  scheduledAt?: Date;
+  endsAt?: Date;
+  location?: string;
+  meetLink?: string;
+  agenda?: string;
+  minutes?: string;
+  decisions?: string;
+  isPrivate?: boolean;
+  departmentId?: string;
+  attendeeIds?: string[];
+  taskIds?: string[];
+  updatedById: string;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared select
+// ─────────────────────────────────────────────────────────────────────────────
+
+const meetingSelect = {
+  id: true,
+  category: true,
+  categoryCustom: true,
+  subject: true,
+  status: true,
+  scheduledAt: true,
+  endsAt: true,
+  location: true,
+  meetLink: true,
+  googleEventId: true,
+  agenda: true,
+  minutes: true,
+  decisions: true,
+  isPrivate: true,
+  departmentId: true,
+  organizerId: true,
+  createdAt: true,
+  updatedAt: true,
+  organizer: { select: { id: true, name: true, position: true } },
+  department: { select: { id: true, name: true } },
+  attendees: {
+    select: {
+      id: true,
+      userId: true,
+      status: true,
+      isRequired: true,
+      user: { select: { id: true, name: true, position: true } },
+    },
+  },
+  tasks: {
+    select: {
+      id: true,
+      taskId: true,
+      notes: true,
+      task: { select: { id: true, title: true, status: true, priority: true } },
+    },
+  },
+} as const;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Queries
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function getMeetings(params: {
+  userId: string;
+  canViewAll: boolean;
+  category?: string;
+  status?: string;
+  from?: Date;
+  to?: Date;
+  page?: number;
+  pageSize?: number;
+}) {
+  const { userId, canViewAll, category, status, from, to, page = 1, pageSize = 50 } = params;
+
+  const where: Parameters<typeof prisma.meeting.findMany>[0]['where'] = {
+    deletedAt: null,
+  };
+
+  if (!canViewAll) {
+    where.OR = [
+      { isPrivate: false },
+      { organizerId: userId },
+      { attendees: { some: { userId } } },
+    ];
+  }
+
+  if (category) where.category = category;
+  if (status) where.status = status;
+  if (from || to) {
+    where.scheduledAt = {};
+    if (from) where.scheduledAt.gte = from;
+    if (to) where.scheduledAt.lte = to;
+  }
+
+  const [meetings, total] = await Promise.all([
+    prisma.meeting.findMany({
+      where,
+      select: meetingSelect,
+      orderBy: { scheduledAt: 'desc' },
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+    }),
+    prisma.meeting.count({ where }),
+  ]);
+
+  return { meetings, total, page, pageSize };
+}
+
+export async function getMeetingById(id: string, userId: string, canViewAll: boolean) {
+  const meeting = await prisma.meeting.findFirst({
+    where: {
+      id,
+      deletedAt: null,
+      ...(!canViewAll && {
+        OR: [
+          { isPrivate: false },
+          { organizerId: userId },
+          { attendees: { some: { userId } } },
+        ],
+      }),
+    },
+    select: meetingSelect,
+  });
+  return meeting;
+}
+
+export async function getMeetingStats(userId: string, canViewAll: boolean, year: number) {
+  const start = new Date(`${year}-01-01T00:00:00.000Z`);
+  const end = new Date(`${year + 1}-01-01T00:00:00.000Z`);
+
+  const where: Parameters<typeof prisma.meeting.findMany>[0]['where'] = {
+    deletedAt: null,
+    scheduledAt: { gte: start, lt: end },
+  };
+
+  if (!canViewAll) {
+    where.OR = [
+      { isPrivate: false },
+      { organizerId: userId },
+      { attendees: { some: { userId } } },
+    ];
+  }
+
+  const meetings = await prisma.meeting.findMany({
+    where,
+    select: { category: true, categoryCustom: true, status: true },
+  });
+
+  const byCategory: Record<string, number> = {};
+  const byStatus: Record<string, number> = {};
+
+  for (const m of meetings) {
+    const label = m.category === 'other' ? (m.categoryCustom ?? 'Other') : m.category;
+    byCategory[label] = (byCategory[label] ?? 0) + 1;
+    byStatus[m.status] = (byStatus[m.status] ?? 0) + 1;
+  }
+
+  return { total: meetings.length, byCategory, byStatus };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mutations
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function createMeeting(input: CreateMeetingInput) {
+  const {
+    attendeeIds,
+    taskIds = [],
+    generateMeetLink,
+    organizerId,
+    createdById,
+    ...data
+  } = input;
+
+  let meetLink: string | undefined;
+  let googleEventId: string | undefined;
+
+  if (generateMeetLink) {
+    const attendeeEmails = await getAttendeeEmails(attendeeIds);
+    const result = await createGoogleMeetLink({
+      summary: data.subject,
+      description: data.agenda,
+      startTime: data.scheduledAt,
+      endTime: data.endsAt,
+      attendeeEmails,
+    });
+    if (result) {
+      meetLink = result.meetLink;
+      googleEventId = result.googleEventId;
+    }
+  }
+
+  const meeting = await prisma.meeting.create({
+    data: {
+      ...data,
+      meetLink,
+      googleEventId,
+      organizerId,
+      createdById,
+      attendees: {
+        create: attendeeIds.map((userId) => ({ id: randomUUID(), userId, status: 'invited' })),
+      },
+      tasks: {
+        create: taskIds.map((taskId) => ({ id: randomUUID(), taskId })),
+      },
+    },
+    select: meetingSelect,
+  });
+
+  logger.info({ meetingId: meeting.id, category: meeting.category }, 'Meeting created');
+  return meeting;
+}
+
+export async function updateMeeting(id: string, input: UpdateMeetingInput) {
+  const { attendeeIds, taskIds, updatedById, ...data } = input;
+
+  const existing = await prisma.meeting.findUnique({ where: { id }, select: { googleEventId: true } });
+
+  const updates: Parameters<typeof prisma.meeting.update>[0]['data'] = {
+    ...data,
+    updatedById,
+  };
+
+  if (attendeeIds !== undefined) {
+    updates.attendees = {
+      deleteMany: {},
+      create: attendeeIds.map((userId) => ({ id: randomUUID(), userId, status: 'invited' })),
+    };
+  }
+
+  if (taskIds !== undefined) {
+    updates.tasks = {
+      deleteMany: {},
+      create: taskIds.map((taskId) => ({ id: randomUUID(), taskId })),
+    };
+  }
+
+  const meeting = await prisma.meeting.update({
+    where: { id },
+    data: updates,
+    select: meetingSelect,
+  });
+
+  logger.info({ meetingId: id, updatedById }, 'Meeting updated');
+  return { meeting, previousGoogleEventId: existing?.googleEventId };
+}
+
+export async function deleteMeeting(id: string, deletedById: string) {
+  const existing = await prisma.meeting.findUnique({
+    where: { id },
+    select: { googleEventId: true },
+  });
+
+  await prisma.meeting.update({
+    where: { id },
+    data: { deletedAt: new Date(), deletedById },
+  });
+
+  if (existing?.googleEventId) {
+    await deleteGoogleCalendarEvent(existing.googleEventId);
+  }
+
+  logger.info({ meetingId: id, deletedById }, 'Meeting soft-deleted');
+}
+
+export async function updateAttendeeStatus(meetingId: string, userId: string, status: AttendeeStatus) {
+  await prisma.meetingAttendee.update({
+    where: { meetingId_userId: { meetingId, userId } },
+    data: { status },
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function getAttendeeEmails(userIds: string[]): Promise<string[]> {
+  const users = await prisma.user.findMany({
+    where: { id: { in: userIds } },
+    select: { email: true },
+  });
+  return users.map((u) => u.email);
+}


### PR DESCRIPTION
Full module for scheduling, tracking, and reporting all company meetings
across every department. Category dropdown (Sales, Operations, Project,
Management Review, HR, Quality & Safety, Board, Client, Supplier, Planning,
Other) drives reporting by meeting type. Attendees and OTS tasks are linked
at scheduling time. Google Meet links auto-generated via Calendar API when
credentials are configured.

Files added:
- prisma/manual_migrations/add_meetings_module.sql (Meeting, MeetingAttendee, MeetingTask tables)
- src/lib/services/meeting.service.ts
- src/lib/services/google-calendar.service.ts
- src/app/api/meetings/route.ts + [id]/route.ts + [id]/attendees/route.ts
- src/app/meetings/_page-client.tsx + page.tsx
- src/components/meetings/meeting-form-sheet.tsx
- src/components/meetings/meeting-detail-sheet.tsx

Modified: schema.prisma, permissions.ts, navigation-permissions.ts,
          app-sidebar.tsx, env.ts, package.json, CHANGELOG.md

https://claude.ai/code/session_019PrzLPUjQ7HgukyMc1cEyo