### PR TITLE
feat: multi-file BD attachments, aging Excel export, print fix, workflow fix (v22.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [22.2.0] - 2026-04-28
+
+### Business Development, Aging Report, Workflow
+
+#### Added
+- **BD multi-file attachments** — each submitted document can now hold multiple named file attachments; existing single-file records remain backward-compatible
+- **Aging report Excel export** — "Export Excel" button generates a two-sheet XLSX (Summary + Invoice Detail) for both AR and AP aging reports
+
+#### Fixed
+- **Aging report print with expanded sidebar** — semi-transparent sidebar overlay no longer bleeds through when printing with the menu open
+- **Workflow edit error** — saving name/description now always succeeds even when workflow instances are in progress; steps are only sent to the server if changed, and a 409 conflict is shown as an informational warning rather than a hard failure
+
+#### Changed
+- Version bumped to **22.2.0**
+- **Database migration**: `prisma/manual_migrations/bd_document_attachments.sql` — adds `attachments` column to `BdDocument`
+
+---
+
 ## [22.1.0] - 2026-04-28
 
 ### Meetings Module

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexa-steel-ots",
-  "version": "22.1.0",
+  "version": "22.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/prisma/manual_migrations/bd_document_attachments.sql
+++ b/prisma/manual_migrations/bd_document_attachments.sql
@@ -1,0 +1,37 @@
+-- ============================================================
+-- BD Document multi-file attachments (v22.2.0)
+-- Adds an `attachments` JSON column to BdDocument so each
+-- document record can hold multiple named file attachments.
+-- Safe to re-run — uses stored procedure pattern.
+-- ============================================================
+
+DROP PROCEDURE IF EXISTS add_column_if_not_exists;
+DELIMITER $$
+CREATE PROCEDURE add_column_if_not_exists(
+  IN p_table VARCHAR(64),
+  IN p_column VARCHAR(64),
+  IN p_definition TEXT
+)
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME   = p_table
+      AND COLUMN_NAME  = p_column
+  ) THEN
+    SET @ddl = CONCAT('ALTER TABLE `', p_table, '` ADD COLUMN `', p_column, '` ', p_definition);
+    PREPARE stmt FROM @ddl;
+    EXECUTE stmt;
+    DEALLOCATE PREPARE stmt;
+  END IF;
+END$$
+DELIMITER ;
+
+-- attachments: JSON array of { name: string, url: string }
+CALL add_column_if_not_exists(
+  'BdDocument',
+  'attachments',
+  'MEDIUMTEXT NULL'
+);
+
+DROP PROCEDURE IF EXISTS add_column_if_not_exists;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5877,6 +5877,7 @@ model BdDocument {
   company     BdCompany @relation(fields: [companyId], references: [id], onDelete: Cascade)
   title       String    @db.VarChar(255)
   fileUrl     String?   @db.VarChar(512)
+  attachments String?   @db.MediumText
   status      String    @default("SUBMITTED") @db.VarChar(30)
   submittedAt DateTime  @default(now())
   deletedAt   DateTime?

--- a/src/app/api/bd/companies/[id]/documents/[docId]/route.ts
+++ b/src/app/api/bd/companies/[id]/documents/[docId]/route.ts
@@ -7,9 +7,15 @@ import { logger } from '@/lib/logger';
 import { getCurrentUserPermissions } from '@/lib/permission-checker';
 import { logActivity } from '@/lib/api-utils';
 
+const attachmentSchema = z.object({
+  name: z.string().min(1).max(255),
+  url: z.string().min(1).max(512),
+});
+
 const updateSchema = z.object({
   title: z.string().min(1).max(255).optional(),
   fileUrl: z.string().max(512).optional().nullable(),
+  attachments: z.array(attachmentSchema).optional().nullable(),
   status: z.enum(['SUBMITTED', 'PENDING', 'APPROVED', 'REJECTED']).optional(),
   submittedAt: z.string().optional().nullable(),
 });
@@ -40,11 +46,12 @@ export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: 
     const existing = await prisma.bdDocument.findFirst({ where: { id: docId, deletedAt: null } });
     if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 
-    const { submittedAt, ...rest } = parsed.data;
+    const { submittedAt, attachments, ...rest } = parsed.data;
     const updated = await prisma.bdDocument.update({
       where: { id: docId },
       data: {
         ...rest,
+        ...(attachments !== undefined ? { attachments: attachments ? JSON.stringify(attachments) : null } : {}),
         ...(submittedAt !== undefined ? { submittedAt: submittedAt ? new Date(submittedAt) : existing.submittedAt } : {}),
       },
     });

--- a/src/app/api/bd/companies/[id]/documents/route.ts
+++ b/src/app/api/bd/companies/[id]/documents/route.ts
@@ -7,9 +7,15 @@ import { logger } from '@/lib/logger';
 import { getCurrentUserPermissions } from '@/lib/permission-checker';
 import { logActivity } from '@/lib/api-utils';
 
+const attachmentSchema = z.object({
+  name: z.string().min(1).max(255),
+  url: z.string().min(1).max(512),
+});
+
 const createSchema = z.object({
   title: z.string().min(1).max(255),
   fileUrl: z.string().max(512).optional().nullable(),
+  attachments: z.array(attachmentSchema).optional().nullable(),
   status: z.enum(['SUBMITTED', 'PENDING', 'APPROVED', 'REJECTED']).default('SUBMITTED'),
   submittedAt: z.string().optional(),
 });
@@ -64,12 +70,13 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
       return NextResponse.json({ error: 'Invalid input', details: parsed.error.flatten() }, { status: 400 });
     }
 
