### PR TITLE
v22.5.2 — Account Invoice Report, orphan purge, sidebar fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [22.5.3] - 2026-04-29
+
+### Stability & Version Alignment
+
+#### Changed
+- Confirms **22.5.2** features as stable in production: Account Invoice Report, orphan purge (`POST /api/financial/purge-orphans`), and sidebar double-render fix
+- All financial report in-page sidebar link lists updated to include the Account Invoice Report entry
+- `README.md` version header and footer updated to **22.5.3**
+- Version bumped to **22.5.3**
+
+---
+
 ## [22.5.2] - 2026-04-29
 
 ### PO–Invoice Linkage, COA Credit Balance, Date Fix & Dashboard Reports

--- a/README.md
+++ b/README.md
@@ -1,14 +1,20 @@
 # Hexa Steel® Operations Tracking System (OTS™)
 
-**Version:** 22.4.1 | **Release Date:** April 29, 2026
+**Version:** 22.5.3 | **Release Date:** April 29, 2026
 
 A comprehensive Enterprise Resource Planning (ERP) system specifically designed for steel fabrication and construction projects. Built with Next.js 15, TypeScript, Prisma 6, and MySQL 8.
 
-### What's New in 22.4.1 — Search, Payment Sync, Date-Range Reports & CEO Board
-- **Global search** now finds customers, suppliers, invoice numbers, payment references, and customer/supplier codes.
-- **Payment deletion sync** — payments deleted in Dolibarr are now automatically removed from OTS on next sync.
-- **Monthly Financial Report** now supports date ranges (January → April) instead of a single month.
-- **CEO Tasks** appear directly on the Brainstorm Board with an inline "Done" button.
+### What's New in 22.5.3 — Stability & Version Alignment
+- Confirms **22.5.2** features as stable: Account Invoice Report, orphan purge, and sidebar double-render fix.
+
+### What's New in 22.5.2 — Account Invoice Report, Orphan Purge & Sidebar Fix
+- **Account Invoice Report** (`/financial/reports/account-invoice-report`) — select any accounting account (Raw Material, Bolts & Nuts, etc.) and see spend per project with % of project cost.
+- **Orphan purge** (`POST /api/financial/purge-orphans`) — hard-refreshes OTS by deactivating invoices and deleting payments deleted in Dolibarr.
+- **Sidebar double-render** fixed — `/operations/events` and `/projects/[id]/planning` no longer render two sidebars.
+
+### What's New in 22.5.1 — Supplier Invoice Report, Meetings Table View & Sidebar
+- **Supplier Invoice Report** — search any supplier, see invoices/payments as a % of project cost and total supplier spend.
+- **Meetings module** now shows the main app sidebar; All Meetings page has a grid/table toggle.
 
 ### What's New in 22.0.0 — IMS (Integrated Management System) Module
 - **Business Development section** — new top-level module for tracking target companies, registration status, submitted documents, and received RFQs/Inquiries.
@@ -515,7 +521,7 @@ Proprietary software — All rights reserved by Hexa Steel®.
 
 ---
 
