### PR TITLE
feat: search thirdparties/invoices/payments, fix payment deletion sync, date-range report, CEO tasks board

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [22.4.1] - 2026-04-29
+
+### Search, Payment Sync, Date-Range Reports & CEO Board
+
+#### Added
+- **Global search** now returns five new result categories: **Customers & Suppliers** (searched by name, alias, code_client, code_supplier, email), **Customer Invoices** (by ref, ref_client, client name/code), **Supplier Invoices** (by ref, ref_supplier, supplier name/code), and **Payments** (by dolibarr_ref)
+- **Monthly Financial Report date range** — "From / To" month+year selector pair added; the API accepts `toYear` / `toMonth` params so any span (e.g. January → April) can be reported in a single view; single-month mode unchanged when From = To
+- **CEO Tasks panel on Brainstorm Board** — active tasks assigned to or created by the CEO (Walid Dami) plus any `isCeoTask`-flagged tasks rendered as an inline panel below the three-column sticky-note board; each row has an inline **Done** button that marks the task `Completed` without leaving the page
+- **`GET /api/ceo-arena/tasks`** — new endpoint returning active (non-completed) CEO tasks with project, assignee, due date, and priority
+
+#### Fixed
+- **Payment deletion sync** — after each invoice sync, OTS now deletes `fin_payments` rows whose `dolibarr_ref` is no longer returned by Dolibarr; previously, payments deleted in Dolibarr remained in OTS and inflated financial report totals; fix applied to all three sync paths: `syncCustomerInvoices`, `syncSupplierInvoices`, and `syncAllPayments`
+
+#### Changed
+- Version bumped to **22.4.1**
+
+---
+
 ## [22.4.0] - 2026-04-29
 
 ### Monthly Financial Report Dashboard

--- a/README.md
+++ b/README.md
@@ -1,16 +1,14 @@
 # Hexa Steel® Operations Tracking System (OTS™)
 
-**Version:** 22.0.1 | **Release Date:** April 28, 2026
+**Version:** 22.4.1 | **Release Date:** April 29, 2026
 
 A comprehensive Enterprise Resource Planning (ERP) system specifically designed for steel fabrication and construction projects. Built with Next.js 15, TypeScript, Prisma 6, and MySQL 8.
 
-### What's New in 22.0.1 — IMS Module Fixes & Quick Guide
-- **IMS sidebar** fixed — all IMS pages now show the sidebar navigation.
-- **Risk Register** page refresh loop fixed.
-- **IMS seed data** (categories, ISO clauses, workflow definitions) now runs automatically on server start.
-- **New Document** creation page at `/ims/documents/new`.
-- **New DCR** submission page at `/ims/change-requests/new`.
-- **IMS Quick Guide** at `/ims/guide`.
+### What's New in 22.4.1 — Search, Payment Sync, Date-Range Reports & CEO Board
+- **Global search** now finds customers, suppliers, invoice numbers, payment references, and customer/supplier codes.
+- **Payment deletion sync** — payments deleted in Dolibarr are now automatically removed from OTS on next sync.
+- **Monthly Financial Report** now supports date ranges (January → April) instead of a single month.
+- **CEO Tasks** appear directly on the Brainstorm Board with an inline "Done" button.
 
 ### What's New in 22.0.0 — IMS (Integrated Management System) Module
 - **Business Development section** — new top-level module for tracking target companies, registration status, submitted documents, and received RFQs/Inquiries.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexa-steel-ots",
-  "version": "22.4.0",
+  "version": "22.4.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/api/ceo-arena/tasks/route.ts
+++ b/src/app/api/ceo-arena/tasks/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import prisma from '@/lib/db';
+
+export async function GET() {
+  const store = await cookies();
+  const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+  const session = token ? verifySession(token) : null;
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  // Find Walid Dami's user ID by name
+  const ceoUser = await prisma.user.findFirst({
+    where: { name: { contains: 'Walid' }, isActive: true },
+    select: { id: true, name: true },
+  });
+
+  const tasks = await prisma.task.findMany({
+    where: {
+      OR: [
+        { isCeoTask: true },
+        ...(ceoUser ? [{ assignedToId: ceoUser.id }, { createdById: ceoUser.id }] : []),
+      ],
+      status: { not: 'Completed' },
+    },
+    select: {
+      id: true,
+      title: true,
+      status: true,
+      priority: true,
+      dueDate: true,
+      project: { select: { name: true, projectNumber: true } },
+      assignedTo: { select: { name: true } },
+    },
+    orderBy: [{ priority: 'desc' }, { dueDate: 'asc' }, { createdAt: 'desc' }],
+    take: 50,
+  });
+
+  return NextResponse.json({ tasks });
+}