-    const { submittedAt, ...rest } = parsed.data;
+    const { submittedAt, attachments, ...rest } = parsed.data;
 
     const document = await prisma.bdDocument.create({
       data: {
         ...rest,
         companyId: id,
+        attachments: attachments ? JSON.stringify(attachments) : null,
         submittedAt: submittedAt ? new Date(submittedAt) : new Date(),
       },
     });

--- a/src/app/api/financial/reports/aging/export-xlsx/route.ts
+++ b/src/app/api/financial/reports/aging/export-xlsx/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from 'next/server';
+import * as XLSX from 'xlsx';
+import { FinancialReportService } from '@/lib/financial/report-service';
+import { requireFinancialPermission } from '@/lib/financial/require-financial-permission';
+
+export const dynamic = 'force-dynamic';
+
+function fmt(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+export async function GET(req: Request) {
+  const auth = await requireFinancialPermission('financial.view');
+  if ('error' in auth) return auth.error;
+
+  const { searchParams } = new URL(req.url);
+  const type = (searchParams.get('type') || 'ar') as 'ar' | 'ap';
+  const asOf = searchParams.get('as_of') || new Date().toISOString().slice(0, 10);
+
+  try {
+    const service = new FinancialReportService();
+    const report = await service.getAgingReport(type, asOf);
+
+    const label = type === 'ar' ? 'Accounts Receivable' : 'Accounts Payable';
+
+    // Summary sheet rows
+    const summaryRows = report.rows.map(row => ({
+      'Third Party': row.thirdpartyName,
+      'Invoices': row.invoices.length,
+      'Current': fmt(row.buckets.current),
+      '1-30 Days': fmt(row.buckets.days1to30),
+      '31-60 Days': fmt(row.buckets.days31to60),
+      '61-90 Days': fmt(row.buckets.days61to90),
+      '90+ Days': fmt(row.buckets.days90plus),
+      'Total': fmt(row.buckets.total),
+    }));
+
+    // Totals row
+    summaryRows.push({
+      'Third Party': 'TOTAL',
+      'Invoices': report.rows.reduce((s, r) => s + r.invoices.length, 0),
+      'Current': fmt(report.totals.current),
+      '1-30 Days': fmt(report.totals.days1to30),
+      '31-60 Days': fmt(report.totals.days31to60),
+      '61-90 Days': fmt(report.totals.days61to90),
+      '90+ Days': fmt(report.totals.days90plus),
+      'Total': fmt(report.totals.total),
+    });
+
+    // Detail sheet rows
+    const detailRows = report.rows.flatMap(row =>
+      row.invoices.map((inv: Record<string, unknown>) => ({
+        'Third Party': row.thirdpartyName,
+        'Invoice Ref': inv.ref,
+        'Invoice Date': inv.dateInvoice,
+        'Due Date': inv.dateDue,
+        'Days Overdue': inv.daysOverdue,
+        'Age Bucket': inv.ageBucket,
+        'Total Amount': fmt(Number(inv.totalAmount)),
+        'Amount Paid': fmt(Number(inv.amountPaid)),
+        'Remaining': fmt(Number(inv.remaining)),
+      }))
+    );
+
+    const wb = XLSX.utils.book_new();
+
+    const wsSummary = XLSX.utils.json_to_sheet(summaryRows);
+    wsSummary['!cols'] = [{ wch: 40 }, { wch: 10 }, { wch: 14 }, { wch: 14 }, { wch: 14 }, { wch: 14 }, { wch: 14 }, { wch: 14 }];
+    XLSX.utils.book_append_sheet(wb, wsSummary, 'Summary');
+
+    const wsDetail = XLSX.utils.json_to_sheet(detailRows);
+    wsDetail['!cols'] = [{ wch: 35 }, { wch: 20 }, { wch: 14 }, { wch: 14 }, { wch: 14 }, { wch: 16 }, { wch: 16 }, { wch: 16 }, { wch: 16 }];
+    XLSX.utils.book_append_sheet(wb, wsDetail, 'Invoice Detail');
+
+    const buf = XLSX.write(wb, { type: 'buffer', bookType: 'xlsx' }) as Buffer;
+    const filename = `${label.replace(/ /g, '_')}_Aging_${asOf}.xlsx`;
+
+    return new NextResponse(buf, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'Content-Disposition': `attachment; filename="${filename}"`,
+      },
+    });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Export failed';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/financial/reports/aging/_page-client.tsx
+++ b/src/app/financial/reports/aging/_page-client.tsx
@@ -6,7 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
-import { Loader2, Clock, Printer, ChevronDown, ChevronRight, ArrowLeft, Search } from 'lucide-react';
+import { Loader2, Clock, Printer, ChevronDown, ChevronRight, ArrowLeft, Search, FileSpreadsheet } from 'lucide-react';
 import Link from 'next/link';
 import { cn, resolveUploadUrl } from '@/lib/utils';
 import { InvoiceDetailSheet } from '@/components/financial/invoice-detail-sheet';
@@ -93,9 +93,21 @@ export default function AgingReportPage() {
             <p className="text-sm text-muted-foreground">Accounts Receivable / Payable aging by due date</p>
           </div>
         </div>
-        <Button variant="outline" size="sm" onClick={() => window.print()} className="print:hidden">
-          <Printer className="h-4 w-4 mr-2" /> Print
-        </Button>
+        <div className="flex items-center gap-2">
+          {report && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="print:hidden"
+              onClick={() => { window.open(`/api/financial/reports/aging/export-xlsx?type=${type}&as_of=${asOfDate}`, '_blank'); }}
+            >
+              <FileSpreadsheet className="h-4 w-4 mr-2" /> Export Excel
+            </Button>
+          )}
+          <Button variant="outline" size="sm" onClick={() => window.print()} className="print:hidden">
+            <Printer className="h-4 w-4 mr-2" /> Print
+          </Button>
+        </div>
       </div>
 
       {/* ── Filters ───────────────────────────────────────────────────────────── */}

--- a/src/app/workflow/definitions/WorkflowDefinitionsClient.tsx
+++ b/src/app/workflow/definitions/WorkflowDefinitionsClient.tsx
@@ -814,6 +814,18 @@ function DefinitionForm({ initial, onClose, onSave }: DefinitionFormProps) {
     setSteps(prev => prev.filter((_, i) => i !== index).map((s, i) => ({ ...s, sequence: i + 1 })));
   };
 
+  const stepsChanged = isEdit && JSON.stringify(
+    (initial?.steps ?? []).map(s => ({
+      sequence: s.sequence, name: s.name, approverResolver: s.approverResolver,
+      minApprovals: s.minApprovals, slaHours: s.slaHours, onRejectBehavior: s.onRejectBehavior, conditions: s.conditions,
+    }))
+  ) !== JSON.stringify(
+    steps.map(s => ({
+      sequence: s.sequence, name: s.name, approverResolver: s.approverResolver,
+      minApprovals: s.minApprovals, slaHours: s.slaHours, onRejectBehavior: s.onRejectBehavior, conditions: s.conditions,
+    }))
+  );
+
   const handleSave = async () => {
     setError('');
     setSaving(true);
@@ -825,12 +837,25 @@ function DefinitionForm({ initial, onClose, onSave }: DefinitionFormProps) {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ name, description: description || undefined }),
         });