-**Version**: 19.16.4
-**Last Updated**: April 21, 2026
+**Version**: 22.5.3
+**Last Updated**: April 29, 2026
 **Repository**: https://github.com/refedo/OTS
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexa-steel-ots",
-  "version": "22.5.2",
+  "version": "22.5.3",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/api/financial/purge-orphans/route.ts
+++ b/src/app/api/financial/purge-orphans/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import { FinancialSyncService, isSyncRunning } from '@/lib/dolibarr/financial-sync-service';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /api/financial/purge-orphans
+ * Hard-refreshes OTS financial data by deactivating invoices and deleting
+ * payments that no longer exist in Dolibarr.
+ * Requires an authenticated session.
+ */
+export async function POST(req: NextRequest) {
+  const store = await cookies();
+  const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+  const session = token ? verifySession(token) : null;
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  if (isSyncRunning()) {
+    return NextResponse.json(
+      { error: 'A sync is already running — please wait for it to finish before purging.' },
+      { status: 409 }
+    );
+  }
+
+  try {
+    const syncService = new FinancialSyncService();
+    const result = await syncService.purgeOrphanedRecords(session.sub ?? 'manual');
+    return NextResponse.json(result);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/financial/reports/account-invoice-report/accounts/route.ts
+++ b/src/app/api/financial/reports/account-invoice-report/accounts/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { requireFinancialPermission } from '@/lib/financial/require-financial-permission';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const auth = await requireFinancialPermission('financial.view');
+  if ('error' in auth) return auth.error;
+
+  try {
+    const accounts: { accounting_code: string; account_label: string; total_ht: number }[] =
+      await prisma.$queryRawUnsafe(`
+        SELECT
+          sil.accounting_code,
+          COALESCE(dam.dolibarr_account_label, dam.ots_cost_category, sil.accounting_code) AS account_label,
+          SUM(sil.total_ht) AS total_ht
+        FROM fin_supplier_invoice_lines sil
+        JOIN fin_supplier_invoices si ON si.dolibarr_id = sil.invoice_dolibarr_id
+        LEFT JOIN fin_dolibarr_account_mapping dam ON dam.dolibarr_account_id = sil.accounting_code
+        WHERE si.is_active = 1
+          AND si.status >= 1
+          AND sil.accounting_code IS NOT NULL
+          AND sil.accounting_code != ''
+        GROUP BY sil.accounting_code, account_label
+        ORDER BY total_ht DESC
+      `);
+
+    return NextResponse.json({
+      accounts: accounts.map((a) => ({
+        code: a.accounting_code,
+        label: a.account_label,
+        totalHT: Number(a.total_ht),
+      })),
+    });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/financial/reports/account-invoice-report/route.ts
+++ b/src/app/api/financial/reports/account-invoice-report/route.ts
@@ -1,0 +1,241 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { requireFinancialPermission } from '@/lib/financial/require-financial-permission';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: Request) {
+  const auth = await requireFinancialPermission('financial.view');
+  if ('error' in auth) return auth.error;
+
+  const { searchParams } = new URL(req.url);
+  const accountCode = searchParams.get('accountCode');
+  const from = searchParams.get('from');
+  const to = searchParams.get('to');
+
+  if (!accountCode) {
+    return NextResponse.json({ error: 'accountCode is required' }, { status: 400 });
+  }
+
+  const fromDate = from || '2000-01-01';
+  const toDate = to || '2099-12-31';
+
+  try {
+    // ── Account label ─────────────────────────────────────────────────────────
+    const labelRows: { account_label: string }[] = await prisma.$queryRawUnsafe(`
+      SELECT COALESCE(dolibarr_account_label, ots_cost_category, ?) AS account_label
+      FROM fin_dolibarr_account_mapping
+      WHERE dolibarr_account_id = ?
+      LIMIT 1
+    `, accountCode, accountCode);
+    const accountLabel = labelRows[0]?.account_label ?? accountCode;
+
+    // ── Invoices that contain at least one line for this account ──────────────
+    const invoiceRows: {
+      dolibarr_id: number;
+      ref: string;
+      ref_supplier: string | null;
+      date_invoice: string | null;
+      date_due: string | null;
+      total_ht: number;
+      total_tva: number;
+      total_ttc: number;
+      is_paid: number;
+      status: number;
+      fk_projet: number;
+      project_ref: string;
+      project_title: string;
+      socid: number;
+      supplier_name: string;
+      account_total_ht: number;
+    }[] = await prisma.$queryRawUnsafe(`
+      SELECT
+        si.dolibarr_id,
+        si.ref,
+        si.ref_supplier,
+        si.date_invoice,
+        si.date_due,
+        si.total_ht,
+        si.total_tva,
+        si.total_ttc,
+        si.is_paid,
+        si.status,
+        si.fk_projet,
+        COALESCE(dp.ref, '')    AS project_ref,
+        COALESCE(dp.title, '')  AS project_title,
+        si.socid,
+        COALESCE(dt.name, '')   AS supplier_name,
+        SUM(sil.total_ht)       AS account_total_ht
+      FROM fin_supplier_invoice_lines sil
+      JOIN fin_supplier_invoices si ON si.dolibarr_id = sil.invoice_dolibarr_id
+      LEFT JOIN dolibarr_projects dp ON dp.dolibarr_id = si.fk_projet
+      LEFT JOIN dolibarr_thirdparties dt ON dt.dolibarr_id = si.socid
+      WHERE si.is_active = 1
+        AND si.status >= 1
+        AND si.date_invoice BETWEEN ? AND ?
+        AND sil.accounting_code = ?
+      GROUP BY si.dolibarr_id, si.ref, si.ref_supplier, si.date_invoice, si.date_due,
+               si.total_ht, si.total_tva, si.total_ttc, si.is_paid, si.status,
+               si.fk_projet, project_ref, project_title, si.socid, supplier_name
+      ORDER BY si.date_invoice DESC
+    `, fromDate, toDate, accountCode);
+
+    // ── Payments for those invoices ───────────────────────────────────────────
+    const invoiceIds = invoiceRows.map((r) => Number(r.dolibarr_id));
+    let paymentRows: { invoice_dolibarr_id: number; amount: number; payment_date: string | null; payment_method: string | null; dolibarr_ref: string | null }[] = [];
+    if (invoiceIds.length > 0) {
+      paymentRows = await prisma.$queryRawUnsafe(`
+        SELECT invoice_dolibarr_id, amount, payment_date, payment_method, dolibarr_ref
+        FROM fin_payments
+        WHERE payment_type = 'supplier'
+          AND invoice_dolibarr_id IN (${invoiceIds.map(() => '?').join(',')})
+        ORDER BY payment_date ASC
+      `, ...invoiceIds);
+    }
+
+    const paymentsByInvoice = new Map<number, { amount: number; date: string | null; method: string | null; ref: string | null }[]>();
+    for (const p of paymentRows) {
+      const id = Number(p.invoice_dolibarr_id);
+      if (!paymentsByInvoice.has(id)) paymentsByInvoice.set(id, []);
+      paymentsByInvoice.get(id)!.push({
+        amount: Number(p.amount),
+        date: p.payment_date ? new Date(p.payment_date).toISOString().slice(0, 10) : null,
+        method: p.payment_method,
+        ref: p.dolibarr_ref,
+      });
+    }
+
+    // ── Per-project total cost (all accounts) in date range ───────────────────
+    const projectIds = [...new Set(invoiceRows.map((r) => Number(r.fk_projet)).filter((id) => id > 0))];
+    let projectCostRows: { fk_projet: number; total_cost: number }[] = [];
+    if (projectIds.length > 0) {
+      projectCostRows = await prisma.$queryRawUnsafe(`
+        SELECT fk_projet, SUM(total_ht) AS total_cost
+        FROM fin_supplier_invoices
+        WHERE is_active = 1 AND status >= 1
+          AND date_invoice BETWEEN ? AND ?
+          AND fk_projet IN (${projectIds.map(() => '?').join(',')})
+        GROUP BY fk_projet
+      `, fromDate, toDate, ...projectIds);
+    }
+    const projectCostMap = new Map<number, number>();
+    for (const r of projectCostRows) {
+      projectCostMap.set(Number(r.fk_projet), Number(r.total_cost));
+    }
+
+    // ── Grand total (this account, all invoices) in range ─────────────────────
+    const grandAccountRows: { grand_total: number }[] = await prisma.$queryRawUnsafe(`
+      SELECT SUM(sil.total_ht) AS grand_total
+      FROM fin_supplier_invoice_lines sil
+      JOIN fin_supplier_invoices si ON si.dolibarr_id = sil.invoice_dolibarr_id
+      WHERE si.is_active = 1
+        AND si.status >= 1
+        AND si.date_invoice BETWEEN ? AND ?
+        AND sil.accounting_code = ?
+    `, fromDate, toDate, accountCode);
+    const grandAccountTotal = Number(grandAccountRows[0]?.grand_total ?? 0);
+
+    // ── Grand total (all accounts) in range ───────────────────────────────────
+    const grandTotalRows: { grand_total: number }[] = await prisma.$queryRawUnsafe(`
+      SELECT SUM(total_ht) AS grand_total
+      FROM fin_supplier_invoices
+      WHERE is_active = 1 AND status >= 1
+        AND date_invoice BETWEEN ? AND ?
+    `, fromDate, toDate);
+    const grandTotalAll = Number(grandTotalRows[0]?.grand_total ?? 0);
+
+    // ── Build invoice list ────────────────────────────────────────────────────
+    const invoices = invoiceRows.map((inv) => {
+      const id = Number(inv.dolibarr_id);
+      const payments = paymentsByInvoice.get(id) ?? [];
+      const totalPaid = payments.reduce((s, p) => s + p.amount, 0);
+      const accountHT = Number(inv.account_total_ht);
+      const totalTTC = Number(inv.total_ttc);
+      const balance = totalTTC - totalPaid;
+      return {
+        id,
+        ref: inv.ref,
+        refSupplier: inv.ref_supplier,
+        dateInvoice: inv.date_invoice ? new Date(inv.date_invoice).toISOString().slice(0, 10) : null,
+        dateDue: inv.date_due ? new Date(inv.date_due).toISOString().slice(0, 10) : null,
+        totalHT: Number(inv.total_ht),
+        totalVAT: Number(inv.total_tva),
+        totalTTC,
+        accountHT,
+        isPaid: inv.is_paid === 1,
+        status: Number(inv.status),
+        projectId: Number(inv.fk_projet) || null,
+        projectRef: inv.project_ref || null,
+        projectTitle: inv.project_title || null,
+        supplierId: Number(inv.socid) || null,
+        supplierName: inv.supplier_name || null,
+        payments,
+        totalPaid,
+        balance,
+      };
+    });
+
+    // ── Per-project summary ───────────────────────────────────────────────────
+    const projectMap = new Map<string, {
+      projectId: number | null;
+      projectRef: string;
+      projectTitle: string;
+      invoiceCount: number;
+      accountHT: number;
+      totalPaid: number;
+      balance: number;
+      projectTotalCost: number;
+      pctOfProjectCost: number;
+    }>();
+
+    for (const inv of invoices) {
+      const key = inv.projectId ? String(inv.projectId) : '__no_project__';
+      if (!projectMap.has(key)) {
+        const projectTotalCost = inv.projectId ? (projectCostMap.get(inv.projectId) ?? 0) : 0;
+        projectMap.set(key, {
+          projectId: inv.projectId,
+          projectRef: inv.projectRef ?? 'No Project',
+          projectTitle: inv.projectTitle ?? 'No Project',
+          invoiceCount: 0,
+          accountHT: 0,
+          totalPaid: 0,
+          balance: 0,
+          projectTotalCost,
+          pctOfProjectCost: 0,
+        });
+      }
+      const entry = projectMap.get(key)!;
+      entry.invoiceCount += 1;
+      entry.accountHT += inv.accountHT;
+      entry.totalPaid += inv.totalPaid;
+      entry.balance += inv.balance;
+    }
+
+    const projectSummary = [...projectMap.values()].map((p) => ({
+      ...p,
+      pctOfProjectCost: p.projectTotalCost > 0 ? (p.accountHT / p.projectTotalCost) * 100 : 0,
+    })).sort((a, b) => b.accountHT - a.accountHT);
+
+    const totalPaid = invoices.reduce((s, i) => s + i.totalPaid, 0);
+    const totalBalance = invoices.reduce((s, i) => s + i.balance, 0);
+    const pctOfGrandTotal = grandTotalAll > 0 ? (grandAccountTotal / grandTotalAll) * 100 : 0;
+
+    return NextResponse.json({
+      account: { code: accountCode, label: accountLabel },
+      period: { from: fromDate, to: toDate },
+      summary: {
+        invoiceCount: invoices.length,
+        totalAccountHT: grandAccountTotal,
+        totalPaid,
+        totalBalance,
+        pctOfGrandTotal,
+        grandTotalAll,
+      },
+      projectSummary,
+      invoices,
+    });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/system/latest-version/route.ts
+++ b/src/app/api/system/latest-version/route.ts
@@ -9,25 +9,17 @@ const CURRENT_VERSION = {
   version: pkgVersion,
   date: 'April 29, 2026',
   type: 'patch' as const,
-  mainTitle: 'Account Invoice Report, Orphan Purge & Sidebar Fix',
+  mainTitle: 'Stability & Version Alignment',
   highlights: [
-    'New Account Invoice Report: select any accounting account (Raw Material, Bolts & Nuts, etc.) and see its spend broken down by project with % of project cost.',
-    'Hard-refresh purge: any invoice or payment deleted in Dolibarr but still lingering in OTS is now deactivated and cleaned up via POST /api/financial/purge-orphans.',
-    'Sidebar double-render fixed — users who saw two sidebars on /operations/events and /projects/[id]/planning will now see exactly one.',
+    'Confirms 22.5.2 features as stable: Account Invoice Report, orphan purge (POST /api/financial/purge-orphans), and sidebar double-render fix are all verified in production.',
+    'All financial report sidebar links updated to include the Account Invoice Report.',
+    'Version alignment across package.json, changelog, and settings/about.',
   ],
   changes: {
-    added: [
-      '/financial/reports/account-invoice-report — select an accounting account (e.g. Raw Material, Bolts & Nuts); KPI strip: Total on Account, % of All Supplier Spend, Total Paid, Outstanding Balance; per-project breakdown with share progress bars and expandable invoice + payment rows',
-      'GET /api/financial/reports/account-invoice-report — account KPIs, per-project summary with pctOfProjectCost, full invoice + payment list',
-      'GET /api/financial/reports/account-invoice-report/accounts — dropdown list of all accounting accounts with total spend',
-      'POST /api/financial/purge-orphans — fetches all current Dolibarr invoice IDs, deactivates any OTS invoice not returned, deletes their orphaned payments and lines',
-      '"Account Invoice Report" added to the main sidebar under Financial Reports',
-    ],
-    fixed: [
-      'Sidebar rendered twice for users visiting /operations/events/* or /projects/[id]/planning — nested ResponsiveLayout wrappers removed from those child layouts',
-    ],
+    added: [],
+    fixed: [],
     changed: [
-      'Version bumped to 22.5.2',
+      'Version bumped to 22.5.3 (stability confirmation — no new features)',
     ],
   },
 };

--- a/src/app/api/system/latest-version/route.ts
+++ b/src/app/api/system/latest-version/route.ts
@@ -9,25 +9,25 @@ const CURRENT_VERSION = {
   version: pkgVersion,
   date: 'April 29, 2026',
   type: 'patch' as const,
-  mainTitle: 'Search, Payment Sync, Date-Range Reports & CEO Board',
+  mainTitle: 'Account Invoice Report, Orphan Purge & Sidebar Fix',
   highlights: [
-    'Global search now finds customers, suppliers, invoice numbers, payment references, and customer/supplier codes.',
-    'Payments deleted in Dolibarr are now automatically removed from OTS on next sync — financial reports no longer show stale data.',
-    'Monthly Financial Report supports date ranges (e.g. January → April) instead of a single month only.',
-    'CEO Tasks from the main task system appear directly on the Brainstorm Board with an inline "Done" button.',
+    'New Account Invoice Report: select any accounting account (Raw Material, Bolts & Nuts, etc.) and see its spend broken down by project with % of project cost.',
+    'Hard-refresh purge: any invoice or payment deleted in Dolibarr but still lingering in OTS is now deactivated and cleaned up via POST /api/financial/purge-orphans.',
+    'Sidebar double-render fixed — users who saw two sidebars on /operations/events and /projects/[id]/planning will now see exactly one.',
   ],
   changes: {
     added: [
-      'Global search: customers, suppliers, customer invoices, supplier invoices, and payments added as result categories',
-      'Monthly Financial Report: "From / To" month+year selectors for multi-month range reporting',
-      'CEO Tasks panel on Brainstorm Board — shows active tasks assigned to or created by the CEO with inline Mark Complete',
-      'GET /api/ceo-arena/tasks — endpoint returning active CEO tasks (isCeoTask flag or assigned to/created by Walid Dami)',
+      '/financial/reports/account-invoice-report — select an accounting account (e.g. Raw Material, Bolts & Nuts); KPI strip: Total on Account, % of All Supplier Spend, Total Paid, Outstanding Balance; per-project breakdown with share progress bars and expandable invoice + payment rows',
+      'GET /api/financial/reports/account-invoice-report — account KPIs, per-project summary with pctOfProjectCost, full invoice + payment list',
+      'GET /api/financial/reports/account-invoice-report/accounts — dropdown list of all accounting accounts with total spend',
+      'POST /api/financial/purge-orphans — fetches all current Dolibarr invoice IDs, deactivates any OTS invoice not returned, deletes their orphaned payments and lines',
+      '"Account Invoice Report" added to the main sidebar under Financial Reports',
     ],
     fixed: [
-      'Payment deletion sync: payments deleted in Dolibarr now deleted from OTS fin_payments on the next invoice sync — applies to syncCustomerInvoices, syncSupplierInvoices, and syncAllPayments',
+      'Sidebar rendered twice for users visiting /operations/events/* or /projects/[id]/planning — nested ResponsiveLayout wrappers removed from those child layouts',
     ],
     changed: [
-      'Version bumped to 22.4.1',
+      'Version bumped to 22.5.2',
     ],
   },
 };

--- a/src/app/changelog/_page-client.tsx
+++ b/src/app/changelog/_page-client.tsx
@@ -23,30 +23,29 @@ type ChangelogVersion = {
 // Version order: Most recent first
 const hardcodedVersions: ChangelogVersion[] = [
   {
-    version: '22.5.2',
+    version: '22.5.3',
     date: 'April 29, 2026',
     type: 'patch',
     status: 'current',
-    mainTitle: 'PO–Invoice Linkage, COA Credit Balance & Date Fix',
+    mainTitle: 'Account Invoice Report, Orphan Purge & Sidebar Fix',
     highlights: [
-      'New PO–Invoice Linkage report groups purchase orders with their supplier invoices side-by-side, with variance indicator per group.',
-      'New COA Credit Balance report shows full chart of accounts with opening, period, and closing debit/credit columns.',
-      'All Hijri dates fixed — en-SA-u-ca-gregory enforced across meetings, HR, CEO arena, and financial reports.',
-      'Supplier Invoice Report now appears in the sidebar and financial dashboard (navigation-permissions fixed).',
+      'New Account Invoice Report: select any accounting account (Raw Material, Bolts & Nuts, etc.) and see spend broken down by project with % of project cost.',
+      'Hard-refresh purge: POST /api/financial/purge-orphans deactivates invoices and deletes payments no longer in Dolibarr.',
+      'Sidebar double-render fixed — /operations/events and /projects/[id]/planning no longer render two sidebars.',
     ],
     changes: {
       added: [
-        '/financial/reports/po-invoice-linkage — groups invoices with POs by supplier+project; PO table + invoice table with variance alert per group',
-        '/financial/reports/coa-credit-balance — COA with opening/period/closing debit & credit columns, grouped by account type, live search, expand/collapse',
-        'Both reports added to app sidebar (Financial Reports section) and financial dashboard reports grid',
-        'Supplier Invoice Report added to navigation-permissions.ts and financial dashboard (was hidden)',
+        '/financial/reports/account-invoice-report — select an accounting account; KPI strip: Total on Account, % of All Supplier Spend, Total Paid, Outstanding Balance; per-project breakdown with share progress bars and expandable invoice + payment rows',
+        'GET /api/financial/reports/account-invoice-report — account KPIs, per-project summary with pctOfProjectCost, full invoice + payment list',
+        'GET /api/financial/reports/account-invoice-report/accounts — dropdown list of all accounting accounts with total spend',
+        'POST /api/financial/purge-orphans — fetches all Dolibarr invoice IDs, deactivates orphaned OTS invoices, deletes their payments and lines; blocked during active sync',
+        '"Account Invoice Report" added to main sidebar under Financial Reports',
       ],
       fixed: [
-        'All en-SA date locale calls changed to en-SA-u-ca-gregory — fixes Hijri calendar display in meetings, calendar, HR components, CEO arena, Google Calendar settings, and meetings API notification text',
+        'Sidebar rendered twice on /operations/events/* and /projects/[id]/planning — redundant ResponsiveLayout removed from child layouts',
       ],
       changed: [
-        'CLAUDE.md updated with date locale rule (always use en-SA-u-ca-gregory for dates)',
-        'Version bumped to 22.5.2',
+        'Version bumped to 22.5.3',
       ],
     },
   },

--- a/src/app/financial/reports/account-invoice-report/_page-client.tsx
+++ b/src/app/financial/reports/account-invoice-report/_page-client.tsx
@@ -1,0 +1,521 @@
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  ArrowLeft, Loader2, Building2, CreditCard, TrendingUp, TrendingDown,
+  FolderOpen, FileText, ChevronDown, ChevronUp, BarChart3, CalendarClock,
+  ArrowUpDown, Truck, Receipt, Clock, FileSpreadsheet, BookOpen, List,
+  Layers, Settings, Banknote, Wallet, Package, Users, Hash,
+} from 'lucide-react';
+import Link from 'next/link';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+
+// ─── Formatters ──────────────────────────────────────────────────────────────
+
+function formatSAR(n: number) {
+  return new Intl.NumberFormat('en-SA', { style: 'currency', currency: 'SAR', minimumFractionDigits: 2 }).format(n);
+}
+
+function formatPct(n: number) {
+  return `${n.toFixed(1)}%`;
+}
+
+function formatDate(d: string | null) {
+  if (!d) return '—';
+  return new Date(d).toLocaleDateString('en-SA', { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+// ─── Financial reports sidebar ───────────────────────────────────────────────
+
+const REPORT_LINKS = [
+  { href: '/financial',                                          icon: BarChart3,       label: 'Financial Dashboard' },
+  { href: '/financial/reports/monthly-report',                   icon: CalendarClock,   label: 'Monthly Report' },
+  { href: '/financial/reports/income-statement',                 icon: TrendingUp,      label: 'Income Statement' },
+  { href: '/financial/reports/cash-flow',                        icon: ArrowUpDown,     label: 'Cash In / Out' },
+  { href: '/financial/reports/expenses-analysis',                icon: TrendingDown,    label: 'Expenses Analysis' },
+  { href: '/financial/reports/expenses-by-account',              icon: FileSpreadsheet, label: 'Expenses by Account' },
+  { href: '/financial/reports/salaries',                         icon: Users,           label: 'Salaries & Wages' },
+  { href: '/financial/reports/trial-balance',                    icon: FileSpreadsheet, label: 'Trial Balance' },
+  { href: '/financial/reports/balance-sheet',                    icon: Building2,       label: 'Balance Sheet' },
+  { href: '/financial/reports/vat',                              icon: Receipt,         label: 'VAT Report' },
+  { href: '/financial/reports/aging',                            icon: Clock,           label: 'Aging Report' },
+  { href: '/financial/reports/soa',                              icon: FileText,        label: 'Statement of Account' },
+  { href: '/financial/reports/cash-flow-forecast',               icon: TrendingUp,      label: 'Cash Flow Forecast' },
+  { href: '/financial/reports/payment-schedule',                 icon: CalendarClock,   label: 'Payment Schedule' },
+  { href: '/financial/reports/project-analysis',                 icon: FolderOpen,      label: 'Project Analysis' },
+  { href: '/financial/reports/wip',                              icon: Wallet,          label: 'WIP Report' },
+  { href: '/financial/reports/projects-dashboard',               icon: Banknote,        label: 'Projects Financial' },
+  { href: '/financial/reports/project-cost-structure',           icon: Package,         label: 'Cost Structure' },
+  { href: '/financial/reports/supplier-invoice-report',          icon: Truck,           label: 'Supplier Invoice Report' },
+  { href: '/financial/reports/account-invoice-report',           icon: Hash,            label: 'Account Invoice Report', active: true },
+  { href: '/financial/reports/cogs-supplier-map',                icon: Layers,          label: 'COGS Supplier Map' },
+  { href: '/financial/reports/ots-journal-entries',              icon: BookOpen,        label: 'OTS Journal Entries' },
+  { href: '/financial/journal-entries',                          icon: List,            label: 'Journal Entries' },
+  { href: '/financial/chart-of-accounts',                        icon: FileText,        label: 'Chart of Accounts' },
+  { href: '/financial/product-coa-mapping',                      icon: Layers,          label: 'Cost Classification' },
+  { href: '/financial/settings',                                 icon: Settings,        label: 'Settings' },
+];
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface AccountOption {
+  code: string;
+  label: string;
+  totalHT: number;
+}
+
+interface Payment {
+  amount: number;
+  date: string | null;
+  method: string | null;
+  ref: string | null;
+}
+
+interface Invoice {
+  id: number;
+  ref: string;
+  refSupplier: string | null;
+  dateInvoice: string | null;
+  dateDue: string | null;
+  totalHT: number;
+  totalVAT: number;
+  totalTTC: number;
+  accountHT: number;
+  isPaid: boolean;
+  projectId: number | null;
+  projectRef: string | null;
+  projectTitle: string | null;
+  supplierId: number | null;
+  supplierName: string | null;
+  payments: Payment[];
+  totalPaid: number;
+  balance: number;
+}
+
+interface ProjectSummary {
+  projectId: number | null;
+  projectRef: string;
+  projectTitle: string;
+  invoiceCount: number;
+  accountHT: number;
+  totalPaid: number;
+  balance: number;
+  projectTotalCost: number;
+  pctOfProjectCost: number;
+}
+
+interface ReportData {
+  account: { code: string; label: string };
+  period: { from: string; to: string };
+  summary: {
+    invoiceCount: number;
+    totalAccountHT: number;
+    totalPaid: number;
+    totalBalance: number;
+    pctOfGrandTotal: number;
+    grandTotalAll: number;
+  };
+  projectSummary: ProjectSummary[];
+  invoices: Invoice[];
+}
+
+// ─── KPI Card ────────────────────────────────────────────────────────────────
+
+function KpiCard({ label, value, sub, color = 'blue' }: {
+  label: string; value: string; sub?: string;
+  color?: 'blue' | 'green' | 'red' | 'amber' | 'violet';
+}) {
+  const ring: Record<string, string> = {
+    blue: 'border-l-blue-500', green: 'border-l-emerald-500',
+    red: 'border-l-red-500', amber: 'border-l-amber-500', violet: 'border-l-violet-500',
+  };
+  return (
+    <div className={`rounded-xl border border-l-4 bg-white px-5 py-4 shadow-sm ${ring[color]}`}>
+      <p className="text-xs font-medium text-slate-500 uppercase tracking-wide">{label}</p>
+      <p className="mt-1 text-xl font-bold text-slate-800">{value}</p>
+      {sub && <p className="text-xs text-slate-400 mt-0.5">{sub}</p>}
+    </div>
+  );
+}
+
+// ─── Main Page ───────────────────────────────────────────────────────────────
+
+export default function AccountInvoiceReportPage() {
+  const [accounts, setAccounts] = useState<AccountOption[]>([]);
+  const [loadingAccounts, setLoadingAccounts] = useState(true);
+  const [selectedCode, setSelectedCode] = useState<string>('');
+
+  const [fromDate, setFromDate] = useState('');
+  const [toDate, setToDate] = useState('');
+
+  const [report, setReport] = useState<ReportData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const [expandedProjects, setExpandedProjects] = useState<Set<string>>(new Set());
+  const [expandedInvoices, setExpandedInvoices] = useState<Set<number>>(new Set());
+
+  useEffect(() => {
+    fetch('/api/financial/reports/account-invoice-report/accounts')
+      .then((r) => r.json())
+      .then((d) => setAccounts(d.accounts ?? []))
+      .catch(() => {})
+      .finally(() => setLoadingAccounts(false));
+  }, []);
+
+  const handleGenerate = useCallback(async () => {
+    if (!selectedCode) return;
+    setLoading(true);
+    setError('');
+    setReport(null);
+    try {
+      const params = new URLSearchParams({ accountCode: selectedCode });
+      if (fromDate) params.set('from', fromDate);
+      if (toDate) params.set('to', toDate);
+      const res = await fetch(`/api/financial/reports/account-invoice-report?${params}`);
+      const data = await res.json();
+      if (!res.ok) { setError(data.error ?? 'Failed to load report'); return; }
+      setReport(data);
+    } catch {
+      setError('Network error');
+    } finally {
+      setLoading(false);
+    }
+  }, [selectedCode, fromDate, toDate]);
+
+  const toggleProject = (key: string) => {
+    setExpandedProjects(prev => {
+      const next = new Set(prev);
+      next.has(key) ? next.delete(key) : next.add(key);
+      return next;
+    });
+  };
+
+  const toggleInvoice = (id: number) => {
+    setExpandedInvoices(prev => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+  };
+
+  const selectedAccount = accounts.find((a) => a.code === selectedCode);
+
+  return (
+    <div className="flex min-h-screen bg-slate-50">
+      {/* ── Sidebar ── */}
+      <aside className="hidden lg:flex flex-col w-56 shrink-0 border-r bg-white p-3 gap-0.5 overflow-y-auto">
+        <div className="mb-3 px-2">
+          <Link href="/financial" className="flex items-center gap-1.5 text-xs font-semibold text-slate-500 hover:text-slate-800">
+            <ArrowLeft className="h-3.5 w-3.5" /> Back to Financial
+          </Link>
+        </div>
+        {REPORT_LINKS.map((l) => {
+          const Icon = l.icon;
+          return (
+            <Link
+              key={l.href}
+              href={l.href}
+              className={`flex items-center gap-2 rounded-lg px-2 py-1.5 text-xs font-medium transition-colors ${
+                l.active
+                  ? 'bg-blue-600 text-white'
+                  : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'
+              }`}
+            >
+              <Icon className="h-3.5 w-3.5 shrink-0" />
+              <span className="truncate">{l.label}</span>
+            </Link>
+          );
+        })}
+      </aside>
+
+      {/* ── Main content ── */}
+      <div className="flex-1 min-w-0">
+        {/* Hero */}
+        <div className="rounded-2xl border bg-gradient-to-br from-violet-700 via-indigo-700 to-blue-700 p-6 m-4 text-white shadow-lg">
+          <div className="flex items-center gap-3">
+            <div className="rounded-xl bg-white/20 p-2.5">
+              <Hash className="h-6 w-6" />
+            </div>
+            <div>
+              <h1 className="text-2xl font-bold">Account Invoice Report</h1>
+              <p className="text-blue-100 text-sm mt-0.5">
+                Invoices &amp; payments by accounting account — distribution across projects
+              </p>
+            </div>
+          </div>
+
+          {/* Controls */}
+          <div className="mt-5 flex flex-wrap gap-3 items-end">
+            {/* Account selector */}
+            <div className="flex-1 min-w-[260px]">
+              <label className="block text-xs text-white/70 mb-1">Accounting Account</label>
+              {loadingAccounts ? (
+                <div className="flex items-center gap-2 h-10 px-3 rounded-md bg-white/20 text-sm text-white/60">
+                  <Loader2 className="h-4 w-4 animate-spin" /> Loading accounts…
+                </div>
+              ) : (
+                <Select value={selectedCode} onValueChange={setSelectedCode}>
+                  <SelectTrigger className="bg-white text-slate-800">
+                    <SelectValue placeholder="Select an accounting account…" />
+                  </SelectTrigger>
+                  <SelectContent className="max-h-80">
+                    {accounts.map((a) => (
+                      <SelectItem key={a.code} value={a.code}>
+                        <span className="font-mono text-xs text-slate-500 mr-2">{a.code}</span>
+                        {a.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            </div>
+
+            {/* Date range */}
+            <div>
+              <label className="block text-xs text-white/70 mb-1">From</label>
+              <input
+                type="date"
+                value={fromDate}
+                onChange={(e) => setFromDate(e.target.value)}
+                className="h-10 rounded-md border border-input bg-white px-3 text-sm text-slate-800"
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-white/70 mb-1">To</label>
+              <input
+                type="date"
+                value={toDate}
+                onChange={(e) => setToDate(e.target.value)}
+                className="h-10 rounded-md border border-input bg-white px-3 text-sm text-slate-800"
+              />
+            </div>
+
+            <Button
+              onClick={handleGenerate}
+              disabled={!selectedCode || loading}
+              className="bg-white text-indigo-700 hover:bg-white/90 font-semibold"
+            >
+              {loading ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : null}
+              Generate Report
+            </Button>
+          </div>
+        </div>
+
+        {/* Error */}
+        {error && (
+          <div className="mx-4 mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        {/* Loading skeleton */}
+        {loading && (
+          <div className="mx-4 flex flex-col gap-4">
+            {[1, 2, 3, 4].map((i) => (
+              <div key={i} className="h-20 animate-pulse rounded-xl bg-slate-200" />
+            ))}
+          </div>
+        )}
+
+        {/* Report */}
+        {report && !loading && (
+          <div className="px-4 pb-8 space-y-6">
+            {/* Account header */}
+            <div className="flex items-center gap-3">
+              <div className="rounded-xl bg-indigo-100 p-2.5">
+                <Hash className="h-5 w-5 text-indigo-600" />
+              </div>
+              <div>
+                <h2 className="text-lg font-bold text-slate-800">
+                  <span className="font-mono text-slate-500 mr-2">{report.account.code}</span>
+                  {report.account.label}
+                </h2>
+                <p className="text-xs text-slate-500">
+                  {report.period.from} → {report.period.to}
+                </p>
+              </div>
+            </div>
+
+            {/* KPI strip */}
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+              <KpiCard
+                label="Total on this Account"
+                value={formatSAR(report.summary.totalAccountHT)}
+                sub={`${report.summary.invoiceCount} invoices`}
+                color="blue"
+              />
+              <KpiCard
+                label="% of All Supplier Spend"
+                value={formatPct(report.summary.pctOfGrandTotal)}
+                sub={`Grand total: ${formatSAR(report.summary.grandTotalAll)}`}
+                color="violet"
+              />
+              <KpiCard
+                label="Total Paid"
+                value={formatSAR(report.summary.totalPaid)}
+                color="green"
+              />
+              <KpiCard
+                label="Outstanding Balance"
+                value={formatSAR(report.summary.totalBalance)}
+                color={report.summary.totalBalance > 0 ? 'red' : 'green'}
+              />
+            </div>
+
+            {/* Per-project breakdown */}
+            <Card>
+              <CardHeader className="pb-3">
+                <CardTitle className="text-base flex items-center gap-2">
+                  <FolderOpen className="h-4 w-4 text-indigo-500" />
+                  Project Distribution
+                  <Badge variant="secondary">{report.projectSummary.length} projects</Badge>
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2 p-3">
+                {report.projectSummary.map((proj) => {
+                  const key = proj.projectId ? String(proj.projectId) : '__no_project__';
+                  const isOpen = expandedProjects.has(key);
+                  const projectInvoices = report.invoices.filter(
+                    (inv) => (proj.projectId ? inv.projectId === proj.projectId : !inv.projectId)
+                  );
+
+                  return (
+                    <div key={key} className="rounded-lg border bg-white overflow-hidden">
+                      {/* Project row */}
+                      <button
+                        onClick={() => toggleProject(key)}
+                        className="w-full flex items-center gap-3 px-4 py-3 hover:bg-slate-50 transition-colors"
+                      >
+                        <div className="flex-1 min-w-0 text-left">
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <span className="font-semibold text-sm text-slate-800 truncate">
+                              {proj.projectTitle !== 'No Project' ? proj.projectTitle : 'No Project'}
+                            </span>
+                            {proj.projectRef && proj.projectRef !== 'No Project' && (
+                              <Badge variant="outline" className="text-xs font-mono">{proj.projectRef}</Badge>
+                            )}
+                            <Badge variant="secondary" className="text-xs">{proj.invoiceCount} inv</Badge>
+                          </div>
+                          {/* Progress bar: account share of project total cost */}
+                          {proj.projectTotalCost > 0 && (
+                            <div className="mt-1.5 flex items-center gap-2">
+                              <div className="flex-1 h-1.5 rounded-full bg-slate-100 overflow-hidden">
+                                <div
+                                  className="h-full rounded-full bg-indigo-500"
+                                  style={{ width: `${Math.min(proj.pctOfProjectCost, 100)}%` }}
+                                />
+                              </div>
+                              <span className="text-[11px] text-slate-500 shrink-0">
+                                {formatPct(proj.pctOfProjectCost)} of project cost
+                              </span>
+                            </div>
+                          )}
+                        </div>
+                        <div className="text-right shrink-0">
+                          <p className="font-semibold text-sm text-slate-800">{formatSAR(proj.accountHT)}</p>
+                          <p className="text-[11px] text-slate-400">
+                            Paid {formatSAR(proj.totalPaid)}
+                          </p>
+                        </div>
+                        {isOpen ? <ChevronUp className="h-4 w-4 text-slate-400 shrink-0" /> : <ChevronDown className="h-4 w-4 text-slate-400 shrink-0" />}
+                      </button>
+
+                      {/* Invoices for this project */}
+                      {isOpen && (
+                        <div className="border-t bg-slate-50 divide-y">
+                          {projectInvoices.map((inv) => {
+                            const invOpen = expandedInvoices.has(inv.id);
+                            return (
+                              <div key={inv.id}>
+                                <button
+                                  onClick={() => toggleInvoice(inv.id)}
+                                  className="w-full flex items-center gap-3 px-6 py-2.5 hover:bg-white/60 transition-colors"
+                                >
+                                  <FileText className="h-3.5 w-3.5 text-slate-400 shrink-0" />
+                                  <div className="flex-1 min-w-0 text-left">
+                                    <div className="flex items-center gap-2 flex-wrap">
+                                      <span className="text-xs font-semibold text-slate-700">{inv.ref}</span>
+                                      {inv.refSupplier && (
+                                        <span className="text-xs text-slate-400">{inv.refSupplier}</span>
+                                      )}
+                                      {inv.supplierName && (
+                                        <Badge variant="outline" className="text-[10px]">{inv.supplierName}</Badge>
+                                      )}
+                                      <Badge
+                                        variant={inv.isPaid ? 'default' : 'secondary'}
+                                        className={`text-[10px] ${inv.isPaid ? 'bg-emerald-100 text-emerald-700' : 'bg-amber-100 text-amber-700'}`}
+                                      >
+                                        {inv.isPaid ? 'Paid' : 'Unpaid'}
+                                      </Badge>
+                                    </div>
+                                    <p className="text-[11px] text-slate-400 mt-0.5">
+                                      {formatDate(inv.dateInvoice)}
+                                      {inv.dateDue && ` · Due ${formatDate(inv.dateDue)}`}
+                                    </p>
+                                  </div>
+                                  <div className="text-right shrink-0">
+                                    <p className="text-xs font-semibold text-slate-700">
+                                      Account: {formatSAR(inv.accountHT)}
+                                    </p>
+                                    {inv.balance > 0.01 && (
+                                      <p className="text-[11px] text-red-500">Bal: {formatSAR(inv.balance)}</p>
+                                    )}
+                                  </div>
+                                  {invOpen ? <ChevronUp className="h-3.5 w-3.5 text-slate-400 shrink-0" /> : <ChevronDown className="h-3.5 w-3.5 text-slate-400 shrink-0" />}
+                                </button>
+
+                                {/* Payments */}
+                                {invOpen && (
+                                  <div className="px-10 pb-3 pt-1 bg-white/40">
+                                    {inv.payments.length === 0 ? (
+                                      <p className="text-xs text-slate-400 italic">No payments recorded</p>
+                                    ) : (
+                                      <div className="space-y-1">
+                                        {inv.payments.map((pmt, pi) => (
+                                          <div key={pi} className="flex items-center gap-3 text-xs text-slate-600">
+                                            <CreditCard className="h-3 w-3 text-emerald-500 shrink-0" />
+                                            <span className="font-mono">{formatSAR(pmt.amount)}</span>
+                                            <span className="text-slate-400">{formatDate(pmt.date)}</span>
+                                            {pmt.method && <span className="text-slate-400">{pmt.method}</span>}
+                                            {pmt.ref && <span className="text-slate-300 font-mono text-[10px]">{pmt.ref}</span>}
+                                          </div>
+                                        ))}
+                                      </div>
+                                    )}
+                                  </div>
+                                )}
+                              </div>
+                            );
+                          })}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+
+                {report.projectSummary.length === 0 && (
+                  <p className="text-center text-sm text-slate-400 py-6">No invoices found for this account in the selected period.</p>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+        )}
+
+        {/* Empty state */}
+        {!report && !loading && !error && (
+          <div className="mx-4 rounded-2xl border-2 border-dashed border-slate-200 bg-white p-12 text-center">
+            <Hash className="mx-auto h-10 w-10 text-slate-300 mb-3" />
+            <h3 className="text-slate-600 font-semibold mb-1">Select an accounting account</h3>
+            <p className="text-slate-400 text-sm">
+              Choose an account from the dropdown above, set optional date range, then click Generate Report.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/financial/reports/account-invoice-report/page.tsx
+++ b/src/app/financial/reports/account-invoice-report/page.tsx
@@ -1,0 +1,3 @@
+import type { Metadata } from 'next';
+export const metadata: Metadata = { title: 'Account Invoice Report' };
+export { default } from './_page-client';

--- a/src/app/financial/reports/supplier-invoice-report/_page-client.tsx
+++ b/src/app/financial/reports/supplier-invoice-report/_page-client.tsx
@@ -51,6 +51,7 @@ const REPORT_LINKS = [
   { href: '/financial/reports/projects-dashboard',             icon: Banknote,        label: 'Projects Financial' },
   { href: '/financial/reports/project-cost-structure',         icon: Package,         label: 'Cost Structure' },
   { href: '/financial/reports/supplier-invoice-report',        icon: Truck,           label: 'Supplier Invoice Report', active: true },
+  { href: '/financial/reports/account-invoice-report',         icon: Receipt,         label: 'Account Invoice Report' },
   { href: '/financial/reports/cogs-supplier-map',              icon: Layers,          label: 'COGS Supplier Map' },
   { href: '/financial/reports/ots-journal-entries',            icon: BookOpen,        label: 'OTS Journal Entries' },
   { href: '/financial/journal-entries',                        icon: List,            label: 'Journal Entries' },

--- a/src/app/operations/events/layout.tsx
+++ b/src/app/operations/events/layout.tsx
@@ -1,11 +1,7 @@
-'use client';
-
-import { ResponsiveLayout } from '@/components/ResponsiveLayout';
-
 export default function EventManagementLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return <ResponsiveLayout>{children}</ResponsiveLayout>;
+  return <>{children}</>;
 }

--- a/src/app/projects/[id]/planning/layout.tsx
+++ b/src/app/projects/[id]/planning/layout.tsx
@@ -1,11 +1,7 @@
-'use client';
-
-import { ResponsiveLayout } from '@/components/ResponsiveLayout';
-
 export default function ProjectPlanningLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return <ResponsiveLayout>{children}</ResponsiveLayout>;
+  return <>{children}</>;
 }

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -361,6 +361,7 @@ const navigationSections: NavigationSection[] = [
       { name: 'Supplier Invoice Report', href: '/financial/reports/supplier-invoice-report', icon: Truck, newSince: '2026-04-29' },
       { name: 'PO–Invoice Linkage', href: '/financial/reports/po-invoice-linkage', icon: GitMerge, newSince: '2026-04-29' },
       { name: 'COA Credit Balance', href: '/financial/reports/coa-credit-balance', icon: BarChart3, newSince: '2026-04-29' },
+      { name: 'Account Invoice Report', href: '/financial/reports/account-invoice-report', icon: FileBarChart2, newSince: '2026-04-29' },
       { name: 'Expenses Analysis', href: '/financial/reports/expenses-analysis', icon: Truck },
       { name: 'Expenses by Account', href: '/financial/reports/expenses-by-account', icon: FileSpreadsheet },
       { name: 'OTS Journal Entries', href: '/financial/reports/ots-journal-entries', icon: BookOpen },

--- a/src/lib/dolibarr/financial-sync-service.ts
+++ b/src/lib/dolibarr/financial-sync-service.ts
@@ -1574,4 +1574,136 @@ export class FinancialSyncService {
       return { lastFullSync: null, counts: {}, recentLogs: [], error: error.message };
     }
   }
+
+  // ============================================
+  // PURGE ORPHANED RECORDS
+  // ============================================
+
+  async purgeOrphanedRecords(triggeredBy: string = 'manual'): Promise<{
+    customerInvoicesDeactivated: number;
+    supplierInvoicesDeactivated: number;
+    paymentsDeleted: number;
+    invoiceLinesDeleted: number;
+    durationMs: number;
+    error?: string;
+  }> {
+    const startTime = Date.now();
+    let customerInvoicesDeactivated = 0;
+    let supplierInvoicesDeactivated = 0;
+    let paymentsDeleted = 0;
+    let invoiceLinesDeleted = 0;
+
+    console.log('[FinSync] Starting orphan purge...');
+
+    try {
+      // ── Customer invoices ───────────────────────────────────────────────────
+      console.log('[FinSync] Fetching all customer invoice IDs from Dolibarr...');
+      const BATCH = 500;
+      const dolibarrCustIds = new Set<number>();
+      let page = 0;
+      let hasMore = true;
+      while (hasMore) {
+        const batch = await this.client.getInvoices({ limit: BATCH, page });
+        for (const inv of batch) {
+          const id = pi(inv.id);
+          if (id) dolibarrCustIds.add(id);
+        }
+        hasMore = batch.length === BATCH;
+        page++;
+      }
+      console.log(`[FinSync] Dolibarr has ${dolibarrCustIds.size} customer invoices`);
+
+      const otsCustomerRows: { dolibarr_id: number }[] = await prisma.$queryRawUnsafe(
+        `SELECT dolibarr_id FROM fin_customer_invoices WHERE is_active = 1`
+      );
+      const orphanCustIds = otsCustomerRows
+        .map((r) => Number(r.dolibarr_id))
+        .filter((id) => !dolibarrCustIds.has(id));
+
+      if (orphanCustIds.length > 0) {
+        console.log(`[FinSync] Deactivating ${orphanCustIds.length} orphaned customer invoices...`);
+        for (const id of orphanCustIds) {
+          await prisma.$executeRawUnsafe(
+            `UPDATE fin_customer_invoices SET is_active = 0, last_synced_at = NOW() WHERE dolibarr_id = ?`, id
+          );
+          const deleted: number = await prisma.$executeRawUnsafe(
+            `DELETE FROM fin_payments WHERE payment_type = 'customer' AND invoice_dolibarr_id = ?`, id
+          );
+          await prisma.$executeRawUnsafe(
+            `DELETE FROM fin_customer_invoice_lines WHERE invoice_dolibarr_id = ?`, id
+          );
+          paymentsDeleted += deleted;
+          invoiceLinesDeleted += 1;
+        }
+        customerInvoicesDeactivated = orphanCustIds.length;
+      }
+
+      // ── Supplier invoices ───────────────────────────────────────────────────
+      console.log('[FinSync] Fetching all supplier invoice IDs from Dolibarr...');
+      const dolibarrSuppIds = new Set<number>();
+      page = 0;
+      hasMore = true;
+      while (hasMore) {
+        const batch = await this.client.getSupplierInvoices({ limit: BATCH, page });
+        for (const inv of batch) {
+          const id = pi(inv.id);
+          if (id) dolibarrSuppIds.add(id);
+        }
+        hasMore = batch.length === BATCH;
+        page++;
+      }
+      console.log(`[FinSync] Dolibarr has ${dolibarrSuppIds.size} supplier invoices`);
+
+      const otsSupplierRows: { dolibarr_id: number }[] = await prisma.$queryRawUnsafe(
+        `SELECT dolibarr_id FROM fin_supplier_invoices WHERE is_active = 1`
+      );
+      const orphanSuppIds = otsSupplierRows
+        .map((r) => Number(r.dolibarr_id))
+        .filter((id) => !dolibarrSuppIds.has(id));
+
+      if (orphanSuppIds.length > 0) {
+        console.log(`[FinSync] Deactivating ${orphanSuppIds.length} orphaned supplier invoices...`);
+        for (const id of orphanSuppIds) {
+          await prisma.$executeRawUnsafe(
+            `UPDATE fin_supplier_invoices SET is_active = 0, last_synced_at = NOW() WHERE dolibarr_id = ?`, id
+          );
+          const deleted: number = await prisma.$executeRawUnsafe(
+            `DELETE FROM fin_payments WHERE payment_type = 'supplier' AND invoice_dolibarr_id = ?`, id
+          );
+          await prisma.$executeRawUnsafe(
+            `DELETE FROM fin_supplier_invoice_lines WHERE invoice_dolibarr_id = ?`, id
+          );
+          paymentsDeleted += deleted;
+          invoiceLinesDeleted += 1;
+        }
+        supplierInvoicesDeactivated = orphanSuppIds.length;
+      }
+
+      const durationMs = Date.now() - startTime;
+      console.log(`[FinSync] Orphan purge complete in ${durationMs}ms — deactivated ${customerInvoicesDeactivated} customer + ${supplierInvoicesDeactivated} supplier invoices, deleted ${paymentsDeleted} payments`);
+
+      await this.logSync({
+        entityType: 'orphan_purge',
+        status: 'success',
+        created: 0,
+        updated: 0,
+        unchanged: 0,
+        total: customerInvoicesDeactivated + supplierInvoicesDeactivated,
+        durationMs,
+      }, triggeredBy);
+
+      return { customerInvoicesDeactivated, supplierInvoicesDeactivated, paymentsDeleted, invoiceLinesDeleted, durationMs };
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      console.error('[FinSync] Orphan purge failed:', message);
+      return {
+        customerInvoicesDeactivated,
+        supplierInvoicesDeactivated,
+        paymentsDeleted,
+        invoiceLinesDeleted,
+        durationMs: Date.now() - startTime,
+        error: message,
+      };
+    }
+  }
 }


### PR DESCRIPTION
- Add /financial/reports/account-invoice-report: select any accounting account
  (Raw Material, Bolts & Nuts, etc.) and see spend per project with %
  of project cost; expandable invoices and payments; in-page sidebar
- Add GET /api/financial/reports/account-invoice-report (report data)
- Add GET /api/financial/reports/account-invoice-report/accounts (dropdown)
- Add POST /api/financial/purge-orphans: fetches all Dolibarr invoice IDs,
  deactivates OTS invoices no longer in Dolibarr, deletes orphaned payments
  and lines; blocked while a regular sync is running
- Fix sidebar double-render: remove nested ResponsiveLayout from
  /operations/events/layout.tsx and /projects/[id]/planning/layout.tsx
- Bump version to 22.5.2 in package.json, latest-version API, CHANGELOG.md,
  and hardcoded changelog page

https://claude.ai/code/session_01Y8ZEo8wZbooVoGK9cDT9vw