### PR TITLE
feat(hr-letters): CEO edit/cancel for approved letters + fix purpose field crash (v22.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [22.6.0] - 2026-04-30
+
+### HR Letters — CEO Edit & Cancel, Purpose Bug Fix
+
+#### Added
+- **CEO edit approved letters** — users with `hr.letters.approveCeo` permission can now edit a letter even after it has been approved (all fields including purpose, content, type, language, etc.)
+- **CEO cancel letters** — new cancel action (Ban icon) on approved letters for CEO users; sets status to `CANCELLED` with an optional reason; letter remains visible in history with a grey "Cancelled" badge
+- **Cancel API** (`POST /api/hr/letters/[id]/cancel`) — CEO-only endpoint that sets status to `CANCELLED` and stores the reason in the notes field
+- **CANCELLED status** — new `HrLetterStatus` enum value added to Prisma schema and MySQL (`add_letter_cancelled_status.sql` migration)
+
+#### Fixed
+- **Purpose field crash** — editing an existing letter caused a runtime error (`undefined is not an object (evaluating 'e_.purpose.trim')`) because `purpose` was missing from the `Letter` TypeScript type and was not populated in `openEdit()`; both fixed
+- **Purpose not saved on edit** — `purpose` field was absent from the `updateSchema` Zod schema in the PUT API route, so it was silently dropped on every save; now included and persisted
+
+#### Changed
+- `PUT /api/hr/letters/[id]` — CEO users (`hr.letters.approveCeo`) can now edit `APPROVED` letters; non-CEO users still receive a 422 for approved letters
+- HR manage users no longer see the edit (pencil) button for `APPROVED` letters — only CEO can edit approved letters
+- Version bumped to **22.6.0**
+
+---
+
 ## [22.5.3] - 2026-04-29
 
 ### Stability & Version Alignment

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexa-steel-ots",
-  "version": "22.5.3",
+  "version": "22.6.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/prisma/manual_migrations/add_letter_cancelled_status.sql
+++ b/prisma/manual_migrations/add_letter_cancelled_status.sql
@@ -1,0 +1,26 @@
+-- ============================================================
+-- Add CANCELLED to HrLetterStatus enum
+-- Safe to re-run: checks information_schema before altering
+-- ============================================================
+
+DROP PROCEDURE IF EXISTS add_letter_cancelled_status;
+DELIMITER $$
+CREATE PROCEDURE add_letter_cancelled_status()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME   = 'HrLetter'
+      AND COLUMN_NAME  = 'status'
+      AND COLUMN_TYPE LIKE '%cancelled%'
+  ) THEN
+    ALTER TABLE `HrLetter`
+      MODIFY COLUMN `status`
+        ENUM('DRAFT','PENDING_CEO','APPROVED','REJECTED','CANCELLED')
+        NOT NULL DEFAULT 'PENDING_CEO';
+  END IF;
+END$$
+DELIMITER ;
+
+CALL add_letter_cancelled_status();
+DROP PROCEDURE IF EXISTS add_letter_cancelled_status;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5530,6 +5530,7 @@ enum HrLetterStatus {
   PENDING_CEO
   APPROVED
   REJECTED
+  CANCELLED
 }
 
 enum HrLetterLanguage {

--- a/src/app/api/hr/letters/[id]/cancel/route.ts
+++ b/src/app/api/hr/letters/[id]/cancel/route.ts
@@ -1,0 +1,61 @@
+/**
+ * POST /api/hr/letters/[id]/cancel  — CEO cancels/voids an issued letter
+ *
+ * 22.6.0
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import prisma from '@/lib/db';
+import { withApiContext } from '@/lib/api-utils';
+import { logger } from '@/lib/logger';
+import { resolveUserPermissions } from '@/lib/services/permission-resolution.service';
+
+const bodySchema = z.object({
+  reason: z.string().max(500).optional(),
+});
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+export const POST = withApiContext(async (req: NextRequest, session, ctx: RouteParams) => {
+  const { id } = await ctx.params;
+
+  const permissions = await resolveUserPermissions(session!.userId);
+  if (!permissions.includes('hr.letters.approveCeo') && !permissions.includes('ALL')) {
+    return NextResponse.json({ error: 'Forbidden — CEO permission required' }, { status: 403 });
+  }
+
+  const letter = await prisma.hrLetter.findFirst({
+    where: { id, deletedAt: null },
+    select: { id: true, status: true, letterNumber: true },
+  });
+  if (!letter) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  if (letter.status === 'CANCELLED') {
+    return NextResponse.json({ error: 'Letter is already cancelled' }, { status: 422 });
+  }
+
+  const body: unknown = await req.json().catch(() => ({}));
+  const parsed = bodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input', details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  try {
+    const updated = await prisma.hrLetter.update({
+      where: { id },
+      data: {
+        status: 'CANCELLED',
+        notes: parsed.data.reason
+          ? `[Cancelled] ${parsed.data.reason}`
+          : '[Cancelled by CEO]',
+        updatedById: session!.userId,
+      },
+    });
+
+    logger.info({ letterId: id, letterNumber: letter.letterNumber, cancelledBy: session!.userId }, '[Letters] Cancelled');
+    return NextResponse.json(updated);
+  } catch (error) {
+    logger.error({ error, id }, 'Failed to cancel HR letter');
+    return NextResponse.json({ error: 'Failed to cancel letter' }, { status: 500 });
+  }
+});

--- a/src/app/api/hr/letters/[id]/route.ts
+++ b/src/app/api/hr/letters/[id]/route.ts
@@ -1,9 +1,9 @@
 /**
  * GET    /api/hr/letters/[id]
- * PUT    /api/hr/letters/[id]  — only editable while PENDING_CEO or REJECTED
+ * PUT    /api/hr/letters/[id]  — editable while PENDING_CEO or REJECTED; CEO can also edit APPROVED
  * DELETE /api/hr/letters/[id]  — soft delete
  *
- * 19.1.0
+ * 22.6.0
  */
 
 import { NextRequest, NextResponse } from 'next/server';
@@ -17,6 +17,7 @@ const updateSchema = z.object({
   subject: z.string().min(1).max(500).optional(),
   content: z.string().max(50000).nullable().optional(),
   contentEn: z.string().max(50000).nullable().optional(),
+  purpose: z.string().max(500).nullable().optional(),
   attachmentUrl: z.string().max(1000).nullable().optional(),
   issuedAt: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
   notes: z.string().max(500).nullable().optional(),
@@ -55,7 +56,11 @@ export const PUT = withApiContext(async (req: NextRequest, session, ctx: RoutePa
   if (!letter) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 
   if (letter.status === 'APPROVED') {
-    return NextResponse.json({ error: 'Approved letters cannot be edited' }, { status: 422 });
+    const perms = await resolveUserPermissions(session!.userId);
+    const isCeo = perms.includes('hr.letters.approveCeo') || perms.includes('ALL');
+    if (!isCeo) {
+      return NextResponse.json({ error: 'Approved letters cannot be edited' }, { status: 422 });
+    }
   }
 
   const body: unknown = await req.json();
@@ -72,6 +77,7 @@ export const PUT = withApiContext(async (req: NextRequest, session, ctx: RoutePa
         ...(d.subject !== undefined ? { subject: d.subject } : {}),
         ...(d.content !== undefined ? { content: d.content } : {}),
         ...(d.contentEn !== undefined ? { contentEn: d.contentEn } : {}),
+        ...(d.purpose !== undefined ? { purpose: d.purpose } : {}),
         ...(d.attachmentUrl !== undefined ? { attachmentUrl: d.attachmentUrl } : {}),
         ...(d.issuedAt !== undefined ? { issuedAt: new Date(d.issuedAt) } : {}),
         ...(d.notes !== undefined ? { notes: d.notes } : {}),

--- a/src/components/hr/letters-client.tsx
+++ b/src/components/hr/letters-client.tsx
@@ -16,6 +16,7 @@ import {
   Mail, Plus, Search, Loader2, FileText, Eye, Pencil, Trash2,
   ExternalLink, User, Calendar, Hash, Upload, X, Building2, Printer,
   CheckCircle, XCircle, Languages, ClipboardList, AlertTriangle, Megaphone,
+  Ban,
 } from 'lucide-react';
 import { CirculationsTab } from './circulations-tab';
 import { AnnouncementsTab } from './announcements-tab';
@@ -25,6 +26,7 @@ const STATUS_CFG: Record<string, { label: string; cls: string }> = {
   PENDING_CEO: { label: 'Pending CEO', cls: 'bg-amber-100 text-amber-700 border-amber-200' },
   APPROVED:    { label: 'Approved',    cls: 'bg-emerald-100 text-emerald-700 border-emerald-200' },
   REJECTED:    { label: 'Rejected',    cls: 'bg-rose-100 text-rose-700 border-rose-200' },
+  CANCELLED:   { label: 'Cancelled',   cls: 'bg-slate-100 text-slate-500 border-slate-200' },
 };
 
 // ── Constants ────────────────────────────────────────────────────────────────
@@ -99,6 +101,7 @@ type Letter = {
   employeeId: string;
   status: string;
   subject: string;
+  purpose: string | null;
   content: string | null;
   contentEn: string | null;
   attachmentUrl: string | null;
@@ -168,6 +171,9 @@ export function LettersClient({ employees, departments, canManage, canApproveCeo
   const [approveLetter, setApproveLetter] = useState<Letter | null>(null);
   const [rejectLetter, setRejectLetter] = useState<Letter | null>(null);
   const [rejectReason, setRejectReason] = useState('');
+  const [cancelLetter, setCancelLetter] = useState<Letter | null>(null);
+  const [cancelReason, setCancelReason] = useState('');
+  const [cancelling, setCancelling] = useState(false);
   const [translating, setTranslating] = useState(false);
   const [approving, setApproving] = useState(false);
   const [rejecting, setRejecting] = useState(false);
@@ -302,14 +308,20 @@ export function LettersClient({ employees, departments, canManage, canApproveCeo
       classification: l.classification,
       language: (l.language as 'ARABIC' | 'ENGLISH' | 'BILINGUAL') ?? 'ARABIC',
       subject: l.subject,
+      purpose: l.purpose ?? '',
       contentMode: l.attachmentUrl ? 'attach' : 'write',
       content: l.content ?? '',
       contentEn: l.contentEn ?? '',
       attachmentUrl: l.attachmentUrl ?? '',
       issuedAt: l.issuedAt.slice(0, 10),
       notes: l.notes ?? '',
+      templateId: '',
     });
     setFormError(null);
+    setTypeTemplates([]);
+    setOverdueTasks([]);
+    setSelectedTaskIds(new Set());
+    setTaskInjectOpen(false);
     setDialogOpen(true);
   }
 
@@ -446,6 +458,31 @@ export function LettersClient({ employees, departments, canManage, canApproveCeo
       setActionError(e instanceof Error ? e.message : 'Rejection failed');
     } finally {
       setRejecting(false);
+    }
+  }
+
+  async function handleCancel() {
+    if (!cancelLetter) return;
+    setCancelling(true);
+    setActionError(null);
+    try {
+      const res = await fetch(`/api/hr/letters/${cancelLetter.id}/cancel`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason: cancelReason.trim() || undefined }),
+      });
+      if (!res.ok) {
+        const d = await res.json().catch(() => ({}));
+        throw new Error(d.error ?? 'Cancel failed');
+      }
+      setCancelLetter(null);
+      setCancelReason('');
+      fetchLetters();
+      router.refresh();
+    } catch (e) {
+      setActionError(e instanceof Error ? e.message : 'Cancel failed');
+    } finally {
+      setCancelling(false);
     }
   }
 
@@ -685,11 +722,23 @@ export function LettersClient({ employees, departments, canManage, canApproveCeo
                               </Button>
                             </>
                           )}
-                          {canManage && (
+                          {canApproveCeo && l.status === 'APPROVED' && (
                             <>
-                              <Button size="sm" variant="ghost" className="h-7 w-7 p-0 text-slate-500 hover:text-slate-700" onClick={() => openEdit(l)}>
+                              <Button size="sm" variant="ghost" className="h-7 w-7 p-0 text-slate-500 hover:text-slate-700" title="Edit approved letter" onClick={() => openEdit(l)}>
                                 <Pencil className="h-3.5 w-3.5" />
                               </Button>
+                              <Button size="sm" variant="ghost" className="h-7 w-7 p-0 text-slate-400 hover:text-slate-600 hover:bg-slate-50" title="Cancel letter" onClick={() => { setCancelLetter(l); setCancelReason(''); setActionError(null); }}>
+                                <Ban className="h-3.5 w-3.5" />
+                              </Button>
+                            </>
+                          )}
+                          {canManage && (
+                            <>
+                              {l.status !== 'APPROVED' && (
+                                <Button size="sm" variant="ghost" className="h-7 w-7 p-0 text-slate-500 hover:text-slate-700" onClick={() => openEdit(l)}>
+                                  <Pencil className="h-3.5 w-3.5" />
+                                </Button>
+                              )}
                               <Button size="sm" variant="ghost" className="h-7 w-7 p-0 text-rose-500 hover:text-rose-700 hover:bg-rose-50" onClick={() => setDeleteLetter(l)}>
                                 <Trash2 className="h-3.5 w-3.5" />
                               </Button>
@@ -1190,6 +1239,36 @@ export function LettersClient({ employees, departments, canManage, canApproveCeo
               <Button variant="outline" onClick={() => setRejectLetter(null)}>Cancel</Button>
               <Button variant="destructive" onClick={handleReject} disabled={rejecting || !rejectReason.trim()}>
                 {rejecting && <Loader2 className="h-4 w-4 mr-2 animate-spin" />} Reject Letter
+              </Button>
+            </div>
+          </DialogContent>
+        )}
+      </Dialog>
+
+      {/* Cancel letter dialog (CEO only) */}
+      <Dialog open={!!cancelLetter} onOpenChange={() => setCancelLetter(null)}>
+        {cancelLetter && (
+          <DialogContent className="max-w-sm">
+            <DialogHeader>
+              <DialogTitle className="text-slate-700 flex items-center gap-2">
+                <Ban className="h-5 w-5" /> Cancel Letter
+              </DialogTitle>
+            </DialogHeader>
+            <p className="text-sm text-slate-600 py-2">
+              Cancel letter <strong>{cancelLetter.letterNumber}</strong> for <strong>{cancelLetter.employee.fullNameEn}</strong>? The letter will be voided and marked as cancelled.
+            </p>
+            <textarea
+              className="w-full border rounded-lg px-3 py-2 text-sm resize-none focus:outline-none focus:ring-2 focus:ring-slate-300"
+              rows={3}
+              placeholder="Reason for cancellation (optional)…"
+              value={cancelReason}
+              onChange={(e) => setCancelReason(e.target.value)}
+            />
+            {actionError && <p className="text-sm text-rose-600 bg-rose-50 border border-rose-200 rounded px-3 py-2">{actionError}</p>}
+            <div className="flex justify-end gap-3">
+              <Button variant="outline" onClick={() => setCancelLetter(null)}>Back</Button>
+              <Button variant="outline" className="border-slate-400 text-slate-700 hover:bg-slate-100" onClick={handleCancel} disabled={cancelling}>
+                {cancelling && <Loader2 className="h-4 w-4 mr-2 animate-spin" />} Confirm Cancel
               </Button>
             </div>
           </DialogContent>


### PR DESCRIPTION
- Fix runtime crash when editing letters: `purpose` was missing from the
  Letter type and openEdit(), causing `.trim()` on undefined
- Fix purpose not persisting on PUT: add `purpose` to updateSchema Zod
  schema and to the Prisma update data spread
- Allow CEO (hr.letters.approveCeo) to edit APPROVED letters via PUT;
  non-CEO still gets 422
- Add POST /api/hr/letters/[id]/cancel — CEO-only endpoint that sets
  status to CANCELLED with an optional reason
- Add CANCELLED to HrLetterStatus enum in Prisma schema + DB migration
  (add_letter_cancelled_status.sql)
- Add Cancel (Ban icon) and Edit (Pencil icon) action buttons for APPROVED
  letters visible only to CEO users in the letters table
- Add cancel confirmation dialog with optional reason field
- Hide HR-manage edit button for APPROVED letters (CEO edit button shown instead)

https://claude.ai/code/session_01J7LvTLN6ZHtn478SxVPRmo