-        if (res.ok) {
-          res = await fetch(`/api/workflow/definitions/${initial!.id}/steps`, {
+        if (!res.ok) {
+          const err = await res.json();
+          throw new Error(err.error ?? 'Save failed');
+        }
+        if (stepsChanged) {
+          const stepsRes = await fetch(`/api/workflow/definitions/${initial!.id}/steps`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ steps }),
           });
+          if (!stepsRes.ok) {
+            const err = await stepsRes.json();
+            if (stepsRes.status === 409) {
+              setError(`Name and description saved. Steps were not updated: ${err.error}`);
+              onSave();
+              return;
+            }
+            throw new Error(err.error ?? 'Failed to update steps');
+          }
         }
       } else {
         res = await fetch('/api/workflow/definitions', {
@@ -838,10 +863,10 @@ function DefinitionForm({ initial, onClose, onSave }: DefinitionFormProps) {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ key, name, description: description || undefined, entityType, steps }),
         });
-      }
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.error ?? 'Save failed');
+        if (!res.ok) {
+          const err = await res.json();
+          throw new Error(err.error ?? 'Save failed');
+        }
       }
       onSave();
     } catch (e) {

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -875,7 +875,7 @@ export function AppSidebar() {
       {/* Overlay for mobile */}
       {!collapsed && (
         <div
-          className="lg:hidden fixed inset-0 bg-background/80 backdrop-blur-sm z-30"
+          className="lg:hidden print:hidden fixed inset-0 bg-background/80 backdrop-blur-sm z-30"
           onClick={() => setCollapsed(true)}
         />
       )}

--- a/src/components/bd/bd-client.tsx
+++ b/src/components/bd/bd-client.tsx
@@ -35,11 +35,14 @@ type ArchiveEntry = {
   company?: { id: string; name: string };
 };
 
+type DocAttachment = { name: string; url: string };
+
 type BdDocument = {
   id: string;
   companyId: string;
   title: string;
   fileUrl: string | null;
+  attachments: string | null;
   status: string;
   submittedAt: string;
   company?: { id: string; name: string };
@@ -484,8 +487,8 @@ function CompanyDialog({
 
 // ─── Document Dialog ──────────────────────────────────────────────────────────
 
-type DocFormData = { companyId: string; title: string; fileUrl: string; status: string; submittedAt: string };
-const EMPTY_DOC_FORM: DocFormData = { companyId: '', title: '', fileUrl: '', status: 'SUBMITTED', submittedAt: '' };
+type DocFormData = { companyId: string; title: string; fileUrl: string; attachments: DocAttachment[]; status: string; submittedAt: string };
+const EMPTY_DOC_FORM: DocFormData = { companyId: '', title: '', fileUrl: '', attachments: [], status: 'SUBMITTED', submittedAt: '' };
 
 function DocumentDialog({
   open, onClose, companies, initial, onSave, isEdit,
@@ -498,9 +501,10 @@ function DocumentDialog({
   const [error, setError] = useState('');
   const [fileUploading, setFileUploading] = useState(false);
   const [fileUploadError, setFileUploadError] = useState('');
+  const [pendingName, setPendingName] = useState('');
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  React.useEffect(() => { setForm(initial); setError(''); setFileUploadError(''); }, [open, initial]);
+  React.useEffect(() => { setForm(initial); setError(''); setFileUploadError(''); setPendingName(''); }, [open, initial]);
 
   async function handleFileUpload(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
@@ -513,7 +517,9 @@ function DocumentDialog({
       const res = await fetch('/api/upload', { method: 'POST', body: fd });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error ?? 'Upload failed');
-      setForm(f => ({ ...f, fileUrl: data.filePath }));
+      const name = pendingName.trim() || file.name.replace(/\.[^.]+$/, '');
+      setForm(f => ({ ...f, attachments: [...f.attachments, { name, url: data.filePath }] }));
+      setPendingName('');
     } catch (err) {
       setFileUploadError(err instanceof Error ? err.message : 'Upload failed');
     } finally {
@@ -522,8 +528,16 @@ function DocumentDialog({
     }
   }
 
+  function removeAttachment(idx: number) {
+    setForm(f => ({ ...f, attachments: f.attachments.filter((_, i) => i !== idx) }));
+  }
+
+  function renameAttachment(idx: number, name: string) {
+    setForm(f => ({ ...f, attachments: f.attachments.map((a, i) => i === idx ? { ...a, name } : a) }));
+  }
+
   const field = (key: keyof DocFormData) => ({
-    value: form[key],
+    value: form[key] as string,
     onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) =>
       setForm(f => ({ ...f, [key]: e.target.value })),
   });
@@ -540,7 +554,7 @@ function DocumentDialog({
 
   return (
     <Dialog open={open} onOpenChange={v => !saving && !v && onClose()}>
-      <DialogContent className="max-w-md">
+      <DialogContent className="max-w-lg">
         <DialogHeader><DialogTitle>{isEdit ? 'Edit Document' : 'Add Document'}</DialogTitle></DialogHeader>
         <form onSubmit={handleSubmit} className="space-y-4 py-2">
           <div className="space-y-1">
@@ -554,24 +568,46 @@ function DocumentDialog({
             <Label>Document Title *</Label>
             <Input {...field('title')} placeholder="e.g. VAT Certificate" />
           </div>
+
+          {/* ── Multi-attachment section ── */}
           <div className="space-y-2">
-            <Label>Attachment</Label>
-            {form.fileUrl && (
-              <div className="flex items-center gap-2 p-2 rounded-lg border bg-slate-50 text-xs text-slate-600">
-                <FileText className="h-4 w-4 text-slate-400 flex-shrink-0" />
-                <span className="truncate flex-1">{form.fileUrl.split('/').pop()}</span>
-                <a href={resolveUrl(form.fileUrl)!} target="_blank" rel="noopener noreferrer" className="text-sky-500 hover:text-sky-700 flex-shrink-0"><ExternalLink className="h-3.5 w-3.5" /></a>
-                <button type="button" onClick={() => setForm(f => ({ ...f, fileUrl: '' }))} className="text-slate-400 hover:text-rose-500 flex-shrink-0"><X className="h-3.5 w-3.5" /></button>
+            <Label>Attachments</Label>
+            {form.attachments.length > 0 && (
+              <div className="space-y-1.5">
+                {form.attachments.map((att, idx) => (
+                  <div key={idx} className="flex items-center gap-2 p-2 rounded-lg border bg-slate-50">
+                    <FileText className="h-4 w-4 text-slate-400 flex-shrink-0" />
+                    <Input
+                      value={att.name}
+                      onChange={e => renameAttachment(idx, e.target.value)}
+                      className="h-7 text-xs flex-1 min-w-0"
+                      placeholder="File name"
+                    />
+                    <a href={resolveUrl(att.url)!} target="_blank" rel="noopener noreferrer" className="text-sky-500 hover:text-sky-700 flex-shrink-0">
+                      <ExternalLink className="h-3.5 w-3.5" />
+                    </a>
+                    <button type="button" onClick={() => removeAttachment(idx)} className="text-slate-400 hover:text-rose-500 flex-shrink-0">
+                      <X className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                ))}
               </div>
             )}
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 flex-wrap">
+              <Input
+                value={pendingName}
+                onChange={e => setPendingName(e.target.value)}
+                placeholder="Optional file label…"
+                className="h-8 text-xs flex-1 min-w-[140px]"
+              />
               <input ref={fileInputRef} type="file" accept=".pdf,.doc,.docx,.xls,.xlsx,.jpg,.jpeg,.png,.zip" className="hidden" onChange={handleFileUpload} />
               <Button type="button" variant="outline" size="sm" onClick={() => fileInputRef.current?.click()} disabled={fileUploading}>
-                {fileUploading ? <><Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />Uploading…</> : <><Upload className="h-3.5 w-3.5 mr-1" />{form.fileUrl ? 'Replace File' : 'Attach File'}</>}
+                {fileUploading ? <><Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />Uploading…</> : <><Upload className="h-3.5 w-3.5 mr-1" />Add File</>}
               </Button>
-              {fileUploadError && <span className="text-xs text-rose-600">{fileUploadError}</span>}
             </div>
+            {fileUploadError && <p className="text-xs text-rose-600">{fileUploadError}</p>}
           </div>
+
           <div className="grid grid-cols-2 gap-4">
             <div className="space-y-1">
               <Label>Status</Label>
@@ -1147,19 +1183,22 @@ export function BdClient({
   }
 
   async function saveDocument(data: DocFormData) {
+    const attachmentsPayload = data.attachments.length > 0 ? data.attachments : null;
     if (docDialog.editId) {
       const res = await fetch(`/api/bd/companies/${data.companyId}/documents/${docDialog.editId}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title: data.title, fileUrl: data.fileUrl || null, status: data.status }),
+        body: JSON.stringify({ title: data.title, attachments: attachmentsPayload, status: data.status }),
       });
       if (!res.ok) { const e = await res.json().catch(() => ({})); throw new Error(e.error ?? 'Failed to update document'); }
-      setDocuments(prev => prev.map(d => d.id === docDialog.editId ? { ...d, title: data.title, fileUrl: data.fileUrl || null, status: data.status } : d));
+      setDocuments(prev => prev.map(d => d.id === docDialog.editId ? {
+        ...d, title: data.title, attachments: attachmentsPayload ? JSON.stringify(attachmentsPayload) : null, status: data.status,
+      } : d));
     } else {
       const res = await fetch(`/api/bd/companies/${data.companyId}/documents`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title: data.title, fileUrl: data.fileUrl || null, status: data.status, submittedAt: data.submittedAt || undefined }),
+        body: JSON.stringify({ title: data.title, attachments: attachmentsPayload, status: data.status, submittedAt: data.submittedAt || undefined }),
       });
       if (!res.ok) { const e = await res.json().catch(() => ({})); throw new Error(e.error ?? 'Failed to create document'); }
       const created = await res.json();
@@ -1565,11 +1604,20 @@ export function BdClient({
                           </div>
                           <div className="flex items-center gap-1 flex-shrink-0">
                             {docStatusBadge(doc.status)}
-                            {doc.fileUrl && (
-                              <a href={resolveUrl(doc.fileUrl)!} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-sky-600">
-                                <ExternalLink className="h-3 w-3" />
-                              </a>
-                            )}
+                            {(() => {
+                              const atts: DocAttachment[] = (() => { try { return doc.attachments ? JSON.parse(doc.attachments) : []; } catch { return []; } })();
+                              if (atts.length > 0) return (
+                                <a href={resolveUrl(atts[0].url)!} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-sky-600" title={`${atts.length} file(s)`}>
+                                  <ExternalLink className="h-3 w-3" />
+                                </a>
+                              );
+                              if (doc.fileUrl) return (
+                                <a href={resolveUrl(doc.fileUrl)!} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-sky-600">
+                                  <ExternalLink className="h-3 w-3" />
+                                </a>
+                              );
+                              return null;
+                            })()}
                           </div>
                         </div>
                       ))}
@@ -1756,18 +1804,32 @@ export function BdClient({
                       <TableCell className="text-xs text-slate-500">{fmt(doc.submittedAt)}</TableCell>
                       <TableCell>{docStatusBadge(doc.status)}</TableCell>
                       <TableCell className="text-right">
-                        {doc.fileUrl ? (
-                          <a href={resolveUrl(doc.fileUrl)!} target="_blank" rel="noopener noreferrer" className="text-sky-600 hover:text-sky-800">
-                            <ExternalLink className="h-4 w-4 inline" />
-                          </a>
-                        ) : (
-                          <span className="text-slate-300 text-xs">—</span>
-                        )}
+                        {(() => {
+                          const atts: DocAttachment[] = (() => { try { return doc.attachments ? JSON.parse(doc.attachments) : []; } catch { return []; } })();
+                          if (atts.length > 0) return (
+                            <div className="flex flex-col items-end gap-0.5">
+                              {atts.map((a, i) => (
+                                <a key={i} href={resolveUrl(a.url)!} target="_blank" rel="noopener noreferrer" className="text-xs text-sky-600 hover:text-sky-800 flex items-center gap-1">
+                                  <ExternalLink className="h-3 w-3" />{a.name}
+                                </a>
+                              ))}
+                            </div>
+                          );
+                          if (doc.fileUrl) return (
+                            <a href={resolveUrl(doc.fileUrl)!} target="_blank" rel="noopener noreferrer" className="text-sky-600 hover:text-sky-800">
+                              <ExternalLink className="h-4 w-4 inline" />
+                            </a>
+                          );
+                          return <span className="text-slate-300 text-xs">—</span>;
+                        })()}
                       </TableCell>
                       {canManage && (
                         <TableCell>
                           <div className="flex items-center justify-end gap-1">
-                            <button title="Edit" onClick={() => setDocDialog({ open: true, editId: doc.id, form: { companyId: doc.companyId, title: doc.title, fileUrl: doc.fileUrl ?? '', status: doc.status, submittedAt: doc.submittedAt ? doc.submittedAt.slice(0,10) : '' } })} className="p-1.5 rounded hover:bg-slate-100 text-slate-500"><Edit className="h-3.5 w-3.5" /></button>
+                            <button title="Edit" onClick={() => {
+                              const atts: DocAttachment[] = (() => { try { return doc.attachments ? JSON.parse(doc.attachments) : []; } catch { return []; } })();
+                              setDocDialog({ open: true, editId: doc.id, form: { companyId: doc.companyId, title: doc.title, fileUrl: doc.fileUrl ?? '', attachments: atts, status: doc.status, submittedAt: doc.submittedAt ? doc.submittedAt.slice(0,10) : '' } });
+                            }} className="p-1.5 rounded hover:bg-slate-100 text-slate-500"><Edit className="h-3.5 w-3.5" /></button>
                             <button title="Delete" onClick={() => setItemDeleteDialog({ open: true, type: 'doc', id: doc.id, label: doc.title })} className="p-1.5 rounded hover:bg-rose-50 text-rose-500"><Trash2 className="h-3.5 w-3.5" /></button>
                           </div>
                         </TableCell>


### PR DESCRIPTION
- BD documents: allow multiple named file attachments per record (new
  `attachments` JSON column via migration bd_document_attachments.sql);
  backward-compatible with existing single fileUrl records
- Aging report: add Excel export (2-sheet XLSX: Summary + Invoice Detail)
  via new GET /api/financial/reports/aging/export-xlsx
- Print fix: add print:hidden to sidebar mobile overlay so it no longer
  fades content when printing with the sidebar expanded
- Workflow edit: skip steps PUT when steps are unchanged; handle 409
  gracefully so name/description always saves even with in-progress instances

https://claude.ai/code/session_01Jpixy9MTh57eDpjJfBEZrs