--- a/src/app/api/financial/reports/monthly-report/route.ts
+++ b/src/app/api/financial/reports/monthly-report/route.ts
@@ -9,13 +9,16 @@ export async function GET(req: Request) {
   if ('error' in auth) return auth.error;
 
   const { searchParams } = new URL(req.url);
-  const year = parseInt(searchParams.get('year') || new Date().getFullYear().toString(), 10);
-  const month = parseInt(searchParams.get('month') || (new Date().getMonth() + 1).toString(), 10);
+  const now = new Date();
+  const year  = parseInt(searchParams.get('year')  || now.getFullYear().toString(), 10);
+  const month = parseInt(searchParams.get('month') || (now.getMonth() + 1).toString(), 10);
+  const toYear  = parseInt(searchParams.get('toYear')  || year.toString(), 10);
+  const toMonth = parseInt(searchParams.get('toMonth') || month.toString(), 10);
 
   const monthStart = `${year}-${String(month).padStart(2, '0')}-01`;
-  const monthEnd = month === 12
-    ? `${year}-12-31`
-    : `${year}-${String(month + 1).padStart(2, '0')}-01`;
+  const monthEnd = toMonth === 12
+    ? `${toYear + 1}-01-01`
+    : `${toYear}-${String(toMonth + 1).padStart(2, '0')}-01`;
 
   try {
     // ── Income: customer payments grouped by client ──────────────────────────
@@ -56,7 +59,7 @@ export async function GET(req: Request) {
       `, monthStart, monthEnd);
     } catch { /* table may be empty */ }
 
-    // ── Salaries for the month ─────────────────────────────────────────────────
+    // ── Salaries for the period ─────────────────────────────────────────────────
     let salaryRows: any[] = [];
     try {
       salaryRows = await prisma.$queryRawUnsafe(`
@@ -102,6 +105,8 @@ export async function GET(req: Request) {
     return NextResponse.json({
       year,
       month,
+      toYear,
+      toMonth,
       monthStart,
       income,
       expenses,

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -23,7 +23,7 @@ export const GET = withApiContext(async (req) => {
   }
 
   try {
-    const [tasks, projects, initiatives, weeklyIssues, backlogItems, ncrs, rfis, assemblyParts, lcrEntries, buildings, users, employees, assets, contracts, hrLetters] =
+    const [tasks, projects, initiatives, weeklyIssues, backlogItems, ncrs, rfis, assemblyParts, lcrEntries, buildings, users, employees, assets, contracts, hrLetters, thirdparties, customerInvoices, supplierInvoices, payments] =
       await Promise.all([
         safe(() => prisma.task.findMany({
           where: {
@@ -248,6 +248,92 @@ export const GET = withApiContext(async (req) => {
           take: MAX_PER_CATEGORY,
           orderBy: { issuedAt: 'desc' },
         })),
+
+        safe(() => prisma.$queryRaw<Array<{
+          id: number;
+          name: string | null;
+          code_client: string | null;
+          code_supplier: string | null;
+          client_type: number;
+          supplier_type: number;
+        }>>`
+          SELECT id, name, code_client, code_supplier, client_type, supplier_type
+          FROM dolibarr_thirdparties
+          WHERE is_active = 1
+            AND (name LIKE ${`%${q}%`}
+              OR name_alias LIKE ${`%${q}%`}
+              OR code_client LIKE ${`%${q}%`}
+              OR code_supplier LIKE ${`%${q}%`}
+              OR email LIKE ${`%${q}%`})
+          ORDER BY name ASC
+          LIMIT 5
+        `),
+
+        safe(() => prisma.$queryRaw<Array<{
+          dolibarr_id: number;
+          ref: string | null;
+          socid: number | null;
+          status: number | null;
+          is_paid: number;
+          entity_name: string | null;
+        }>>`
+          SELECT ci.dolibarr_id, ci.ref, ci.socid, ci.status, ci.is_paid,
+                 COALESCE(dt.name, CONCAT('Client #', ci.socid)) AS entity_name
+          FROM fin_customer_invoices ci
+          LEFT JOIN dolibarr_thirdparties dt ON dt.dolibarr_id = ci.socid
+          WHERE ci.is_active = 1
+            AND (ci.ref LIKE ${`%${q}%`}
+              OR ci.ref_client LIKE ${`%${q}%`}
+              OR dt.name LIKE ${`%${q}%`}
+              OR dt.code_client LIKE ${`%${q}%`})
+          ORDER BY ci.last_synced_at DESC
+          LIMIT 5
+        `),
+
+        safe(() => prisma.$queryRaw<Array<{
+          dolibarr_id: number;
+          ref: string | null;
+          socid: number | null;
+          status: number | null;
+          is_paid: number;
+          entity_name: string | null;
+        }>>`
+          SELECT si.dolibarr_id, si.ref, si.socid, si.status, si.is_paid,
+                 COALESCE(dt.name, CONCAT('Supplier #', si.socid)) AS entity_name
+          FROM fin_supplier_invoices si
+          LEFT JOIN dolibarr_thirdparties dt ON dt.dolibarr_id = si.socid
+          WHERE si.is_active = 1
+            AND (si.ref LIKE ${`%${q}%`}
+              OR si.ref_supplier LIKE ${`%${q}%`}
+              OR dt.name LIKE ${`%${q}%`}
+              OR dt.code_supplier LIKE ${`%${q}%`})
+          ORDER BY si.last_synced_at DESC
+          LIMIT 5
+        `),
+
+        safe(() => prisma.$queryRaw<Array<{
+          id: number;
+          dolibarr_ref: string | null;
+          payment_type: string;
+          amount: number | null;
+          payment_date: string | null;
+          entity_name: string | null;
+        }>>`
+          SELECT fp.id, fp.dolibarr_ref, fp.payment_type, fp.amount, fp.payment_date,
+                 COALESCE(dt.name,
+                   CASE fp.payment_type
+                     WHEN 'customer' THEN CONCAT('Client #', ci.socid)
+                     ELSE CONCAT('Supplier #', si.socid)
+                   END
+                 ) AS entity_name
+          FROM fin_payments fp
+          LEFT JOIN fin_customer_invoices ci ON fp.payment_type = 'customer' AND ci.dolibarr_id = fp.invoice_dolibarr_id
+          LEFT JOIN fin_supplier_invoices si ON fp.payment_type = 'supplier' AND si.dolibarr_id = fp.invoice_dolibarr_id
+          LEFT JOIN dolibarr_thirdparties dt ON dt.dolibarr_id = COALESCE(ci.socid, si.socid)
+          WHERE fp.dolibarr_ref LIKE ${`%${q}%`}
+          ORDER BY fp.payment_date DESC
+          LIMIT 5
+        `),
       ]);
 
     const taskArr = Array.isArray(tasks) ? tasks : [];
@@ -265,6 +351,10 @@ export const GET = withApiContext(async (req) => {
     const assetArr = Array.isArray(assets) ? assets : [];
     const contractArr = Array.isArray(contracts) ? contracts : [];
     const hrLetterArr = Array.isArray(hrLetters) ? hrLetters : [];
+    const thirdpartyArr = Array.isArray(thirdparties) ? thirdparties : [];
+    const customerInvoiceArr = Array.isArray(customerInvoices) ? customerInvoices : [];
+    const supplierInvoiceArr = Array.isArray(supplierInvoices) ? supplierInvoices : [];
+    const paymentArr = Array.isArray(payments) ? payments : [];
 
     return NextResponse.json({
       results: {
@@ -393,6 +483,44 @@ export const GET = withApiContext(async (req) => {
           badge: l.classification,
           url: `/hr/letters`,
           type: 'Letter',
+        })),
+        thirdparties: thirdpartyArr.map((t) => {
+          const isCustomer = Number(t.client_type) > 0;
+          const isSupplier = Number(t.supplier_type) > 0;
+          const role = isCustomer && isSupplier ? 'Customer & Supplier' : isCustomer ? 'Customer' : 'Supplier';
+          const code = isCustomer ? t.code_client : t.code_supplier;
+          return {
+            id: String(t.id),
+            title: t.name || `Party #${t.id}`,
+            subtitle: code ? `${code} · ${role}` : role,
+            badge: role,
+            url: `/financial/thirdparties`,
+            type: 'Thirdparty',
+          };
+        }),
+        customerInvoices: customerInvoiceArr.map((i) => ({
+          id: String(i.dolibarr_id),
+          title: i.ref || `Invoice #${i.dolibarr_id}`,
+          subtitle: i.entity_name || 'Unknown client',
+          badge: i.is_paid ? 'Paid' : 'Unpaid',
+          url: `/financial/invoices/customer`,
+          type: 'Customer Invoice',
+        })),
+        supplierInvoices: supplierInvoiceArr.map((i) => ({
+          id: String(i.dolibarr_id),
+          title: i.ref || `Invoice #${i.dolibarr_id}`,
+          subtitle: i.entity_name || 'Unknown supplier',
+          badge: i.is_paid ? 'Paid' : 'Unpaid',
+          url: `/financial/invoices/supplier`,
+          type: 'Supplier Invoice',
+        })),
+        payments: paymentArr.map((p) => ({
+          id: String(p.id),
+          title: p.dolibarr_ref || `Payment #${p.id}`,
+          subtitle: p.entity_name || 'Unknown',
+          badge: p.payment_type === 'customer' ? 'Income' : 'Expense',
+          url: `/financial/payments`,
+          type: 'Payment',
         })),
       },
     });

--- a/src/app/api/system/latest-version/route.ts
+++ b/src/app/api/system/latest-version/route.ts
@@ -7,29 +7,27 @@ const { version: pkgVersion } = require('../../../../../package.json') as { vers
 
 const CURRENT_VERSION = {
   version: pkgVersion,
-  date: 'April 28, 2026',
+  date: 'April 29, 2026',
   type: 'patch' as const,
-  mainTitle: 'IMS Sidebar, Workflow Fix & Seed Repair',
+  mainTitle: 'Search, Payment Sync, Date-Range Reports & CEO Board',
   highlights: [
-    'Workflow definition save (edit mode) no longer shows "Invalid input" — fixed Zod schema to accept null conditions.',
-    'IMS Quick Guide now appears in sidebar — added /ims/guide to navigation-permissions.ts.',
-    'All IMS pages now have an IMS Dashboard back-link in the breadcrumb area.',
-    'IMS seed SQL workflow section rewritten with correct column names (key, sequence, approverResolver) — seed data will now apply correctly on server restart.',
-    'Added /ims/change-requests/new to navigation permissions so the route is accessible.',
+    'Global search now finds customers, suppliers, invoice numbers, payment references, and customer/supplier codes.',
+    'Payments deleted in Dolibarr are now automatically removed from OTS on next sync — financial reports no longer show stale data.',
+    'Monthly Financial Report supports date ranges (e.g. January → April) instead of a single month only.',
+    'CEO Tasks from the main task system appear directly on the Brainstorm Board with an inline "Done" button.',
   ],
   changes: {
     added: [
-      '/ims/guide added to NAVIGATION_PERMISSIONS with null (open to any logged-in user)',
-      '/ims/change-requests/new added to NAVIGATION_PERMISSIONS',
-      'IMS Dashboard back-link breadcrumb added to all IMS pages (documents, change-requests, clause-matrix, review-calendar, risks, risk matrix, treatments, risk detail, document detail)',
+      'Global search: customers, suppliers, customer invoices, supplier invoices, and payments added as result categories',
+      'Monthly Financial Report: "From / To" month+year selectors for multi-month range reporting',
+      'CEO Tasks panel on Brainstorm Board — shows active tasks assigned to or created by the CEO with inline Mark Complete',
+      'GET /api/ceo-arena/tasks — endpoint returning active CEO tasks (isCeoTask flag or assigned to/created by Walid Dami)',
     ],
     fixed: [
-      'Workflow steps PUT API: conditions schema changed from .optional() to .optional().nullable() — null conditions from the form no longer cause "Invalid input"',
-      'Workflow definitions POST API: same nullable fix applied',
-      'seed_ims_data.sql workflow section: rewrote INSERT statements to use correct column names (key, sequence, approverResolver, entityType) instead of old names (code, stepOrder, approverRole)',
+      'Payment deletion sync: payments deleted in Dolibarr now deleted from OTS fin_payments on the next invoice sync — applies to syncCustomerInvoices, syncSupplierInvoices, and syncAllPayments',
     ],
     changed: [
-      'Version bumped to 22.0.2',
+      'Version bumped to 22.4.1',
     ],
   },
 };

--- a/src/app/changelog/_page-client.tsx
+++ b/src/app/changelog/_page-client.tsx
@@ -23,10 +23,68 @@ type ChangelogVersion = {
 // Version order: Most recent first
 const hardcodedVersions: ChangelogVersion[] = [
   {
+    version: '22.4.1',
+    date: 'April 29, 2026',
+    type: 'patch',
+    status: 'current',
+    mainTitle: 'Search, Payment Sync, Date-Range Reports & CEO Board',
+    highlights: [
+      'Global search now finds customers, suppliers, invoice numbers, payment references, and customer/supplier codes — all linked to the financial pages.',
+      'Payments deleted in Dolibarr are now automatically removed from OTS on next sync — financial reports no longer show stale totals.',
+      'Monthly Financial Report now supports full date ranges (e.g. January → April) with "From / To" month+year selectors.',
+      'CEO Tasks appear directly on the Brainstorm Board as an inline panel with an "Done" button to mark complete without leaving the page.',
+    ],
+    changes: {
+      added: [
+        'Global search: Customers & Suppliers (name, alias, code_client, code_supplier, email), Customer Invoices (ref, client name/code), Supplier Invoices (ref, supplier name/code), and Payments (dolibarr_ref) added as search result categories',
+        'Monthly Financial Report: "From / To" month+year selector pair; API accepts toYear/toMonth params; any span can be reported in one view',
+        'CEO Tasks panel on Brainstorm Board — active tasks assigned to or created by CEO (Walid Dami) plus isCeoTask-flagged tasks; inline Done button marks task Completed',
+        'GET /api/ceo-arena/tasks — endpoint returning active CEO tasks with project, assignee, due date, and priority',
+      ],
+      fixed: [
+        'Payment deletion sync — after each invoice sync, fin_payments rows whose dolibarr_ref is no longer in Dolibarr are deleted; fix applied to syncCustomerInvoices, syncSupplierInvoices, and syncAllPayments',
+      ],
+      changed: [
+        'Version bumped to 22.4.1',
+      ],
+    },
+  },
+  {
+    version: '22.4.0',
+    date: 'April 29, 2026',
+    type: 'minor',
+    status: 'previous',
+    mainTitle: 'Monthly Financial Report Dashboard',
+    highlights: [
+      'New full-page Monthly Financial Report showing income and expenses side by side for any selected month/year.',
+      'KPI tiles for Total Income, Total Expenses, Net Profit, and Salaries & Wages with compact SAR formatting.',
+      'Income panel groups all client payments by client name with proportional progress bars.',
+      'Supplier Payments and Salaries & Wages panels with live search/filter within each section.',
+      'Dedicated left-sidebar navigation for quick access to all financial reports.',
+    ],
+    changes: {
+      added: [
+        '/financial/reports/monthly-report — full-page report with KPI tiles, income vs expenses columns, and salary breakdown',
+        'Income panel: client payments grouped by client with payment count, invoice count, and proportional progress bar',
+        'Supplier Payments panel: supplier payments grouped by supplier with proportional breakdown',
+        'Salaries & Wages panel: salary records for the month with Paid/Pending status badges',
+        'In-page sidebar navigation listing all financial reports (visible lg+ screens)',
+        'Month/year navigation with prev/next buttons and dropdowns; live search within each panel',
+        'Summary bar: income vs expenses vs net overview with cash-flow link',
+        'API endpoint: GET /api/financial/reports/monthly-report?year=&month=',
+        '"Monthly Report" added to Financial Reports section in the main app sidebar',
+      ],
+      fixed: [],
+      changed: [
+        'Version bumped to 22.4.0',
+      ],
+    },
+  },
+  {
     version: '22.3.0',
     date: 'April 29, 2026',
     type: 'minor',
-    status: 'current',
+    status: 'previous',
     mainTitle: 'CEO Arena — Private Command Room',
     highlights: [
       'New CEO Arena sidebar section groups CEO Dashboard and the new Brainstorm Board under a single crown menu.',
@@ -49,6 +107,59 @@ const hardcodedVersions: ChangelogVersion[] = [
       changed: [
         'CEO Dashboard moved from top-level single nav into the CEO Arena collapsible section',
         'Version bumped to 22.3.0',
+      ],
+    },
+  },
+  {
+    version: '22.2.0',
+    date: 'April 28, 2026',
+    type: 'minor',
+    status: 'previous',
+    mainTitle: 'Business Development, Aging Report & Workflow Fixes',
+    highlights: [
+      'Each submitted BD document can now hold multiple named file attachments; existing single-file records remain backward-compatible.',
+      'Aging report gains an "Export Excel" button that generates a two-sheet XLSX (Summary + Invoice Detail) for both AR and AP.',
+      'Aging report print no longer bleeds a semi-transparent sidebar overlay when the menu is open.',
+      'Workflow edit now always succeeds even when workflow instances are in progress — step changes send only when changed, 409 shown as informational warning.',
+    ],
+    changes: {
+      added: [
+        'BD multi-file attachments — each submitted document can hold multiple named file attachments; bd_document_attachments.sql migration adds attachments column',
+        'Aging report Excel export — Export Excel button generates two-sheet XLSX (Summary + Invoice Detail) for AR and AP aging',
+      ],
+      fixed: [
+        'Aging report print with expanded sidebar — semi-transparent overlay no longer bleeds through when printing with sidebar open',
+        'Workflow edit error — saving name/description now always succeeds even with in-progress instances; steps only sent if changed; 409 shown as informational warning',
+      ],
+      changed: [
+        'Version bumped to 22.2.0',
+      ],
+    },
+  },
+  {
+    version: '22.1.0',
+    date: 'April 28, 2026',
+    type: 'patch',
+    status: 'previous',
+    mainTitle: 'IMS Sidebar, Workflow Fix & Seed Repair',
+    highlights: [
+      'Workflow edit no longer shows "Invalid input" — Zod schema now accepts null conditions from the form.',
+      'IMS Quick Guide now visible in sidebar — added to navigation permissions.',
+      'All IMS pages now have an IMS Dashboard back-link breadcrumb.',
+      'IMS seed SQL workflow section corrected (key, sequence, approverResolver columns).',
+      '/ims/change-requests/new route added to navigation permissions.',
+    ],
+    changes: {
+      added: [
+        '/ims/guide and /ims/change-requests/new added to NAVIGATION_PERMISSIONS',
+        'IMS Dashboard back-link breadcrumb added to all IMS pages',
+      ],
+      fixed: [
+        'Workflow steps PUT + POST: conditions .nullable() fix — null no longer causes "Invalid input"',
+        'seed_ims_data.sql workflow section: correct column names (key, sequence, approverResolver, entityType)',
+      ],
+      changed: [
+        'Version bumped to 22.1.0',
       ],
     },
   },
@@ -145,6 +256,40 @@ const hardcodedVersions: ChangelogVersion[] = [
       fixed: [],
       changed: [
         'Version bumped to 22.0.0',
+      ],
+    },
+  },
+  {
+    version: '21.3.0',
+    date: 'April 27, 2026',
+    type: 'minor',
+    status: 'previous',
+    mainTitle: 'Business Development & Workflow UX Improvements',
+    highlights: [
+      'Company detail modal — eye icon on every company row opens a full read-only view with inline Edit button.',
+      'Archive entries now support full CRUD: clear individual entries from the archive panel or the Archives tab.',
+      'Workflow PBAC_PERMISSION picker replaces raw text input with a grouped, searchable dropdown showing human-readable names.',
+      'Workflow FIXED_USER step now shows a user selector; ROLE step shows a role dropdown.',
+      'Vendor Portal fields added: Vendor ID#, portal username, and password (visibility restricted to creator and CEO).',
+    ],
+    changes: {
+      added: [
+        'Company detail modal (eye icon button) — full read-only view of all fields with inline Edit button',
+        'Archive entry delete — clear button in archive panel and delete button in Archives tab; DELETE /api/bd/companies/[id]/archive endpoint',
+        'Workflow PBAC_PERMISSION picker — grouped select + live search by name or permission key with description preview',
+        'Workflow FIXED_USER selector — dropdown of active users fetched from /api/users',
+        'Workflow ROLE selector — dropdown of roles fetched from /api/roles',
+        'Vendor Portal Fields — Vendor ID#, portal username, and password (visibility restricted to creator and CEO)',
+      ],
+      fixed: [
+        'BD company logos: onError fallback renders initials instead of broken image icon',
+        'PM2 Prisma error: resolveUserPermissions now guards against empty userId before calling findUnique',
+      ],
+      changed: [
+        'Company avatar size increased to h-16 w-16 in company table (was h-14 w-14)',
+        'Archive panel save/delete updates React state immediately without full page refresh',
+        'resolverSummary shows human-readable permission name instead of raw permission key in workflow step list',
+        'Version bumped to 21.3.0',
       ],
     },
   },
@@ -8513,18 +8658,24 @@ export default function ChangelogPage() {
                 key={version.version}
                 className={cn(
                   'rounded-2xl border bg-white shadow-sm overflow-hidden transition-shadow hover:shadow-md',
-                  isCurrent && 'border-sky-300 ring-1 ring-sky-200'
+                  isCurrent && 'border-sky-300 ring-1 ring-sky-200',
+                  !isCurrent && version.type === 'major' && 'border-amber-300 ring-1 ring-amber-100'
                 )}
               >
                 {/* Header row */}
                 <button
-                  className="w-full flex items-center gap-4 px-5 py-4 text-left hover:bg-slate-50/60 transition-colors"
+                  className={cn(
+                    'w-full flex items-center gap-4 px-5 py-4 text-left transition-colors',
+                    version.type === 'major' && !isCurrent ? 'hover:bg-amber-50/40' : 'hover:bg-slate-50/60'
+                  )}
                   onClick={() => toggle(version.version)}
                 >
                   {/* Version badge */}
                   <div className={cn(
                     'shrink-0 rounded-xl px-3 py-2 text-center min-w-[72px]',
-                    isCurrent ? 'bg-sky-600 text-white' : 'bg-slate-100 text-slate-600'
+                    isCurrent ? 'bg-sky-600 text-white'
+                    : version.type === 'major' ? 'bg-amber-500 text-white'
+                    : 'bg-slate-100 text-slate-600'
                   )}>
                     <div className="text-xs font-medium opacity-75">v</div>
                     <div className="text-sm font-bold leading-tight">{version.version}</div>

--- a/src/app/financial/reports/monthly-report/_page-client.tsx
+++ b/src/app/financial/reports/monthly-report/_page-client.tsx
@@ -176,8 +176,10 @@ function ProgressBar({ value, max, color }: { value: number; max: number; color:
 
 export default function MonthlyFinancialReportPage() {
   const now = new Date();
-  const [year, setYear]   = useState(now.getFullYear());
-  const [month, setMonth] = useState(now.getMonth() + 1);
+  const [year, setYear]       = useState(now.getFullYear());
+  const [month, setMonth]     = useState(now.getMonth() + 1);
+  const [toYear, setToYear]   = useState(now.getFullYear());
+  const [toMonth, setToMonth] = useState(now.getMonth() + 1);
   const [data, setData]   = useState<ReportData | null>(null);
   const [loading, setLoading] = useState(true);
   const [incomeSearch,  setIncomeSearch]  = useState('');
@@ -189,11 +191,11 @@ export default function MonthlyFinancialReportPage() {
   const fetchData = useCallback(async () => {
     setLoading(true);
     try {
-      const res = await fetch(`/api/financial/reports/monthly-report?year=${year}&month=${month}`);
+      const res = await fetch(`/api/financial/reports/monthly-report?year=${year}&month=${month}&toYear=${toYear}&toMonth=${toMonth}`);
       if (res.ok) setData(await res.json());
     } catch { /* silent */ }
     finally { setLoading(false); }
-  }, [year, month]);
+  }, [year, month, toYear, toMonth]);
 
   useEffect(() => { fetchData(); }, [fetchData]);
 
@@ -258,7 +260,9 @@ export default function MonthlyFinancialReportPage() {
             <div>
               <h1 className="text-2xl font-bold tracking-tight">Monthly Financial Report</h1>
               <p className="text-sm text-muted-foreground mt-0.5">
-                Income &amp; expenses for {MONTH_NAMES[month - 1]} {year}
+                {year === toYear && month === toMonth
+                  ? `Income & expenses for ${MONTH_NAMES[month - 1]} ${year}`
+                  : `Income & expenses from ${MONTH_NAMES[month - 1]} ${year} to ${MONTH_NAMES[toMonth - 1]} ${toYear}`}
               </p>
             </div>
           </div>
@@ -268,6 +272,7 @@ export default function MonthlyFinancialReportPage() {
             <Button variant="outline" size="icon" className="h-9 w-9" onClick={prevMonth}>
               <ChevronLeft className="h-4 w-4" />
             </Button>
+            <span className="text-xs text-muted-foreground font-medium">From</span>
             <Select value={month.toString()} onValueChange={v => setMonth(Number(v))}>
               <SelectTrigger className="w-[130px] h-9"><SelectValue /></SelectTrigger>
               <SelectContent>
@@ -277,6 +282,21 @@ export default function MonthlyFinancialReportPage() {
               </SelectContent>
             </Select>
             <Select value={year.toString()} onValueChange={v => setYear(Number(v))}>
+              <SelectTrigger className="w-[90px] h-9"><SelectValue /></SelectTrigger>
+              <SelectContent>
+                {yearOptions.map(y => <SelectItem key={y} value={y.toString()}>{y}</SelectItem>)}
+              </SelectContent>
+            </Select>
+            <span className="text-xs text-muted-foreground font-medium">To</span>
+            <Select value={toMonth.toString()} onValueChange={v => setToMonth(Number(v))}>
+              <SelectTrigger className="w-[130px] h-9"><SelectValue /></SelectTrigger>
+              <SelectContent>
+                {MONTH_NAMES.map((name, i) => (
+                  <SelectItem key={i + 1} value={(i + 1).toString()}>{name}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Select value={toYear.toString()} onValueChange={v => setToYear(Number(v))}>
               <SelectTrigger className="w-[90px] h-9"><SelectValue /></SelectTrigger>
               <SelectContent>
                 {yearOptions.map(y => <SelectItem key={y} value={y.toString()}>{y}</SelectItem>)}
@@ -580,7 +600,11 @@ export default function MonthlyFinancialReportPage() {
                 <div className="flex flex-wrap items-center justify-between gap-4">
                   <div className="flex items-center gap-2 text-sm text-muted-foreground">
                     <BarChart3 className="h-4 w-4" />
-                    <span className="font-medium">Period Summary — {MONTH_NAMES[month - 1]} {year}</span>
+                    <span className="font-medium">
+                      {year === toYear && month === toMonth
+                        ? `Period Summary — ${MONTH_NAMES[month - 1]} ${year}`
+                        : `Period Summary — ${MONTH_NAMES[month - 1]} ${year} → ${MONTH_NAMES[toMonth - 1]} ${toYear}`}
+                    </span>
                   </div>
                   <div className="flex flex-wrap items-center gap-6">
                     <div className="flex items-center gap-2">

--- a/src/components/ceo-arena/CeoArenaBoard.tsx
+++ b/src/components/ceo-arena/CeoArenaBoard.tsx
@@ -6,7 +6,7 @@ import {
   Plus, Trash2, CheckCircle2, Circle, Clock, Flame,
   Lightbulb, HeartCrack, RefreshCw, X, ChevronDown,
   Tag, Sparkles, Brain, AlertCircle, Loader2, MoreVertical,
-  ArrowUpCircle, MinusCircle, ArrowDownCircle, Zap,
+  ArrowUpCircle, MinusCircle, ArrowDownCircle, Zap, ListTodo,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
@@ -476,6 +476,90 @@ function SectionColumn({
   );
 }
 
+interface CeoTask {
+  id: string;
+  title: string;
+  status: string;
+  priority: string;
+  dueDate: string | null;
+  project: { name: string; projectNumber: string } | null;
+  assignedTo: { name: string } | null;
+}
+
+const TASK_PRIORITY_COLOR: Record<string, string> = {
+  High:   'bg-red-100 text-red-700',
+  Medium: 'bg-amber-100 text-amber-700',
+  Low:    'bg-slate-100 text-slate-600',
+};
+
+const TASK_STATUS_COLOR: Record<string, string> = {
+  'Pending':     'text-slate-500',
+  'In Progress': 'text-blue-600',
+};
+
+function CeoTasksPanel() {
+  const [tasks, setTasks] = useState<CeoTask[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('/api/ceo-arena/tasks')
+      .then(r => r.ok ? r.json() : { tasks: [] })
+      .then(d => setTasks(d.tasks || []))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return (
+    <div className="flex items-center justify-center py-10">
+      <Loader2 className="size-5 animate-spin text-slate-400" />
+    </div>
+  );
+
+  if (tasks.length === 0) return null;
+
+  return (
+    <div className="mt-6 rounded-xl border border-gray-200 bg-white shadow-sm overflow-hidden">
+      <div className="px-5 py-3.5 border-b border-gray-100 flex items-center gap-2.5">
+        <div className="p-1.5 rounded-lg bg-slate-100">
+          <ListTodo className="size-4 text-slate-600" />
+        </div>
+        <div>
+          <p className="font-semibold text-gray-800 text-sm">CEO Tasks</p>
+          <p className="text-xs text-gray-400">Active tasks assigned to or created by the CEO</p>
+        </div>
+        <span className="ml-auto text-xs font-medium bg-slate-100 text-slate-600 px-2 py-0.5 rounded-full">
+          {tasks.length}
+        </span>
+      </div>
+      <div className="divide-y divide-gray-50">
+        {tasks.map(task => {
+          const StatusIcon = task.status === 'In Progress' ? Clock : Circle;
+          return (
+            <div key={task.id} className="px-5 py-3 flex items-center gap-3 hover:bg-gray-50 transition-colors">
+              <StatusIcon className={cn('size-4 shrink-0', TASK_STATUS_COLOR[task.status] ?? 'text-slate-400')} />
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium text-gray-800 truncate">{task.title}</p>
+                {task.project && (
+                  <p className="text-xs text-gray-400 truncate">{task.project.projectNumber} · {task.project.name}</p>
+                )}
+              </div>
+              <div className="flex items-center gap-2 shrink-0">
+                {task.dueDate && (
+                  <span className="text-xs text-gray-400">
+                    {new Date(task.dueDate).toLocaleDateString('en-SA', { month: 'short', day: 'numeric' })}
+                  </span>
+                )}
+                <span className={cn('text-[11px] font-medium px-1.5 py-0.5 rounded', TASK_PRIORITY_COLOR[task.priority] ?? 'bg-slate-100 text-slate-600')}>
+                  {task.priority}
+                </span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 export function CeoArenaBoard() {
   const [notes, setNotes] = useState<CeoNote[]>([]);
   const [loading, setLoading] = useState(true);
@@ -627,6 +711,8 @@ export function CeoArenaBoard() {
             ))}
           </div>
         )}
+
+        <CeoTasksPanel />
 
         {/* Footer tip */}
         <div className="mt-8 flex items-center gap-2 text-xs text-gray-300 justify-center">

--- a/src/components/ceo-arena/CeoArenaBoard.tsx
+++ b/src/components/ceo-arena/CeoArenaBoard.tsx
@@ -500,6 +500,7 @@ const TASK_STATUS_COLOR: Record<string, string> = {
 function CeoTasksPanel() {
   const [tasks, setTasks] = useState<CeoTask[]>([]);
   const [loading, setLoading] = useState(true);
+  const [completing, setCompleting] = useState<string | null>(null);
 
   useEffect(() => {
     fetch('/api/ceo-arena/tasks')
@@ -507,6 +508,20 @@ function CeoTasksPanel() {
       .then(d => setTasks(d.tasks || []))
       .finally(() => setLoading(false));
   }, []);
+
+  const markComplete = async (id: string) => {
+    setCompleting(id);
+    try {
+      const res = await fetch(`/api/tasks/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'Completed' }),
+      });
+      if (res.ok) setTasks(prev => prev.filter(t => t.id !== id));
+    } finally {
+      setCompleting(null);
+    }
+  };
 
   if (loading) return (
     <div className="flex items-center justify-center py-10">
@@ -533,8 +548,9 @@ function CeoTasksPanel() {
       <div className="divide-y divide-gray-50">
         {tasks.map(task => {
           const StatusIcon = task.status === 'In Progress' ? Clock : Circle;
+          const isCompleting = completing === task.id;
           return (
-            <div key={task.id} className="px-5 py-3 flex items-center gap-3 hover:bg-gray-50 transition-colors">
+            <div key={task.id} className="px-5 py-3 flex items-center gap-3 hover:bg-gray-50 transition-colors group">
               <StatusIcon className={cn('size-4 shrink-0', TASK_STATUS_COLOR[task.status] ?? 'text-slate-400')} />
               <div className="flex-1 min-w-0">
                 <p className="text-sm font-medium text-gray-800 truncate">{task.title}</p>
@@ -551,6 +567,15 @@ function CeoTasksPanel() {
                 <span className={cn('text-[11px] font-medium px-1.5 py-0.5 rounded', TASK_PRIORITY_COLOR[task.priority] ?? 'bg-slate-100 text-slate-600')}>
                   {task.priority}
                 </span>
+                <button
+                  onClick={() => markComplete(task.id)}
+                  disabled={isCompleting}
+                  title="Mark as complete"
+                  className="opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-1 text-[11px] font-medium text-emerald-600 hover:text-emerald-700 bg-emerald-50 hover:bg-emerald-100 px-2 py-0.5 rounded disabled:opacity-50"
+                >
+                  {isCompleting ? <Loader2 className="size-3 animate-spin" /> : <CheckCircle2 className="size-3" />}
+                  Done
+                </button>
               </div>
             </div>
           );

--- a/src/lib/dolibarr/financial-sync-service.ts
+++ b/src/lib/dolibarr/financial-sync-service.ts
@@ -466,14 +466,18 @@ export class FinancialSyncService {
           // Sync payments for this invoice
           try {
             const payments = await this.client.getInvoicePayments(dolibarrId);
+            const activeRefs = new Set<string>();
             for (const pmt of payments) {
               paymentsTotal++;
               const pmtDate = formatDate(parseDateString(pmt.date));
               if (!pmtDate) continue;
 
+              const ref = pmt.ref || `PAY-${dolibarrId}`;
+              activeRefs.add(ref);
+
               const existingPmt: any[] = await prisma.$queryRawUnsafe(
                 `SELECT id FROM fin_payments WHERE dolibarr_ref = ? AND payment_type = 'customer' AND invoice_dolibarr_id = ?`,
-                pmt.ref || `PAY-${dolibarrId}`, dolibarrId
+                ref, dolibarrId
               );
 
               if (existingPmt.length > 0) {
@@ -489,11 +493,25 @@ export class FinancialSyncService {
                   `INSERT INTO fin_payments (dolibarr_ref, payment_type, invoice_dolibarr_id, amount,
                    payment_date, payment_method, fk_bank_line, bank_account_id, first_synced_at, last_synced_at)
                    VALUES (?, 'customer', ?, ?, ?, ?, ?, ?, NOW(), NOW())`,
-                  pmt.ref || `PAY-${dolibarrId}`, dolibarrId, pf(pmt.amount), pmtDate,
+                  ref, dolibarrId, pf(pmt.amount), pmtDate,
                   pmt.type || null, pi(pmt.fk_bank_line), pi(pmt.fk_bank_account)
                 );
                 paymentsCreated++;
               }
+            }
+            // Remove OTS payments that no longer exist in Dolibarr
+            if (activeRefs.size > 0) {
+              const placeholders = Array.from(activeRefs).map(() => '?').join(',');
+              await prisma.$executeRawUnsafe(
+                `DELETE FROM fin_payments WHERE payment_type = 'customer' AND invoice_dolibarr_id = ? AND dolibarr_ref NOT IN (${placeholders})`,
+                dolibarrId, ...Array.from(activeRefs)
+              );
+            } else {
+              // No payments in Dolibarr — remove all OTS payments for this invoice
+              await prisma.$executeRawUnsafe(
+                `DELETE FROM fin_payments WHERE payment_type = 'customer' AND invoice_dolibarr_id = ?`,
+                dolibarrId
+              );
             }
           } catch (e: any) {
             console.error(`[FinSync] Error fetching payments for invoice ${dolibarrId}:`, e.message);
@@ -640,14 +658,18 @@ export class FinancialSyncService {
           // Sync payments for this supplier invoice
           try {
             const payments = await this.client.getSupplierInvoicePayments(dolibarrId);
+            const activeRefs = new Set<string>();
             for (const pmt of payments) {
               paymentsTotal++;
               const pmtDate = formatDate(parseDateString(pmt.date));
               if (!pmtDate) continue;
 
+              const ref = pmt.ref || `PAY-${dolibarrId}`;
+              activeRefs.add(ref);
+
               const existingPmt: any[] = await prisma.$queryRawUnsafe(
                 `SELECT id FROM fin_payments WHERE dolibarr_ref = ? AND payment_type = 'supplier' AND invoice_dolibarr_id = ?`,
-                pmt.ref || `PAY-${dolibarrId}`, dolibarrId
+                ref, dolibarrId
               );
 
               if (existingPmt.length > 0) {
@@ -663,11 +685,25 @@ export class FinancialSyncService {
                   `INSERT INTO fin_payments (dolibarr_ref, payment_type, invoice_dolibarr_id, amount,
                    payment_date, payment_method, fk_bank_line, bank_account_id, first_synced_at, last_synced_at)
                    VALUES (?, 'supplier', ?, ?, ?, ?, ?, ?, NOW(), NOW())`,
-                  pmt.ref || `PAY-${dolibarrId}`, dolibarrId, pf(pmt.amount), pmtDate,
+                  ref, dolibarrId, pf(pmt.amount), pmtDate,
                   pmt.type || null, pi(pmt.fk_bank_line), pi(pmt.fk_bank_account)
                 );
                 paymentsCreated++;
               }
+            }
+            // Remove OTS payments that no longer exist in Dolibarr
+            if (activeRefs.size > 0) {
+              const placeholders = Array.from(activeRefs).map(() => '?').join(',');
+              await prisma.$executeRawUnsafe(
+                `DELETE FROM fin_payments WHERE payment_type = 'supplier' AND invoice_dolibarr_id = ? AND dolibarr_ref NOT IN (${placeholders})`,
+                dolibarrId, ...Array.from(activeRefs)
+              );
+            } else {
+              // No payments in Dolibarr — remove all OTS payments for this invoice
+              await prisma.$executeRawUnsafe(
+                `DELETE FROM fin_payments WHERE payment_type = 'supplier' AND invoice_dolibarr_id = ?`,
+                dolibarrId
+              );
             }
           } catch (e: any) {
             console.error(`[FinSync] Error fetching payments for supplier invoice ${dolibarrId}:`, e.message);
@@ -727,14 +763,18 @@ export class FinancialSyncService {
         }
         try {
           const payments = await this.client.getInvoicePayments(dolibarrId);
+          const activeRefs = new Set<string>();
           for (const pmt of payments) {
             custTotal++;
             const pmtDate = formatDate(parseDateString(pmt.date));
             if (!pmtDate) continue;
 
+            const ref = pmt.ref || `PAY-${dolibarrId}`;
+            activeRefs.add(ref);
+
             const existingPmt: any[] = await prisma.$queryRawUnsafe(
               `SELECT id FROM fin_payments WHERE dolibarr_ref = ? AND payment_type = 'customer' AND invoice_dolibarr_id = ?`,
-              pmt.ref || `PAY-${dolibarrId}`, dolibarrId
+              ref, dolibarrId
             );
 
             if (existingPmt.length > 0) {
@@ -750,11 +790,24 @@ export class FinancialSyncService {
                 `INSERT INTO fin_payments (dolibarr_ref, payment_type, invoice_dolibarr_id, amount,
                  payment_date, payment_method, fk_bank_line, bank_account_id, first_synced_at, last_synced_at)
                  VALUES (?, 'customer', ?, ?, ?, ?, ?, ?, NOW(), NOW())`,
-                pmt.ref || `PAY-${dolibarrId}`, dolibarrId, pf(pmt.amount), pmtDate,
+                ref, dolibarrId, pf(pmt.amount), pmtDate,
                 pmt.type || null, pi(pmt.fk_bank_line), pi(pmt.fk_bank_account)
               );
               custCreated++;
             }
+          }
+          // Remove OTS payments that no longer exist in Dolibarr
+          if (activeRefs.size > 0) {
+            const placeholders = Array.from(activeRefs).map(() => '?').join(',');
+            await prisma.$executeRawUnsafe(
+              `DELETE FROM fin_payments WHERE payment_type = 'customer' AND invoice_dolibarr_id = ? AND dolibarr_ref NOT IN (${placeholders})`,
+              dolibarrId, ...Array.from(activeRefs)
+            );
+          } else {
+            await prisma.$executeRawUnsafe(
+              `DELETE FROM fin_payments WHERE payment_type = 'customer' AND invoice_dolibarr_id = ?`,
+              dolibarrId
+            );
           }
         } catch (e: any) {
           // 404 = no payments for this invoice, skip silently
@@ -770,7 +823,7 @@ export class FinancialSyncService {
       const suppInvoices: any[] = await prisma.$queryRawUnsafe(
         `SELECT dolibarr_id FROM fin_supplier_invoices WHERE is_active = 1`
       );
-      
+
       for (let i = 0; i < suppInvoices.length; i++) {
         const dolibarrId = suppInvoices[i].dolibarr_id;
         if (i > 0 && i % 500 === 0) {
@@ -778,14 +831,18 @@ export class FinancialSyncService {
         }
         try {
           const payments = await this.client.getSupplierInvoicePayments(dolibarrId);
+          const activeRefs = new Set<string>();
           for (const pmt of payments) {
             suppTotal++;
             const pmtDate = formatDate(parseDateString(pmt.date));
             if (!pmtDate) continue;
 
+            const ref = pmt.ref || `PAY-${dolibarrId}`;
+            activeRefs.add(ref);
+
             const existingPmt: any[] = await prisma.$queryRawUnsafe(
               `SELECT id FROM fin_payments WHERE dolibarr_ref = ? AND payment_type = 'supplier' AND invoice_dolibarr_id = ?`,
-              pmt.ref || `PAY-${dolibarrId}`, dolibarrId
+              ref, dolibarrId
             );
 
             if (existingPmt.length > 0) {
@@ -801,11 +858,24 @@ export class FinancialSyncService {
                 `INSERT INTO fin_payments (dolibarr_ref, payment_type, invoice_dolibarr_id, amount,
                  payment_date, payment_method, fk_bank_line, bank_account_id, first_synced_at, last_synced_at)
                  VALUES (?, 'supplier', ?, ?, ?, ?, ?, ?, NOW(), NOW())`,
-                pmt.ref || `PAY-${dolibarrId}`, dolibarrId, pf(pmt.amount), pmtDate,
+                ref, dolibarrId, pf(pmt.amount), pmtDate,
                 pmt.type || null, pi(pmt.fk_bank_line), pi(pmt.fk_bank_account)
               );
               suppCreated++;
             }
+          }
+          // Remove OTS payments that no longer exist in Dolibarr
+          if (activeRefs.size > 0) {
+            const placeholders = Array.from(activeRefs).map(() => '?').join(',');
+            await prisma.$executeRawUnsafe(
+              `DELETE FROM fin_payments WHERE payment_type = 'supplier' AND invoice_dolibarr_id = ? AND dolibarr_ref NOT IN (${placeholders})`,
+              dolibarrId, ...Array.from(activeRefs)
+            );
+          } else {
+            await prisma.$executeRawUnsafe(
+              `DELETE FROM fin_payments WHERE payment_type = 'supplier' AND invoice_dolibarr_id = ?`,
+              dolibarrId
+            );
           }
         } catch (e: any) {
           if (!e.message?.includes('404')) {

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -9,8 +9,8 @@ const { version: pkgVersion } = require('../../package.json') as { version: stri
 
 export const APP_VERSION = {
   version: pkgVersion,
-  date: 'April 28, 2026',
-  type: 'patch' as const, // 22.0.2 — IMS sidebar, workflow fix, seed fix
+  date: 'April 29, 2026',
+  type: 'patch' as const,
   name: 'Hexa Steel Operation Tracking System',
 };
 


### PR DESCRIPTION
- Global search: add customers, suppliers, customer invoices, supplier
  invoices, and payments (by dolibarr_ref) to results
- Payment sync: after each invoice payment sync, delete fin_payments rows
  whose dolibarr_ref no longer appears in Dolibarr — prevents stale
  payments from inflating financial reports when deleted in Dolibarr
  (applied to syncCustomerInvoices, syncSupplierInvoices, syncAllPayments)
- Monthly financial report: add "From / To" month+year selectors so the
  report can cover any date range; API accepts toYear/toMonth params and
  adjusts monthEnd accordingly; single-month view unchanged by default
- Brainstorm board: add CEO Tasks panel showing active tasks assigned to
  or created by Walid Dami (CEO), plus isCeoTask-flagged tasks, via new
  GET /api/ceo-arena/tasks endpoint

https://claude.ai/code/session_01Q8DduHXHPfvgDwVmD2mZDi