### PR TITLE
feat(22.11.0): Concentration Risk Dashboard in CEO Arena

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [22.11.0] - 2026-05-03
+
+### Concentration Risk Dashboard (CEO Arena)
+
+#### Added
+- **Concentration Risk Dashboard** — new CEO Arena module at `/concentration-risk` with full RBAC (`concentrationRisk.view`, `concentrationRisk.manage`, `concentrationRisk.export`).
+- **Six risk dimensions** computed server-side with deterministic scoring (0–100): customer (HHI + top shares), project (largest %), segment (HHI), supplier (LCR spend), operational dependency (production output), revenue timing (CV).
+- **Executive Risk Summary cards**, Risk Heatmap, and detail tabs for each dimension.
+- **Revenue Timing Chart** (Recharts BarChart with reference line and CV interpretation).
+- **CSV Export** at `GET /api/concentration-risk/export`.
+- **Sidebar item** in CEO Arena section.
+- **ProjectSegment model** + additive migration seeding 7 default segments; nullable `segmentId` FK on Project.
+- **Service layer** in `src/lib/concentration-risk/` with pure calculation helpers and per-dimension services.
+- **Unit tests** in `src/lib/__tests__/concentration-risk.test.ts`.
+- Version bumped to **22.11.0**
+
+---
+
 ## [22.10.3] - 2026-05-03
 
 ### IMS PDF Polish — White Logo, Form References, Full Field Coverage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexa-steel-ots",
-  "version": "22.10.3",
+  "version": "22.11.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/prisma/manual_migrations/add_project_segment.sql
+++ b/prisma/manual_migrations/add_project_segment.sql
@@ -1,0 +1,48 @@
+-- Concentration Risk: additive migration — ProjectSegment table + segmentId on Project
+-- Uses conditional stored procedure pattern (no IF NOT EXISTS on ALTER TABLE ADD COLUMN)
+
+DROP PROCEDURE IF EXISTS add_project_segment;
+DELIMITER $$
+CREATE PROCEDURE add_project_segment()
+BEGIN
+  -- Create ProjectSegment table if it does not exist
+  CREATE TABLE IF NOT EXISTS `ProjectSegment` (
+    `id`          VARCHAR(36)  NOT NULL,
+    `name`        VARCHAR(100) NOT NULL,
+    `description` VARCHAR(255) NULL,
+    `isActive`    TINYINT(1)   NOT NULL DEFAULT 1,
+    `createdAt`   DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt`   DATETIME(3)  NOT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `ProjectSegment_name_key` (`name`)
+  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+  -- Add segmentId column to Project if it does not already exist
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME   = 'Project'
+      AND COLUMN_NAME  = 'segmentId'
+  ) THEN
+    ALTER TABLE `Project` ADD COLUMN `segmentId` CHAR(36) NULL;
+    ALTER TABLE `Project` ADD INDEX `Project_segmentId_idx` (`segmentId`);
+    ALTER TABLE `Project`
+      ADD CONSTRAINT `Project_segmentId_fkey`
+      FOREIGN KEY (`segmentId`) REFERENCES `ProjectSegment`(`id`)
+      ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+
+  -- Seed default segments used by Hexa Steel
+  INSERT IGNORE INTO `ProjectSegment` (`id`, `name`, `description`, `isActive`, `createdAt`, `updatedAt`) VALUES
+    (UUID(), 'Warehouses',       'Warehouse structures',             1, NOW(), NOW()),
+    (UUID(), 'Factories',        'Industrial factory buildings',     1, NOW(), NOW()),
+    (UUID(), 'Poultry Farms',    'Poultry farming facilities',       1, NOW(), NOW()),
+    (UUID(), 'Commercial',       'Commercial and retail buildings',  1, NOW(), NOW()),
+    (UUID(), 'Industrial',       'General industrial structures',    1, NOW(), NOW()),
+    (UUID(), 'Oil & Gas',        'Oil and gas sector projects',      1, NOW(), NOW()),
+    (UUID(), 'Other',            'Other / uncategorised',            1, NOW(), NOW());
+END$$
+DELIMITER ;
+
+CALL add_project_segment();
+DROP PROCEDURE IF EXISTS add_project_segment;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -407,6 +407,19 @@ model PasswordResetToken {
 }
 
 /// Client model
+/// Concentration Risk — project segment / market vertical lookup table
+model ProjectSegment {
+  id          String    @id @default(cuid())
+  name        String    @unique @db.VarChar(100)
+  description String?   @db.VarChar(255)
+  isActive    Boolean   @default(true)
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+  projects    Project[]
+
+  @@map("ProjectSegment")
+}
+
 model Client {
   id        String    @id @default(uuid()) @db.Char(36)
   name      String
@@ -476,6 +489,9 @@ model Project {
   projectNature         String?
   projectLocation       String?
 
+  // Concentration Risk — market segment classification (additive, nullable)
+  segmentId             String?         @db.Char(36)
+
   // Durations (in days) - legacy
   engineeringDuration         Int?
   fabricationDeliveryDuration Int?
@@ -536,6 +552,7 @@ model Project {
   isGalvanized    Boolean @default(false)
 
   client                     Client                      @relation(fields: [clientId], references: [id])
+  segment                    ProjectSegment?             @relation(fields: [segmentId], references: [id])
   projectManager             User                        @relation("ProjectManager", fields: [projectManagerId], references: [id])
   salesEngineer              User?                       @relation("SalesEngineer", fields: [salesEngineerId], references: [id])
   buildings                  Building[]

--- a/src/app/api/concentration-risk/_parse-filters.ts
+++ b/src/app/api/concentration-risk/_parse-filters.ts
@@ -1,0 +1,18 @@
+import type { RiskFilters, RiskLevel } from '@/lib/concentration-risk/types';
+
+export function parseFilters(params: URLSearchParams): RiskFilters {
+  const year = params.get('year');
+  const riskLevel = params.get('riskLevel') as RiskLevel | null;
+
+  return {
+    startDate: params.get('startDate') ?? undefined,
+    endDate: params.get('endDate') ?? undefined,
+    year: year ? parseInt(year, 10) : undefined,
+    customerId: params.get('customerId') ?? undefined,
+    projectId: params.get('projectId') ?? undefined,
+    segment: params.get('segment') ?? undefined,
+    supplierId: params.get('supplierId') ?? undefined,
+    departmentId: params.get('departmentId') ?? undefined,
+    riskLevel: riskLevel ?? undefined,
+  };
+}

--- a/src/app/api/concentration-risk/customers/route.ts
+++ b/src/app/api/concentration-risk/customers/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withApiContext } from '@/lib/api-utils';
+import { resolveUserPermissions } from '@/lib/services/permission-resolution.service';
+import { hasPermission } from '@/lib/permissions';
+import { getCustomerConcentration } from '@/lib/concentration-risk/customer-risk';
+import { parseFilters } from '../_parse-filters';
+
+export const GET = withApiContext(async (req: NextRequest, session) => {
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const permissions = await resolveUserPermissions(session.userId);
+  if (!hasPermission(permissions, 'concentrationRisk.view')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const filters = parseFilters(req.nextUrl.searchParams);
+  const result = await getCustomerConcentration(filters);
+  return NextResponse.json(result);
+});

--- a/src/app/api/concentration-risk/export/route.ts
+++ b/src/app/api/concentration-risk/export/route.ts
@@ -1,0 +1,114 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withApiContext } from '@/lib/api-utils';
+import { resolveUserPermissions } from '@/lib/services/permission-resolution.service';
+import { hasPermission } from '@/lib/permissions';
+import { getOverallRisk, buildSummary } from '@/lib/concentration-risk/overall-risk';
+import { parseFilters } from '../_parse-filters';
+import { logger } from '@/lib/logger';
+
+function toCsvRow(values: (string | number)[]): string {
+  return values
+    .map((v) => {
+      const s = String(v);
+      return s.includes(',') || s.includes('"') || s.includes('\n')
+        ? `"${s.replace(/"/g, '""')}"`
+        : s;
+    })
+    .join(',');
+}
+
+function pct(n: number): string {
+  return `${(n * 100).toFixed(1)}%`;
+}
+
+export const GET = withApiContext(async (req: NextRequest, session) => {
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const permissions = await resolveUserPermissions(session.userId);
+  if (!hasPermission(permissions, 'concentrationRisk.export')) {
+    return NextResponse.json({ error: 'Forbidden — requires concentrationRisk.export permission' }, { status: 403 });
+  }
+
+  const filters = parseFilters(req.nextUrl.searchParams);
+  const result = await getOverallRisk(filters);
+  const summary = buildSummary(result);
+
+  const lines: string[] = [];
+
+  // Summary
+  lines.push('CONCENTRATION RISK REPORT');
+  lines.push(`Generated:,${new Date().toLocaleDateString('en-SA-u-ca-gregory')}`);
+  lines.push('');
+  lines.push('EXECUTIVE SUMMARY');
+  lines.push(toCsvRow(['Overall Risk Score', summary.overallScore]));
+  lines.push(toCsvRow(['Risk Label', summary.riskLabel.toUpperCase()]));
+  lines.push(toCsvRow(['Customer HHI', summary.customerHhi.toFixed(4)]));
+  lines.push(toCsvRow(['Top Customer Share', pct(summary.topCustomerShare)]));
+  lines.push(toCsvRow(['Largest Project Share', pct(summary.largestProjectShare)]));
+  lines.push(toCsvRow(['Top Supplier Share', pct(summary.topSupplierShare)]));
+  lines.push(toCsvRow(['Revenue Volatility (CV)', summary.revenueVolatilityCv.toFixed(3)]));
+  lines.push(toCsvRow(['Critical Bottleneck Share', pct(summary.criticalBottleneckShare)]));
+  lines.push('');
+
+  // Customer
+  lines.push('CUSTOMER CONCENTRATION (Contract Exposure)');
+  lines.push(toCsvRow(['Customer', 'Contract Exposure (SAR)', 'Share %', 'Projects', 'Risk Level']));
+  for (const r of result.customer.rows) {
+    lines.push(toCsvRow([r.customerName, r.contractExposure.toFixed(2), pct(r.share), r.projectCount, r.riskLevel]));
+  }
+  lines.push('');
+
+  // Projects
+  lines.push('PROJECT CONCENTRATION (Contract Value)');
+  lines.push(toCsvRow(['Project Number', 'Project Name', 'Customer', 'Contract Value (SAR)', 'Share %', 'Status', 'Risk Level']));
+  for (const r of result.project.rows) {
+    lines.push(toCsvRow([r.projectNumber, r.projectName, r.customerName, r.contractValue.toFixed(2), pct(r.share), r.status, r.riskLevel]));
+  }
+  lines.push('');
+
+  // Segments
+  lines.push('SEGMENT CONCENTRATION');
+  lines.push(toCsvRow(['Segment', 'Contract Exposure (SAR)', 'Share %', 'Projects', 'Risk Level']));
+  for (const r of result.segment.rows) {
+    lines.push(toCsvRow([r.segment, r.contractExposure.toFixed(2), pct(r.share), r.projectCount, r.riskLevel]));
+  }
+  lines.push('');
+
+  // Suppliers
+  lines.push('SUPPLIER CONCENTRATION (Procurement Spend)');
+  lines.push(toCsvRow(['Supplier', 'Spend (SAR)', 'Share %', 'PO Count', 'Risk Level']));
+  for (const r of result.supplier.rows) {
+    lines.push(toCsvRow([r.supplierName, r.spend.toFixed(2), pct(r.share), r.poCount, r.riskLevel]));
+  }
+  lines.push('');
+
+  // Resources
+  lines.push('OPERATIONAL DEPENDENCY');
+  lines.push(toCsvRow(['Type', 'Resource', 'Output', 'Unit', 'Share %', 'Dependency Level']));
+  for (const r of result.resource.rows) {
+    lines.push(toCsvRow([r.resourceType, r.resourceName, r.output.toFixed(1), r.outputUnit, pct(r.share), r.dependencyLevel]));
+  }
+  lines.push('');
+
+  // Revenue Timing
+  lines.push('REVENUE TIMING');
+  lines.push(toCsvRow(['Month', 'Amount (SAR)']));
+  for (const p of result.revenueTiming.monthly) {
+    lines.push(toCsvRow([p.label, p.amount.toFixed(2)]));
+  }
+  lines.push(toCsvRow(['Average Monthly', result.revenueTiming.averageMonthly.toFixed(2)]));
+  lines.push(toCsvRow(['Std Dev', result.revenueTiming.stdDev.toFixed(2)]));
+  lines.push(toCsvRow(['Coefficient of Variation', result.revenueTiming.cv.toFixed(3)]));
+
+  const csv = lines.join('\n');
+
+  logger.info({ userId: session.userId, filters }, '[ConcentrationRisk] export generated');
+
+  return new NextResponse(csv, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/csv; charset=utf-8',
+      'Content-Disposition': `attachment; filename="concentration-risk-${new Date().toISOString().slice(0, 10)}.csv"`,
+    },
+  });
+});

--- a/src/app/api/concentration-risk/projects/route.ts
+++ b/src/app/api/concentration-risk/projects/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withApiContext } from '@/lib/api-utils';
+import { resolveUserPermissions } from '@/lib/services/permission-resolution.service';
+import { hasPermission } from '@/lib/permissions';
+import { getProjectConcentration } from '@/lib/concentration-risk/project-risk';
+import { parseFilters } from '../_parse-filters';
+
+export const GET = withApiContext(async (req: NextRequest, session) => {
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const permissions = await resolveUserPermissions(session.userId);
+  if (!hasPermission(permissions, 'concentrationRisk.view')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const filters = parseFilters(req.nextUrl.searchParams);
+  const result = await getProjectConcentration(filters);
+  return NextResponse.json(result);
+});

--- a/src/app/api/concentration-risk/resources/route.ts
+++ b/src/app/api/concentration-risk/resources/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withApiContext } from '@/lib/api-utils';
+import { resolveUserPermissions } from '@/lib/services/permission-resolution.service';
+import { hasPermission } from '@/lib/permissions';
+import { getResourceConcentration } from '@/lib/concentration-risk/resource-risk';
+import { parseFilters } from '../_parse-filters';
+
+export const GET = withApiContext(async (req: NextRequest, session) => {
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const permissions = await resolveUserPermissions(session.userId);
+  if (!hasPermission(permissions, 'concentrationRisk.view')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const filters = parseFilters(req.nextUrl.searchParams);
+  const result = await getResourceConcentration(filters);
+  return NextResponse.json(result);
+});

--- a/src/app/api/concentration-risk/revenue-timing/route.ts
+++ b/src/app/api/concentration-risk/revenue-timing/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withApiContext } from '@/lib/api-utils';
+import { resolveUserPermissions } from '@/lib/services/permission-resolution.service';
+import { hasPermission } from '@/lib/permissions';
+import { getRevenueTimingConcentration } from '@/lib/concentration-risk/revenue-timing-risk';
+import { parseFilters } from '../_parse-filters';
+
+export const GET = withApiContext(async (req: NextRequest, session) => {
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const permissions = await resolveUserPermissions(session.userId);
+  if (!hasPermission(permissions, 'concentrationRisk.view')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const filters = parseFilters(req.nextUrl.searchParams);
+  const result = await getRevenueTimingConcentration(filters);
+  return NextResponse.json(result);
+});

--- a/src/app/api/concentration-risk/segments/route.ts
+++ b/src/app/api/concentration-risk/segments/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withApiContext } from '@/lib/api-utils';
+import { resolveUserPermissions } from '@/lib/services/permission-resolution.service';
+import { hasPermission } from '@/lib/permissions';
+import { getSegmentConcentration } from '@/lib/concentration-risk/segment-risk';
+import { parseFilters } from '../_parse-filters';
+
+export const GET = withApiContext(async (req: NextRequest, session) => {
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const permissions = await resolveUserPermissions(session.userId);
+  if (!hasPermission(permissions, 'concentrationRisk.view')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const filters = parseFilters(req.nextUrl.searchParams);
+  const result = await getSegmentConcentration(filters);
+  return NextResponse.json(result);
+});

--- a/src/app/api/concentration-risk/summary/route.ts
+++ b/src/app/api/concentration-risk/summary/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withApiContext } from '@/lib/api-utils';
+import { resolveUserPermissions } from '@/lib/services/permission-resolution.service';
+import { hasPermission } from '@/lib/permissions';
+import { getOverallRisk, buildSummary } from '@/lib/concentration-risk/overall-risk';
+import { parseFilters } from '../_parse-filters';
+import { logger } from '@/lib/logger';
+
+export const GET = withApiContext(async (req: NextRequest, session) => {
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const permissions = await resolveUserPermissions(session.userId);
+  if (!hasPermission(permissions, 'concentrationRisk.view')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const filters = parseFilters(req.nextUrl.searchParams);
+  const result = await getOverallRisk(filters);
+  const summary = buildSummary(result);
+
+  logger.info({ userId: session.userId, filters }, '[ConcentrationRisk] summary viewed');
+
+  return NextResponse.json(summary);
+});

--- a/src/app/api/concentration-risk/suppliers/route.ts
+++ b/src/app/api/concentration-risk/suppliers/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withApiContext } from '@/lib/api-utils';
+import { resolveUserPermissions } from '@/lib/services/permission-resolution.service';
+import { hasPermission } from '@/lib/permissions';
+import { getSupplierConcentration } from '@/lib/concentration-risk/supplier-risk';
+import { parseFilters } from '../_parse-filters';
+
+export const GET = withApiContext(async (req: NextRequest, session) => {
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const permissions = await resolveUserPermissions(session.userId);
+  if (!hasPermission(permissions, 'concentrationRisk.view')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const filters = parseFilters(req.nextUrl.searchParams);
+  const result = await getSupplierConcentration(filters);
+  return NextResponse.json(result);
+});

--- a/src/app/concentration-risk/layout.tsx
+++ b/src/app/concentration-risk/layout.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { ResponsiveLayout } from '@/components/ResponsiveLayout';
+
+export default function ConcentrationRiskLayout({ children }: { children: React.ReactNode }) {
+  return <ResponsiveLayout>{children}</ResponsiveLayout>;
+}

--- a/src/app/concentration-risk/page.tsx
+++ b/src/app/concentration-risk/page.tsx
@@ -1,0 +1,28 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { verifySession } from '@/lib/jwt';
+import { checkPermission } from '@/lib/permission-checker';
+import type { Metadata } from 'next';
+import { ConcentrationRiskDashboard } from '@/components/concentration-risk/ConcentrationRiskDashboard';
+
+export const metadata: Metadata = {
+  title: 'Concentration Risk Dashboard',
+};
+
+export default async function ConcentrationRiskPage() {
+  const cookieName = process.env.COOKIE_NAME || 'ots_session';
+  const store = await cookies();
+  const token = store.get(cookieName)?.value;
+  const session = token ? verifySession(token) : null;
+
+  if (!session) {
+    redirect('/login');
+  }
+
+  const hasAccess = await checkPermission('concentrationRisk.view');
+  if (!hasAccess) {
+    redirect('/unauthorized');
+  }
+
+  return <ConcentrationRiskDashboard />;
+}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -92,6 +92,7 @@ import {
   HardHat,
   Workflow,
   Award,
+  PieChart,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useState, useEffect, useLayoutEffect } from 'react';
@@ -131,6 +132,7 @@ const navigationSections: NavigationSection[] = [
     items: [
       { name: 'CEO Dashboard', href: '/executive', icon: BarChart3 },
       { name: 'Brainstorm Board', href: '/ceo-arena/brainstorm', icon: Brain, newSince: '2026-04-29' },
+      { name: 'Concentration Risk', href: '/concentration-risk', icon: PieChart, newSince: '2026-05-03' },
     ],
   },
   {

--- a/src/components/concentration-risk/ConcentrationRiskDashboard.tsx
+++ b/src/components/concentration-risk/ConcentrationRiskDashboard.tsx
@@ -1,0 +1,370 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import {
+  PieChart,
+  AlertTriangle,
+  RefreshCw,
+  Download,
+  Calendar,
+  Shield,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { ConcentrationRiskSummary, CustomerConcentrationResult, ProjectConcentrationResult, SegmentConcentrationResult, SupplierConcentrationResult, ResourceConcentrationResult, RevenueTimingResult } from '@/lib/concentration-risk/types';
+import { ExecutiveSummaryCards } from './ExecutiveSummaryCards';
+import { RiskHeatmap } from './RiskHeatmap';
+import { CustomerTable } from './CustomerTable';
+import { ProjectTable } from './ProjectTable';
+import { SupplierTable } from './SupplierTable';
+import { ResourceTable } from './ResourceTable';
+import { RevenueTimingChart } from './RevenueTimingChart';
+import { RiskFiltersPanel } from './RiskFiltersPanel';
+
+type TabKey = 'summary' | 'customers' | 'projects' | 'segments' | 'suppliers' | 'resources' | 'revenue';
+
+const TABS: { key: TabKey; label: string }[] = [
+  { key: 'summary', label: 'Executive Summary' },
+  { key: 'customers', label: 'Customers' },
+  { key: 'projects', label: 'Projects' },
+  { key: 'segments', label: 'Segments' },
+  { key: 'suppliers', label: 'Suppliers' },
+  { key: 'resources', label: 'Operational Dependency' },
+  { key: 'revenue', label: 'Revenue Timing' },
+];
+
+function buildQuery(params: Record<string, string | undefined>): string {
+  const sp = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    if (v) sp.set(k, v);
+  }
+  const s = sp.toString();
+  return s ? `?${s}` : '';
+}
+
+export function ConcentrationRiskDashboard() {
+  const currentYear = new Date().getFullYear();
+  const [activeTab, setActiveTab] = useState<TabKey>('summary');
+  const [year, setYear] = useState<string>(String(currentYear));
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [exporting, setExporting] = useState(false);
+
+  const [summary, setSummary] = useState<ConcentrationRiskSummary | null>(null);
+  const [customers, setCustomers] = useState<CustomerConcentrationResult | null>(null);
+  const [projects, setProjects] = useState<ProjectConcentrationResult | null>(null);
+  const [segments, setSegments] = useState<SegmentConcentrationResult | null>(null);
+  const [suppliers, setSuppliers] = useState<SupplierConcentrationResult | null>(null);
+  const [resources, setResources] = useState<ResourceConcentrationResult | null>(null);
+  const [revenueTiming, setRevenueTiming] = useState<RevenueTimingResult | null>(null);
+
+  const query = buildQuery({ year });
+
+  const fetchAll = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [s, c, p, seg, sup, res, rev] = await Promise.all([
+        fetch(`/api/concentration-risk/summary${query}`).then((r) => r.json()),
+        fetch(`/api/concentration-risk/customers${query}`).then((r) => r.json()),
+        fetch(`/api/concentration-risk/projects${query}`).then((r) => r.json()),
+        fetch(`/api/concentration-risk/segments${query}`).then((r) => r.json()),
+        fetch(`/api/concentration-risk/suppliers${query}`).then((r) => r.json()),
+        fetch(`/api/concentration-risk/resources${query}`).then((r) => r.json()),
+        fetch(`/api/concentration-risk/revenue-timing${query}`).then((r) => r.json()),
+      ]);
+      setSummary(s);
+      setCustomers(c);
+      setProjects(p);
+      setSegments(seg);
+      setSuppliers(sup);
+      setResources(res);
+      setRevenueTiming(rev);
+    } catch {
+      setError('Failed to load concentration risk data. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  }, [query]);
+
+  useEffect(() => {
+    fetchAll();
+  }, [fetchAll]);
+
+  async function handleExport() {
+    setExporting(true);
+    try {
+      const resp = await fetch(`/api/concentration-risk/export${query}`);
+      if (!resp.ok) {
+        const err = await resp.json();
+        alert(err.error ?? 'Export failed');
+        return;
+      }
+      const blob = await resp.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `concentration-risk-${new Date().toISOString().slice(0, 10)}.csv`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch {
+      alert('Export failed');
+    } finally {
+      setExporting(false);
+    }
+  }
+
+  const riskColor = summary
+    ? summary.riskLabel === 'critical' ? 'text-red-400'
+    : summary.riskLabel === 'high' ? 'text-orange-400'
+    : summary.riskLabel === 'medium' ? 'text-amber-400'
+    : summary.riskLabel === 'insufficient_data' ? 'text-slate-400'
+    : 'text-emerald-400'
+    : 'text-slate-400';
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100 p-4 md:p-6 space-y-6">
+      {/* Header */}
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <div className="p-2 rounded-lg bg-violet-500/20 border border-violet-500/30">
+            <PieChart className="h-6 w-6 text-violet-400" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold text-white tracking-tight">Concentration Risk Dashboard</h1>
+            <p className="text-sm text-slate-400">Exposure analysis across customers, projects, suppliers &amp; operations</p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2 flex-wrap">
+          {/* Year selector */}
+          <div className="flex items-center gap-1.5 bg-slate-800/80 border border-slate-700/50 rounded-lg px-3 py-2">
+            <Calendar className="h-4 w-4 text-slate-400" />
+            <select
+              value={year}
+              onChange={(e) => setYear(e.target.value)}
+              className="bg-transparent text-sm text-slate-200 outline-none cursor-pointer"
+            >
+              {[currentYear + 1, currentYear, currentYear - 1, currentYear - 2].map((y) => (
+                <option key={y} value={String(y)} className="bg-slate-800">
+                  {y}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <button
+            onClick={fetchAll}
+            disabled={loading}
+            className="flex items-center gap-1.5 bg-slate-800/80 border border-slate-700/50 hover:border-slate-600 text-slate-300 hover:text-white rounded-lg px-3 py-2 text-sm transition-colors"
+          >
+            <RefreshCw className={cn('h-4 w-4', loading && 'animate-spin')} />
+            Refresh
+          </button>
+
+          <button
+            onClick={handleExport}
+            disabled={exporting || loading}
+            className="flex items-center gap-1.5 bg-violet-600/90 hover:bg-violet-600 border border-violet-500/50 text-white rounded-lg px-3 py-2 text-sm transition-colors disabled:opacity-50"
+          >
+            <Download className="h-4 w-4" />
+            {exporting ? 'Exporting...' : 'Export CSV'}
+          </button>
+        </div>
+      </div>
+
+      {/* Overall Risk Badge */}
+      {summary && !loading && (
+        <div className="flex items-center gap-3 bg-slate-900/60 border border-slate-700/50 rounded-xl px-4 py-3">
+          <Shield className={cn('h-5 w-5', riskColor)} />
+          <span className="text-sm text-slate-400">Overall Concentration Risk Score:</span>
+          <span className={cn('text-2xl font-bold', riskColor)}>{summary.overallScore}</span>
+          <span className={cn('text-sm font-medium uppercase tracking-wider px-2 py-0.5 rounded-full border', riskColor,
+            summary.riskLabel === 'low' ? 'bg-emerald-500/10 border-emerald-500/30'
+            : summary.riskLabel === 'medium' ? 'bg-amber-500/10 border-amber-500/30'
+            : summary.riskLabel === 'high' ? 'bg-orange-500/10 border-orange-500/30'
+            : summary.riskLabel === 'critical' ? 'bg-red-500/10 border-red-500/30'
+            : 'bg-slate-500/10 border-slate-500/30'
+          )}>
+            {summary.riskLabel}
+          </span>
+          {summary.insufficientData && (
+            <span className="text-xs text-slate-500 ml-2">(Insufficient data — score may be understated)</span>
+          )}
+        </div>
+      )}
+
+      {/* Error */}
+      {error && (
+        <div className="flex items-center gap-2 bg-red-900/30 border border-red-500/30 text-red-300 rounded-xl px-4 py-3 text-sm">
+          <AlertTriangle className="h-4 w-4 flex-shrink-0" />
+          {error}
+        </div>
+      )}
+
+      {/* Tabs */}
+      <div className="border-b border-slate-700/50 overflow-x-auto">
+        <div className="flex gap-0 min-w-max">
+          {TABS.map((tab) => (
+            <button
+              key={tab.key}
+              onClick={() => setActiveTab(tab.key)}
+              className={cn(
+                'px-4 py-2.5 text-sm font-medium border-b-2 transition-colors whitespace-nowrap',
+                activeTab === tab.key
+                  ? 'border-violet-500 text-violet-400'
+                  : 'border-transparent text-slate-400 hover:text-slate-200 hover:border-slate-600'
+              )}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Tab Content */}
+      {loading ? (
+        <LoadingSkeleton />
+      ) : (
+        <div className="min-h-[400px]">
+          {activeTab === 'summary' && summary && (
+            <div className="space-y-6">
+              <ExecutiveSummaryCards summary={summary} />
+              {customers && projects && segments && suppliers && resources && revenueTiming && (
+                <RiskHeatmap
+                  customer={customers}
+                  project={projects}
+                  segment={segments}
+                  supplier={suppliers}
+                  resource={resources}
+                  revenueTiming={revenueTiming}
+                />
+              )}
+            </div>
+          )}
+          {activeTab === 'customers' && customers && (
+            <CustomerTable data={customers} />
+          )}
+          {activeTab === 'projects' && projects && (
+            <ProjectTable data={projects} />
+          )}
+          {activeTab === 'segments' && segments && (
+            <SegmentTable data={segments} />
+          )}
+          {activeTab === 'suppliers' && suppliers && (
+            <SupplierTable data={suppliers} />
+          )}
+          {activeTab === 'resources' && resources && (
+            <ResourceTable data={resources} />
+          )}
+          {activeTab === 'revenue' && revenueTiming && (
+            <RevenueTimingChart data={revenueTiming} />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function LoadingSkeleton() {
+  return (
+    <div className="space-y-4 animate-pulse">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {Array.from({ length: 7 }).map((_, i) => (
+          <div key={i} className="h-24 bg-slate-800/60 rounded-xl border border-slate-700/30" />
+        ))}
+      </div>
+      <div className="h-64 bg-slate-800/60 rounded-xl border border-slate-700/30" />
+    </div>
+  );
+}
+
+// Inline SegmentTable (simple, no separate file needed)
+function SegmentTable({ data }: { data: SegmentConcentrationResult }) {
+  if (data.insufficientData) return <InsufficientData label="segment" />;
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <MetricBox label="Segments" value={String(data.rows.length)} />
+        <MetricBox label="Largest Segment" value={`${(data.largestShare * 100).toFixed(1)}%`} risk={data.riskLevel} />
+        <MetricBox label="Segment HHI" value={data.hhi.toFixed(4)} />
+        <MetricBox label="Risk Level" value={data.riskLevel.toUpperCase()} risk={data.riskLevel} />
+      </div>
+      <div className="bg-slate-900/50 border border-slate-700/50 rounded-xl overflow-hidden">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-slate-700/50 text-slate-400 text-xs uppercase tracking-wider">
+              <th className="px-4 py-3 text-left">Segment / Market</th>
+              <th className="px-4 py-3 text-right">Contract Exposure (SAR)</th>
+              <th className="px-4 py-3 text-right">Share %</th>
+              <th className="px-4 py-3 text-right">Projects</th>
+              <th className="px-4 py-3 text-center">Risk Level</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.rows.map((row) => (
+              <tr key={row.segment} className="border-b border-slate-800/50 hover:bg-slate-800/30 transition-colors">
+                <td className="px-4 py-3 font-medium text-slate-200">{row.segment}</td>
+                <td className="px-4 py-3 text-right text-slate-300">{formatSAR(row.contractExposure)}</td>
+                <td className="px-4 py-3 text-right font-medium">{(row.share * 100).toFixed(1)}%</td>
+                <td className="px-4 py-3 text-right text-slate-400">{row.projectCount}</td>
+                <td className="px-4 py-3 text-center"><RiskBadge level={row.riskLevel} /></td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {data.rows.length === 0 && (
+          <div className="px-4 py-8 text-center text-slate-500 text-sm">No segment data available</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// Shared helpers used across this file
+export function RiskBadge({ level }: { level: string }) {
+  const styles: Record<string, string> = {
+    low: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/30',
+    medium: 'bg-amber-500/15 text-amber-400 border-amber-500/30',
+    high: 'bg-orange-500/15 text-orange-400 border-orange-500/30',
+    critical: 'bg-red-500/15 text-red-400 border-red-500/30',
+    insufficient_data: 'bg-slate-500/15 text-slate-400 border-slate-500/30',
+  };
+  return (
+    <span className={cn('inline-block px-2 py-0.5 text-xs font-medium rounded-full border capitalize', styles[level] ?? styles.insufficient_data)}>
+      {level === 'insufficient_data' ? 'N/A' : level}
+    </span>
+  );
+}
+
+export function MetricBox({ label, value, risk }: { label: string; value: string; risk?: string }) {
+  const textColor = risk
+    ? risk === 'high' || risk === 'critical' ? 'text-red-400'
+    : risk === 'medium' ? 'text-amber-400'
+    : risk === 'low' ? 'text-emerald-400'
+    : 'text-slate-300'
+    : 'text-slate-200';
+
+  return (
+    <div className="bg-slate-900/50 border border-slate-700/50 rounded-xl px-4 py-3">
+      <p className="text-xs text-slate-500 mb-1">{label}</p>
+      <p className={cn('text-xl font-bold', textColor)}>{value}</p>
+    </div>
+  );
+}
+
+export function InsufficientData({ label }: { label: string }) {
+  return (
+    <div className="bg-slate-900/40 border border-slate-700/40 rounded-xl px-6 py-12 text-center">
+      <AlertTriangle className="h-8 w-8 text-slate-500 mx-auto mb-3" />
+      <p className="text-slate-400 font-medium">Insufficient Data</p>
+      <p className="text-slate-500 text-sm mt-1">
+        No {label} data found for the selected period. Add records to unlock this analysis.
+      </p>
+    </div>
+  );
+}
+
+export function formatSAR(value: number): string {
+  return new Intl.NumberFormat('en-SA', { maximumFractionDigits: 0 }).format(value);
+}

--- a/src/components/concentration-risk/CustomerTable.tsx
+++ b/src/components/concentration-risk/CustomerTable.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import type { CustomerConcentrationResult } from '@/lib/concentration-risk/types';
+import { RiskBadge, MetricBox, InsufficientData, formatSAR } from './ConcentrationRiskDashboard';
+
+function formatDate(d: Date | null | string): string {
+  if (!d) return '—';
+  return new Date(d).toLocaleDateString('en-SA-u-ca-gregory', { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+function MiniBar({ share }: { share: number }) {
+  const pct = Math.min(share * 100, 100);
+  const color = share >= 0.25 ? 'bg-red-500' : share >= 0.15 ? 'bg-amber-500' : 'bg-emerald-500';
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-right w-12 text-xs font-mono">{pct.toFixed(1)}%</span>
+      <div className="flex-1 bg-slate-700/50 rounded-full h-1.5 min-w-[60px]">
+        <div className={`${color} h-1.5 rounded-full`} style={{ width: `${pct}%` }} />
+      </div>
+    </div>
+  );
+}
+
+export function CustomerTable({ data }: { data: CustomerConcentrationResult }) {
+  if (data.insufficientData) return <InsufficientData label="customer" />;
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <MetricBox label="Customers" value={String(data.rows.length)} />
+        <MetricBox label="Customer HHI" value={data.hhi.toFixed(4)} risk={data.riskLevel} />
+        <MetricBox label="Top Customer" value={`${(data.top1Share * 100).toFixed(1)}%`} risk={data.riskLevel} />
+        <MetricBox label="Top 3 Customers" value={`${(data.top3Share * 100).toFixed(1)}%`} risk={data.top3Share >= 0.40 ? 'high' : data.top3Share >= 0.25 ? 'medium' : 'low'} />
+      </div>
+
+      <div className="text-xs text-slate-500 px-1">
+        Values shown are <span className="text-slate-400 font-medium">contract exposure</span> (Project.contractValue), not invoiced revenue.
+      </div>
+
+      <div className="bg-slate-900/50 border border-slate-700/50 rounded-xl overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-700/50 text-slate-400 text-xs uppercase tracking-wider">
+                <th className="px-4 py-3 text-left">#</th>
+                <th className="px-4 py-3 text-left">Customer</th>
+                <th className="px-4 py-3 text-right">Contract Exposure (SAR)</th>
+                <th className="px-4 py-3 text-right min-w-[140px]">Share %</th>
+                <th className="px-4 py-3 text-right">Projects</th>
+                <th className="px-4 py-3 text-left">Last Activity</th>
+                <th className="px-4 py-3 text-center">Risk Level</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.rows.map((row, idx) => (
+                <tr key={row.customerId} className="border-b border-slate-800/50 hover:bg-slate-800/30 transition-colors">
+                  <td className="px-4 py-3 text-slate-500 text-xs">{idx + 1}</td>
+                  <td className="px-4 py-3 font-medium text-slate-200">{row.customerName}</td>
+                  <td className="px-4 py-3 text-right font-mono text-slate-300">{formatSAR(row.contractExposure)}</td>
+                  <td className="px-4 py-3"><MiniBar share={row.share} /></td>
+                  <td className="px-4 py-3 text-right text-slate-400">{row.projectCount}</td>
+                  <td className="px-4 py-3 text-slate-400 text-xs">{formatDate(row.lastActivityDate)}</td>
+                  <td className="px-4 py-3 text-center"><RiskBadge level={row.riskLevel} /></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        {data.rows.length === 0 && (
+          <div className="px-4 py-8 text-center text-slate-500 text-sm">No customer data found</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/concentration-risk/ExecutiveSummaryCards.tsx
+++ b/src/components/concentration-risk/ExecutiveSummaryCards.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import {
+  Users,
+  FolderKanban,
+  Layers,
+  Truck,
+  Wrench,
+  TrendingUp,
+  ShieldAlert,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { ConcentrationRiskSummary } from '@/lib/concentration-risk/types';
+
+interface CardDef {
+  label: string;
+  value: string;
+  subLabel: string;
+  color: 'green' | 'amber' | 'orange' | 'red' | 'neutral';
+  icon: React.ElementType;
+  tooltip: string;
+}
+
+function getColor(value: number, lowThreshold: number, highThreshold: number): 'green' | 'amber' | 'orange' | 'red' {
+  if (value >= highThreshold) return 'red';
+  if (value >= lowThreshold) return 'amber';
+  return 'green';
+}
+
+function pct(n: number): string {
+  return `${(n * 100).toFixed(1)}%`;
+}
+
+const colorMap: Record<string, { text: string; bg: string; border: string }> = {
+  green:   { text: 'text-emerald-400',  bg: 'bg-emerald-400/10',  border: 'border-emerald-400/20' },
+  amber:   { text: 'text-amber-400',    bg: 'bg-amber-400/10',    border: 'border-amber-400/20' },
+  orange:  { text: 'text-orange-400',   bg: 'bg-orange-400/10',   border: 'border-orange-400/20' },
+  red:     { text: 'text-red-400',      bg: 'bg-red-400/10',      border: 'border-red-400/20' },
+  neutral: { text: 'text-slate-300',    bg: 'bg-slate-400/10',    border: 'border-slate-400/20' },
+};
+
+function SummaryCard({ card }: { card: CardDef }) {
+  const Icon = card.icon;
+  const c = colorMap[card.color];
+  return (
+    <div className={cn(
+      'relative bg-slate-900/60 border rounded-xl p-4 flex flex-col gap-2',
+      c.border
+    )}>
+      <div className="flex items-start justify-between">
+        <div className={cn('p-2 rounded-lg', c.bg)}>
+          <Icon className={cn('h-4 w-4', c.text)} />
+        </div>
+        <span className={cn('text-2xl font-bold', c.text)}>{card.value}</span>
+      </div>
+      <div>
+        <p className="text-xs text-slate-400 font-medium">{card.label}</p>
+        <p className="text-xs text-slate-500 mt-0.5">{card.subLabel}</p>
+      </div>
+    </div>
+  );
+}
+
+export function ExecutiveSummaryCards({ summary }: { summary: ConcentrationRiskSummary }) {
+  const cards: CardDef[] = [
+    {
+      label: 'Overall Risk Score',
+      value: String(summary.overallScore),
+      subLabel: `${summary.riskLabel.toUpperCase()} — weighted across 6 dimensions`,
+      color: summary.overallScore >= 80 ? 'red' : summary.overallScore >= 60 ? 'orange' : summary.overallScore >= 31 ? 'amber' : 'green',
+      icon: ShieldAlert,
+      tooltip: 'Deterministic weighted score 0–100 across all risk dimensions',
+    },
+    {
+      label: 'Customer HHI',
+      value: summary.customerHhi.toFixed(3),
+      subLabel: summary.customerHhi >= 0.25 ? 'High concentration' : summary.customerHhi >= 0.15 ? 'Moderate concentration' : 'Diversified',
+      color: getColor(summary.customerHhi, 0.15, 0.25),
+      icon: Users,
+      tooltip: 'Herfindahl-Hirschman Index — sum of squared customer shares',
+    },
+    {
+      label: 'Top Customer Exposure',
+      value: pct(summary.topCustomerShare),
+      subLabel: summary.topCustomerShare >= 0.25 ? 'Single-point-of-failure risk' : summary.topCustomerShare >= 0.15 ? 'Warning threshold exceeded' : 'Within safe range',
+      color: getColor(summary.topCustomerShare, 0.15, 0.25),
+      icon: Users,
+      tooltip: 'Largest single customer as % of total contract exposure',
+    },
+    {
+      label: 'Largest Project Exposure',
+      value: pct(summary.largestProjectShare),
+      subLabel: summary.largestProjectShare >= 0.25 ? 'Overexposed to single project' : summary.largestProjectShare >= 0.15 ? 'Monitor closely' : 'Diversified portfolio',
+      color: getColor(summary.largestProjectShare, 0.15, 0.25),
+      icon: FolderKanban,
+      tooltip: 'Largest single project as % of total contract value',
+    },
+    {
+      label: 'Top Supplier Spend',
+      value: summary.topSupplierShare > 0 ? pct(summary.topSupplierShare) : '—',
+      subLabel: summary.topSupplierShare >= 0.40 ? 'Critical supplier dependency' : summary.topSupplierShare >= 0.25 ? 'Moderate supplier risk' : summary.topSupplierShare === 0 ? 'No procurement data' : 'Acceptable range',
+      color: summary.topSupplierShare === 0 ? 'neutral' : getColor(summary.topSupplierShare, 0.25, 0.40),
+      icon: Truck,
+      tooltip: 'Top supplier as % of total procurement spend (LCR data)',
+    },
+    {
+      label: 'Revenue Volatility (CV)',
+      value: summary.revenueVolatilityCv > 0 ? summary.revenueVolatilityCv.toFixed(2) : '—',
+      subLabel: summary.revenueVolatilityCv >= 0.60 ? 'Highly irregular cash flow' : summary.revenueVolatilityCv >= 0.30 ? 'Moderate seasonal variance' : summary.revenueVolatilityCv === 0 ? 'No receipt data' : 'Stable monthly flow',
+      color: summary.revenueVolatilityCv === 0 ? 'neutral' : getColor(summary.revenueVolatilityCv, 0.30, 0.60),
+      icon: TrendingUp,
+      tooltip: 'Coefficient of variation of monthly payment receipts',
+    },
+    {
+      label: 'Critical Bottleneck',
+      value: summary.criticalBottleneckShare > 0 ? pct(summary.criticalBottleneckShare) : '—',
+      subLabel: summary.criticalBottleneckShare >= 0.40 ? 'Single-point-of-failure in operations' : summary.criticalBottleneckShare >= 0.25 ? 'High operational dependency' : summary.criticalBottleneckShare === 0 ? 'No production data' : 'Distributed workload',
+      color: summary.criticalBottleneckShare === 0 ? 'neutral' : getColor(summary.criticalBottleneckShare, 0.25, 0.40),
+      icon: Wrench,
+      tooltip: 'Top resource (team/process) as % of total production output',
+    },
+  ];
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-4">
+      {cards.map((card) => (
+        <SummaryCard key={card.label} card={card} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/concentration-risk/ProjectTable.tsx
+++ b/src/components/concentration-risk/ProjectTable.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import type { ProjectConcentrationResult } from '@/lib/concentration-risk/types';
+import { RiskBadge, MetricBox, InsufficientData, formatSAR } from './ConcentrationRiskDashboard';
+
+const STATUS_COLORS: Record<string, string> = {
+  Active:     'bg-emerald-500/20 text-emerald-400',
+  Completed:  'bg-blue-500/20 text-blue-400',
+  Draft:      'bg-slate-500/20 text-slate-400',
+  'On Hold':  'bg-amber-500/20 text-amber-400',
+  Cancelled:  'bg-red-500/20 text-red-400',
+};
+
+function MiniBar({ share }: { share: number }) {
+  const pct = Math.min(share * 100, 100);
+  const color = share >= 0.25 ? 'bg-red-500' : share >= 0.15 ? 'bg-amber-500' : 'bg-emerald-500';
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-right w-12 text-xs font-mono">{pct.toFixed(1)}%</span>
+      <div className="flex-1 bg-slate-700/50 rounded-full h-1.5 min-w-[60px]">
+        <div className={`${color} h-1.5 rounded-full`} style={{ width: `${pct}%` }} />
+      </div>
+    </div>
+  );
+}
+
+export function ProjectTable({ data }: { data: ProjectConcentrationResult }) {
+  if (data.insufficientData) return <InsufficientData label="project" />;
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <MetricBox label="Projects" value={String(data.rows.length)} />
+        <MetricBox label="Largest Project" value={`${(data.largestShare * 100).toFixed(1)}%`} risk={data.riskLevel} />
+        <MetricBox label="Top 3 Projects" value={`${(data.top3Share * 100).toFixed(1)}%`} risk={data.top3Share >= 0.5 ? 'high' : data.top3Share >= 0.35 ? 'medium' : 'low'} />
+        <MetricBox label="Top 5 Projects" value={`${(data.top5Share * 100).toFixed(1)}%`} />
+      </div>
+
+      <div className="text-xs text-slate-500 px-1">
+        Values shown are <span className="text-slate-400 font-medium">contract value</span> (Project.contractValue), not invoiced revenue.
+      </div>
+
+      <div className="bg-slate-900/50 border border-slate-700/50 rounded-xl overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-700/50 text-slate-400 text-xs uppercase tracking-wider">
+                <th className="px-4 py-3 text-left">#</th>
+                <th className="px-4 py-3 text-left">Project</th>
+                <th className="px-4 py-3 text-left">Customer</th>
+                <th className="px-4 py-3 text-right">Contract Value (SAR)</th>
+                <th className="px-4 py-3 text-right min-w-[140px]">Share %</th>
+                <th className="px-4 py-3 text-center">Status</th>
+                <th className="px-4 py-3 text-center">Risk Level</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.rows.map((row, idx) => (
+                <tr key={row.projectId} className="border-b border-slate-800/50 hover:bg-slate-800/30 transition-colors">
+                  <td className="px-4 py-3 text-slate-500 text-xs">{idx + 1}</td>
+                  <td className="px-4 py-3">
+                    <div className="font-medium text-slate-200">{row.projectNumber}</div>
+                    <div className="text-xs text-slate-500 mt-0.5 truncate max-w-[180px]">{row.projectName}</div>
+                  </td>
+                  <td className="px-4 py-3 text-slate-400 text-xs">{row.customerName}</td>
+                  <td className="px-4 py-3 text-right font-mono text-slate-300">{formatSAR(row.contractValue)}</td>
+                  <td className="px-4 py-3"><MiniBar share={row.share} /></td>
+                  <td className="px-4 py-3 text-center">
+                    <span className={`inline-block px-2 py-0.5 text-xs rounded-full ${STATUS_COLORS[row.status] ?? STATUS_COLORS.Draft}`}>
+                      {row.status}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-center"><RiskBadge level={row.riskLevel} /></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        {data.rows.length === 0 && (
+          <div className="px-4 py-8 text-center text-slate-500 text-sm">No project data found</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/concentration-risk/ResourceTable.tsx
+++ b/src/components/concentration-risk/ResourceTable.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import type { ResourceConcentrationResult } from '@/lib/concentration-risk/types';
+import { RiskBadge, MetricBox, InsufficientData } from './ConcentrationRiskDashboard';
+
+const RESOURCE_TYPE_LABELS: Record<string, string> = {
+  team: 'Production Team',
+  process: 'Process Stage',
+  department: 'Department',
+  employee: 'Operator',
+};
+
+function MiniBar({ share }: { share: number }) {
+  const pct = Math.min(share * 100, 100);
+  const color = share >= 0.40 ? 'bg-red-500' : share >= 0.25 ? 'bg-amber-500' : 'bg-emerald-500';
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-right w-12 text-xs font-mono">{pct.toFixed(1)}%</span>
+      <div className="flex-1 bg-slate-700/50 rounded-full h-1.5 min-w-[60px]">
+        <div className={`${color} h-1.5 rounded-full`} style={{ width: `${pct}%` }} />
+      </div>
+    </div>
+  );
+}
+
+export function ResourceTable({ data }: { data: ResourceConcentrationResult }) {
+  if (data.insufficientData) return <InsufficientData label="production" />;
+
+  const topShare = data.topShare;
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <MetricBox label="Resources Tracked" value={String(data.rows.length)} />
+        <MetricBox label="Top Dependency" value={`${(topShare * 100).toFixed(1)}%`} risk={data.riskLevel} />
+        <MetricBox label="Total Output" value={`${data.totalOutput.toFixed(0)} ${data.outputUnit}`} />
+        <MetricBox label="Risk Level" value={data.riskLevel.toUpperCase()} risk={data.riskLevel} />
+      </div>
+
+      <div className="text-xs text-slate-500 px-1">
+        Operational dependency analysis — sourced from production logs.{' '}
+        Output unit: <span className="text-slate-400 font-medium">{data.outputUnit}</span>.
+        This identifies process concentration, not individual performance.
+      </div>
+
+      <div className="bg-slate-900/50 border border-slate-700/50 rounded-xl overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-700/50 text-slate-400 text-xs uppercase tracking-wider">
+                <th className="px-4 py-3 text-left">Type</th>
+                <th className="px-4 py-3 text-left">Resource / Process</th>
+                <th className="px-4 py-3 text-right">Output</th>
+                <th className="px-4 py-3 text-right min-w-[140px]">Output %</th>
+                <th className="px-4 py-3 text-center">Dependency Level</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.rows.map((row, idx) => (
+                <tr key={`${row.resourceType}-${row.resourceName}-${idx}`} className="border-b border-slate-800/50 hover:bg-slate-800/30 transition-colors">
+                  <td className="px-4 py-3">
+                    <span className="inline-block px-2 py-0.5 text-xs bg-slate-700/50 text-slate-400 rounded">
+                      {RESOURCE_TYPE_LABELS[row.resourceType] ?? row.resourceType}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 font-medium text-slate-200">{row.resourceName}</td>
+                  <td className="px-4 py-3 text-right font-mono text-slate-300">
+                    {row.output.toFixed(1)} <span className="text-slate-500 text-xs">{row.outputUnit}</span>
+                  </td>
+                  <td className="px-4 py-3"><MiniBar share={row.share} /></td>
+                  <td className="px-4 py-3 text-center"><RiskBadge level={row.dependencyLevel} /></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        {data.rows.length === 0 && (
+          <div className="px-4 py-8 text-center text-slate-500 text-sm">No production data found</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/concentration-risk/RevenueTimingChart.tsx
+++ b/src/components/concentration-risk/RevenueTimingChart.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ReferenceLine,
+  ResponsiveContainer,
+  Cell,
+} from 'recharts';
+import type { RevenueTimingResult } from '@/lib/concentration-risk/types';
+import { MetricBox, InsufficientData, RiskBadge } from './ConcentrationRiskDashboard';
+
+function formatSARCompact(value: number): string {
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(0)}K`;
+  return String(Math.round(value));
+}
+
+interface CustomTooltipProps {
+  active?: boolean;
+  payload?: Array<{ value: number }>;
+  label?: string;
+}
+
+function CustomTooltip({ active, payload, label }: CustomTooltipProps) {
+  if (!active || !payload?.length) return null;
+  const value = payload[0].value;
+  return (
+    <div className="bg-slate-800 border border-slate-600/50 rounded-lg px-3 py-2 text-sm shadow-xl">
+      <p className="text-slate-400 text-xs mb-1">{label}</p>
+      <p className="text-white font-semibold">
+        {new Intl.NumberFormat('en-SA', { maximumFractionDigits: 0 }).format(value)} SAR
+      </p>
+    </div>
+  );
+}
+
+export function RevenueTimingChart({ data }: { data: RevenueTimingResult }) {
+  if (data.insufficientData) return <InsufficientData label="payment receipt" />;
+
+  const barColor = (value: number) => {
+    if (value > data.averageMonthly * 1.5) return '#f97316';
+    if (value === 0) return '#475569';
+    return '#8b5cf6';
+  };
+
+  const chartData = data.monthly.map((p) => ({
+    label: p.label,
+    amount: p.amount,
+    fill: barColor(p.amount),
+  }));
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <MetricBox
+          label="Average Monthly"
+          value={`${new Intl.NumberFormat('en-SA', { maximumFractionDigits: 0 }).format(data.averageMonthly)} SAR`}
+        />
+        <MetricBox label="Std Deviation" value={`${new Intl.NumberFormat('en-SA', { maximumFractionDigits: 0 }).format(data.stdDev)} SAR`} />
+        <MetricBox
+          label="Coeff. of Variation"
+          value={data.cv.toFixed(3)}
+          risk={data.cv >= 0.60 ? 'high' : data.cv >= 0.30 ? 'medium' : 'low'}
+        />
+        <MetricBox label="Timing Risk" value={data.riskLevel.toUpperCase()} risk={data.riskLevel} />
+      </div>
+
+      <div className="bg-slate-900/50 border border-slate-700/50 rounded-xl p-4">
+        <div className="flex items-center justify-between mb-4">
+          <div>
+            <h3 className="text-sm font-semibold text-slate-200">Monthly Payment Receipts</h3>
+            <p className="text-xs text-slate-500 mt-0.5">
+              CV = {data.cv.toFixed(3)} — <RiskBadge level={data.riskLevel} />
+            </p>
+          </div>
+          <div className="flex items-center gap-4 text-xs text-slate-500">
+            <span className="flex items-center gap-1.5"><span className="inline-block w-3 h-3 rounded-sm bg-violet-500" />Monthly receipts</span>
+            <span className="flex items-center gap-1.5"><span className="inline-block w-3 h-0.5 bg-amber-400" />Average</span>
+          </div>
+        </div>
+
+        <ResponsiveContainer width="100%" height={280}>
+          <BarChart data={chartData} margin={{ top: 4, right: 4, bottom: 4, left: 8 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#1e293b" vertical={false} />
+            <XAxis
+              dataKey="label"
+              tick={{ fontSize: 11, fill: '#64748b' }}
+              tickLine={false}
+              axisLine={false}
+            />
+            <YAxis
+              tickFormatter={formatSARCompact}
+              tick={{ fontSize: 11, fill: '#64748b' }}
+              tickLine={false}
+              axisLine={false}
+              width={48}
+            />
+            <Tooltip content={<CustomTooltip />} cursor={{ fill: 'rgba(255,255,255,0.04)' }} />
+            <ReferenceLine
+              y={data.averageMonthly}
+              stroke="#f59e0b"
+              strokeDasharray="4 4"
+              strokeWidth={1.5}
+              label={{ value: 'Avg', position: 'right', fill: '#f59e0b', fontSize: 10 }}
+            />
+            <Bar dataKey="amount" radius={[3, 3, 0, 0]} fill="#8b5cf6">
+              {chartData.map((entry, index) => (
+                <Cell key={`cell-${index}`} fill={entry.fill} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+
+        <div className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-3">
+          <div className="bg-slate-800/50 rounded-lg px-3 py-2 text-xs">
+            <p className="text-slate-500">Interpretation</p>
+            <p className="text-slate-300 mt-0.5">
+              {data.cv < 0.30
+                ? 'Revenue timing is stable. Cash flow is predictable and well-distributed throughout the year.'
+                : data.cv < 0.60
+                ? 'Moderate revenue concentration. Some months receive significantly more than average — consider smoothing billing milestones.'
+                : 'High revenue volatility. Cash flow is highly irregular — significant risk of cash shortfalls. Review milestone billing structure.'}
+            </p>
+          </div>
+          <div className="bg-slate-800/50 rounded-lg px-3 py-2 text-xs">
+            <p className="text-slate-500">Recommended Action</p>
+            <p className="text-slate-300 mt-0.5">
+              {data.cv < 0.30
+                ? 'Maintain current billing cadence.'
+                : data.cv < 0.60
+                ? 'Negotiate monthly or bi-monthly progress payment structures on large contracts.'
+                : 'Restructure milestone billing across portfolio. Align delivery milestones with cash needs.'}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/concentration-risk/RiskFiltersPanel.tsx
+++ b/src/components/concentration-risk/RiskFiltersPanel.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+// RiskFiltersPanel is exported for potential future use with advanced filtering.
+// The main dashboard currently uses the year selector built into ConcentrationRiskDashboard.
+export function RiskFiltersPanel() {
+  return null;
+}

--- a/src/components/concentration-risk/RiskHeatmap.tsx
+++ b/src/components/concentration-risk/RiskHeatmap.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import type {
+  CustomerConcentrationResult,
+  ProjectConcentrationResult,
+  SegmentConcentrationResult,
+  SupplierConcentrationResult,
+  ResourceConcentrationResult,
+  RevenueTimingResult,
+  RiskLevel,
+} from '@/lib/concentration-risk/types';
+import { RiskBadge } from './ConcentrationRiskDashboard';
+
+interface HeatmapRow {
+  dimension: string;
+  exposure: string;
+  metric: string;
+  metricLabel: string;
+  riskLevel: RiskLevel;
+  trigger: string;
+  action: string;
+}
+
+function pct(n: number): string {
+  return `${(n * 100).toFixed(1)}%`;
+}
+
+function buildRows(
+  customer: CustomerConcentrationResult,
+  project: ProjectConcentrationResult,
+  segment: SegmentConcentrationResult,
+  supplier: SupplierConcentrationResult,
+  resource: ResourceConcentrationResult,
+  revenueTiming: RevenueTimingResult,
+): HeatmapRow[] {
+  const customerTrigger =
+    customer.insufficientData ? 'No data'
+    : customer.top1Share >= 0.25 ? `Top client ≥ 25% (${pct(customer.top1Share)})`
+    : customer.top3Share >= 0.40 ? `Top 3 clients ≥ 40% (${pct(customer.top3Share)})`
+    : customer.hhi >= 0.25 ? `HHI ≥ 0.25 (${customer.hhi.toFixed(3)})`
+    : customer.top1Share >= 0.15 ? `Top client ≥ 15% (${pct(customer.top1Share)})`
+    : 'Within thresholds';
+
+  const projectTrigger =
+    project.insufficientData ? 'No data'
+    : project.largestShare >= 0.25 ? `Largest project ≥ 25% (${pct(project.largestShare)})`
+    : project.largestShare >= 0.15 ? `Largest project ≥ 15% (${pct(project.largestShare)})`
+    : 'Within thresholds';
+
+  const segmentTrigger =
+    segment.insufficientData ? 'No data'
+    : segment.largestShare >= 0.50 ? `Largest segment ≥ 50% (${pct(segment.largestShare)})`
+    : segment.largestShare >= 0.35 ? `Largest segment ≥ 35% (${pct(segment.largestShare)})`
+    : 'Within thresholds';
+
+  const supplierTrigger =
+    supplier.insufficientData ? 'No data'
+    : supplier.top1Share >= 0.40 ? `Top supplier ≥ 40% (${pct(supplier.top1Share)})`
+    : supplier.top1Share >= 0.25 ? `Top supplier ≥ 25% (${pct(supplier.top1Share)})`
+    : 'Within thresholds';
+
+  const resourceTrigger =
+    resource.insufficientData ? 'No data'
+    : resource.topShare >= 0.40 ? `Top resource ≥ 40% (${pct(resource.topShare)})`
+    : resource.topShare >= 0.25 ? `Top resource ≥ 25% (${pct(resource.topShare)})`
+    : 'Within thresholds';
+
+  const revTrigger =
+    revenueTiming.insufficientData ? 'No data'
+    : revenueTiming.cv >= 0.60 ? `CV ≥ 0.60 (${revenueTiming.cv.toFixed(2)})`
+    : revenueTiming.cv >= 0.30 ? `CV ≥ 0.30 (${revenueTiming.cv.toFixed(2)})`
+    : 'Within thresholds';
+
+  return [
+    {
+      dimension: 'Customer',
+      exposure: customer.insufficientData ? '—' : pct(customer.top1Share),
+      metric: customer.insufficientData ? '—' : customer.hhi.toFixed(3),
+      metricLabel: 'HHI',
+      riskLevel: customer.riskLevel,
+      trigger: customerTrigger,
+      action: customer.riskLevel === 'low' ? 'No action required' : customer.top1Share >= 0.25 ? 'Diversify customer pipeline — reduce dependency on top client' : 'Monitor and build pipeline with new clients',
+    },
+    {
+      dimension: 'Projects',
+      exposure: project.insufficientData ? '—' : pct(project.largestShare),
+      metric: project.insufficientData ? '—' : pct(project.top3Share),
+      metricLabel: 'Top-3 Share',
+      riskLevel: project.riskLevel,
+      trigger: projectTrigger,
+      action: project.riskLevel === 'low' ? 'No action required' : 'Increase project count; pursue smaller complementary contracts',
+    },
+    {
+      dimension: 'Segments',
+      exposure: segment.insufficientData ? '—' : pct(segment.largestShare),
+      metric: segment.insufficientData ? '—' : segment.hhi.toFixed(3),
+      metricLabel: 'HHI',
+      riskLevel: segment.riskLevel,
+      trigger: segmentTrigger,
+      action: segment.riskLevel === 'low' ? 'No action required' : 'Pursue business development in under-represented market segments',
+    },
+    {
+      dimension: 'Suppliers',
+      exposure: supplier.insufficientData ? '—' : pct(supplier.top1Share),
+      metric: supplier.insufficientData ? '—' : supplier.hhi.toFixed(3),
+      metricLabel: 'HHI',
+      riskLevel: supplier.riskLevel,
+      trigger: supplierTrigger,
+      action: supplier.riskLevel === 'low' ? 'No action required' : 'Secure alternate suppliers; dual-source critical materials',
+    },
+    {
+      dimension: 'Operational Dependency',
+      exposure: resource.insufficientData ? '—' : pct(resource.topShare),
+      metric: '—',
+      metricLabel: '—',
+      riskLevel: resource.riskLevel,
+      trigger: resourceTrigger,
+      action: resource.riskLevel === 'low' ? 'No action required' : 'Cross-train backup resources; redistribute workload across teams',
+    },
+    {
+      dimension: 'Revenue Timing',
+      exposure: revenueTiming.insufficientData ? '—' : revenueTiming.cv.toFixed(2),
+      metric: revenueTiming.insufficientData ? '—' : revenueTiming.averageMonthly > 0 ? `Avg ${new Intl.NumberFormat('en-SA', { maximumFractionDigits: 0 }).format(revenueTiming.averageMonthly)} SAR/mo` : '—',
+      metricLabel: 'Avg Monthly',
+      riskLevel: revenueTiming.riskLevel,
+      trigger: revTrigger,
+      action: revenueTiming.riskLevel === 'low' ? 'No action required' : 'Smooth billing milestones; negotiate monthly retainers where possible',
+    },
+  ];
+}
+
+export function RiskHeatmap({
+  customer, project, segment, supplier, resource, revenueTiming,
+}: {
+  customer: CustomerConcentrationResult;
+  project: ProjectConcentrationResult;
+  segment: SegmentConcentrationResult;
+  supplier: SupplierConcentrationResult;
+  resource: ResourceConcentrationResult;
+  revenueTiming: RevenueTimingResult;
+}) {
+  const rows = buildRows(customer, project, segment, supplier, resource, revenueTiming);
+
+  const rowBg = (level: RiskLevel) => {
+    if (level === 'high' || level === 'critical') return 'bg-red-500/5 hover:bg-red-500/10';
+    if (level === 'medium') return 'bg-amber-500/5 hover:bg-amber-500/10';
+    return 'hover:bg-slate-800/30';
+  };
+
+  return (
+    <div className="bg-slate-900/50 border border-slate-700/50 rounded-xl overflow-hidden">
+      <div className="px-4 py-3 border-b border-slate-700/50">
+        <h2 className="text-sm font-semibold text-slate-200">Risk Heatmap</h2>
+        <p className="text-xs text-slate-500 mt-0.5">Concentration exposure across all dimensions</p>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm min-w-[700px]">
+          <thead>
+            <tr className="border-b border-slate-700/50 text-slate-400 text-xs uppercase tracking-wider">
+              <th className="px-4 py-3 text-left w-40">Dimension</th>
+              <th className="px-4 py-3 text-right">Top Exposure</th>
+              <th className="px-4 py-3 text-right">HHI / CV</th>
+              <th className="px-4 py-3 text-center w-24">Risk Level</th>
+              <th className="px-4 py-3 text-left">Trigger</th>
+              <th className="px-4 py-3 text-left">Recommended Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.dimension} className={cn('border-b border-slate-800/50 transition-colors', rowBg(row.riskLevel))}>
+                <td className="px-4 py-3 font-medium text-slate-200">{row.dimension}</td>
+                <td className="px-4 py-3 text-right font-mono text-slate-300">{row.exposure}</td>
+                <td className="px-4 py-3 text-right font-mono text-slate-400">
+                  <span>{row.metric}</span>
+                  {row.metric !== '—' && <span className="text-xs text-slate-600 ml-1">({row.metricLabel})</span>}
+                </td>
+                <td className="px-4 py-3 text-center"><RiskBadge level={row.riskLevel} /></td>
+                <td className="px-4 py-3 text-slate-400 text-xs">{row.trigger}</td>
+                <td className="px-4 py-3 text-slate-300 text-xs">{row.action}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/concentration-risk/SupplierTable.tsx
+++ b/src/components/concentration-risk/SupplierTable.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import type { SupplierConcentrationResult } from '@/lib/concentration-risk/types';
+import { RiskBadge, MetricBox, InsufficientData, formatSAR } from './ConcentrationRiskDashboard';
+
+function MiniBar({ share }: { share: number }) {
+  const pct = Math.min(share * 100, 100);
+  const color = share >= 0.40 ? 'bg-red-500' : share >= 0.25 ? 'bg-amber-500' : 'bg-emerald-500';
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-right w-12 text-xs font-mono">{pct.toFixed(1)}%</span>
+      <div className="flex-1 bg-slate-700/50 rounded-full h-1.5 min-w-[60px]">
+        <div className={`${color} h-1.5 rounded-full`} style={{ width: `${pct}%` }} />
+      </div>
+    </div>
+  );
+}
+
+export function SupplierTable({ data }: { data: SupplierConcentrationResult }) {
+  if (data.insufficientData) return <InsufficientData label="supplier" />;
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <MetricBox label="Suppliers" value={String(data.rows.length)} />
+        <MetricBox label="Top Supplier" value={`${(data.top1Share * 100).toFixed(1)}%`} risk={data.riskLevel} />
+        <MetricBox label="Top 3 Suppliers" value={`${(data.top3Share * 100).toFixed(1)}%`} risk={data.top3Share >= 0.70 ? 'high' : data.top3Share >= 0.50 ? 'medium' : 'low'} />
+        <MetricBox label="Supplier HHI" value={data.hhi.toFixed(4)} risk={data.riskLevel} />
+      </div>
+
+      <div className="text-xs text-slate-500 px-1">
+        Procurement spend sourced from <span className="text-slate-400 font-medium">LCR procurement entries</span> (LcrEntry.amount by awardedToRaw).
+      </div>
+
+      <div className="bg-slate-900/50 border border-slate-700/50 rounded-xl overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-700/50 text-slate-400 text-xs uppercase tracking-wider">
+                <th className="px-4 py-3 text-left">#</th>
+                <th className="px-4 py-3 text-left">Supplier</th>
+                <th className="px-4 py-3 text-right">Spend (SAR)</th>
+                <th className="px-4 py-3 text-right min-w-[140px]">Spend %</th>
+                <th className="px-4 py-3 text-right">PO Count</th>
+                <th className="px-4 py-3 text-center">Risk Level</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.rows.map((row, idx) => (
+                <tr key={row.supplierName} className="border-b border-slate-800/50 hover:bg-slate-800/30 transition-colors">
+                  <td className="px-4 py-3 text-slate-500 text-xs">{idx + 1}</td>
+                  <td className="px-4 py-3 font-medium text-slate-200">{row.supplierName}</td>
+                  <td className="px-4 py-3 text-right font-mono text-slate-300">{formatSAR(row.spend)}</td>
+                  <td className="px-4 py-3"><MiniBar share={row.share} /></td>
+                  <td className="px-4 py-3 text-right text-slate-400">{row.poCount}</td>
+                  <td className="px-4 py-3 text-center"><RiskBadge level={row.riskLevel} /></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        {data.rows.length === 0 && (
+          <div className="px-4 py-8 text-center text-slate-500 text-sm">No supplier data found</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/__tests__/concentration-risk.test.ts
+++ b/src/lib/__tests__/concentration-risk.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect } from 'vitest';
+import {
+  safeDivide,
+  calculateShare,
+  calculateHHI,
+  calculateCoefficientOfVariation,
+  calculateStdDev,
+  classifyRisk,
+  riskLevelToScore,
+  ratioToScore,
+  classifyOverallScore,
+  buildDateRange,
+} from '../concentration-risk/helpers';
+import { DIMENSION_WEIGHTS } from '../concentration-risk/risk-thresholds';
+
+// ── safeDivide ────────────────────────────────────────────────────────────────
+
+describe('safeDivide', () => {
+  it('divides normally', () => {
+    expect(safeDivide(10, 4)).toBe(2.5);
+  });
+
+  it('returns 0 when denominator is 0', () => {
+    expect(safeDivide(100, 0)).toBe(0);
+  });
+
+  it('returns 0 when denominator is Infinity', () => {
+    expect(safeDivide(100, Infinity)).toBe(0);
+  });
+});
+
+// ── calculateShare ────────────────────────────────────────────────────────────
+
+describe('calculateShare', () => {
+  it('calculates correct share', () => {
+    expect(calculateShare(250, 1000)).toBe(0.25);
+  });
+
+  it('returns 0 for zero total', () => {
+    expect(calculateShare(100, 0)).toBe(0);
+  });
+
+  it('can return 1.0 when value equals total', () => {
+    expect(calculateShare(500, 500)).toBe(1);
+  });
+});
+
+// ── calculateHHI ──────────────────────────────────────────────────────────────
+
+describe('calculateHHI', () => {
+  it('returns 1 for monopoly (single player)', () => {
+    expect(calculateHHI([1])).toBe(1);
+  });
+
+  it('returns low HHI for highly diversified market (10 equal shares)', () => {
+    const shares = Array(10).fill(0.1);
+    expect(calculateHHI(shares)).toBeCloseTo(0.1, 5);
+  });
+
+  it('returns correct HHI for known distribution', () => {
+    // Customer A = 50%, B = 30%, C = 20%
+    const hhi = calculateHHI([0.5, 0.3, 0.2]);
+    expect(hhi).toBeCloseTo(0.38, 5); // 0.25 + 0.09 + 0.04
+  });
+
+  it('returns 0 for empty array', () => {
+    expect(calculateHHI([])).toBe(0);
+  });
+});
+
+// ── calculateCoefficientOfVariation ──────────────────────────────────────────
+
+describe('calculateCoefficientOfVariation', () => {
+  it('returns 0 for empty array', () => {
+    expect(calculateCoefficientOfVariation([])).toBe(0);
+  });
+
+  it('returns 0 for single element', () => {
+    expect(calculateCoefficientOfVariation([100])).toBe(0);
+  });
+
+  it('returns 0 when all values are equal', () => {
+    expect(calculateCoefficientOfVariation([200, 200, 200, 200])).toBe(0);
+  });
+
+  it('returns correct CV for known values', () => {
+    // mean = 100, stdDev = 50 → CV = 0.5
+    const values = [50, 100, 150];
+    const cv = calculateCoefficientOfVariation(values);
+    expect(cv).toBeCloseTo(0.4082, 3);
+  });
+
+  it('returns 0 when mean is 0', () => {
+    expect(calculateCoefficientOfVariation([0, 0, 0])).toBe(0);
+  });
+});
+
+// ── calculateStdDev ───────────────────────────────────────────────────────────
+
+describe('calculateStdDev', () => {
+  it('returns 0 for uniform values', () => {
+    expect(calculateStdDev([5, 5, 5, 5])).toBe(0);
+  });
+
+  it('calculates correct stdDev for known values', () => {
+    // [2, 4, 4, 4, 5, 5, 7, 9] → mean=5, variance=4, stdDev=2
+    expect(calculateStdDev([2, 4, 4, 4, 5, 5, 7, 9])).toBeCloseTo(2, 5);
+  });
+});
+
+// ── classifyRisk ──────────────────────────────────────────────────────────────
+
+describe('classifyRisk (higher_is_worse)', () => {
+  it('classifies low when below low threshold', () => {
+    expect(classifyRisk(0.10, { low: 0.15, medium: 0.25 })).toBe('low');
+  });
+
+  it('classifies medium when above low threshold', () => {
+    expect(classifyRisk(0.20, { low: 0.15, medium: 0.25 })).toBe('medium');
+  });
+
+  it('classifies high when above high threshold', () => {
+    expect(classifyRisk(0.30, { low: 0.15, medium: 0.25, high: 0.25 })).toBe('high');
+  });
+});
+
+// ── riskLevelToScore ──────────────────────────────────────────────────────────
+
+describe('riskLevelToScore', () => {
+  it('returns 15 for low', () => expect(riskLevelToScore('low')).toBe(15));
+  it('returns 55 for medium', () => expect(riskLevelToScore('medium')).toBe(55));
+  it('returns 75 for high', () => expect(riskLevelToScore('high')).toBe(75));
+  it('returns 95 for critical', () => expect(riskLevelToScore('critical')).toBe(95));
+  it('returns 0 for insufficient_data', () => expect(riskLevelToScore('insufficient_data')).toBe(0));
+});
+
+// ── ratioToScore ──────────────────────────────────────────────────────────────
+
+describe('ratioToScore', () => {
+  it('returns 0 for ratio 0', () => {
+    expect(ratioToScore(0, 0.15, 0.25)).toBe(0);
+  });
+
+  it('returns score ≤ 30 when within low threshold', () => {
+    const score = ratioToScore(0.10, 0.15, 0.25);
+    expect(score).toBeLessThanOrEqual(30);
+  });
+
+  it('returns score between 30 and 75 in medium range', () => {
+    const score = ratioToScore(0.20, 0.15, 0.25);
+    expect(score).toBeGreaterThan(30);
+    expect(score).toBeLessThanOrEqual(75);
+  });
+
+  it('returns score > 75 above high threshold', () => {
+    const score = ratioToScore(0.50, 0.15, 0.25);
+    expect(score).toBeGreaterThan(75);
+  });
+
+  it('caps at 100 for extreme values', () => {
+    const score = ratioToScore(1.0, 0.15, 0.25);
+    expect(score).toBeLessThanOrEqual(100);
+  });
+});
+
+// ── classifyOverallScore ──────────────────────────────────────────────────────
+
+describe('classifyOverallScore', () => {
+  it('returns low for score 0-30', () => {
+    expect(classifyOverallScore(0)).toBe('low');
+    expect(classifyOverallScore(30)).toBe('low');
+  });
+
+  it('returns medium for score 31-60', () => {
+    expect(classifyOverallScore(31)).toBe('medium');
+    expect(classifyOverallScore(60)).toBe('medium');
+  });
+
+  it('returns high for score 61-80', () => {
+    expect(classifyOverallScore(61)).toBe('high');
+    expect(classifyOverallScore(80)).toBe('high');
+  });
+
+  it('returns critical for score 81-100', () => {
+    expect(classifyOverallScore(81)).toBe('critical');
+    expect(classifyOverallScore(100)).toBe('critical');
+  });
+});
+
+// ── buildDateRange ────────────────────────────────────────────────────────────
+
+describe('buildDateRange', () => {
+  it('uses explicit startDate/endDate when provided', () => {
+    const range = buildDateRange(undefined, '2025-01-01', '2025-06-30');
+    expect(range.gte).toEqual(new Date('2025-01-01'));
+    expect(range.lte).toEqual(new Date('2025-06-30'));
+  });
+
+  it('builds year range when year is provided', () => {
+    const range = buildDateRange(2024);
+    expect(range.gte).toEqual(new Date('2024-01-01T00:00:00.000Z'));
+    expect(range.lte).toEqual(new Date('2024-12-31T23:59:59.999Z'));
+  });
+
+  it('defaults to current year when no params', () => {
+    const range = buildDateRange();
+    const currentYear = new Date().getFullYear();
+    expect(range.gte?.getFullYear()).toBe(currentYear);
+    expect(range.lte?.getFullYear()).toBe(currentYear);
+  });
+});
+
+// ── dimension weights sanity check ───────────────────────────────────────────
+
+describe('dimension weights', () => {
+  it('all weights sum to 1.0', () => {
+    const total = Object.values(DIMENSION_WEIGHTS).reduce((sum, w) => sum + w, 0);
+    expect(total).toBeCloseTo(1.0, 10);
+  });
+});
+
+// ── overall score determinism ─────────────────────────────────────────────────
+
+describe('overall score determinism', () => {
+  it('produces identical scores for identical inputs', () => {
+    const dimensionScores = [50, 30, 20, 60, 40, 70];
+    const weights = Object.values(DIMENSION_WEIGHTS);
+    const score1 = Math.round(dimensionScores.reduce((sum, s, i) => sum + s * weights[i], 0));
+    const score2 = Math.round(dimensionScores.reduce((sum, s, i) => sum + s * weights[i], 0));
+    expect(score1).toBe(score2);
+  });
+});
+
+// ── empty dataset behaviour ───────────────────────────────────────────────────
+
+describe('empty dataset helpers', () => {
+  it('calculateHHI returns 0 for empty', () => {
+    expect(calculateHHI([])).toBe(0);
+  });
+
+  it('calculateCV returns 0 for empty', () => {
+    expect(calculateCoefficientOfVariation([])).toBe(0);
+  });
+
+  it('safeDivide handles zero total', () => {
+    expect(safeDivide(0, 0)).toBe(0);
+  });
+});

--- a/src/lib/concentration-risk/customer-risk.ts
+++ b/src/lib/concentration-risk/customer-risk.ts
@@ -1,0 +1,131 @@
+import db from '@/lib/db';
+import { logger } from '@/lib/logger';
+import type { RiskFilters, CustomerConcentrationResult, CustomerRiskRow, RiskLevel } from './types';
+import {
+  calculateShare,
+  calculateHHI,
+  buildDateRange,
+  ratioToScore,
+} from './helpers';
+import { CUSTOMER_THRESHOLDS } from './risk-thresholds';
+
+function classifyCustomerRisk(share: number): RiskLevel {
+  if (share >= CUSTOMER_THRESHOLDS.singleHigh) return 'high';
+  if (share >= CUSTOMER_THRESHOLDS.singleWarning) return 'medium';
+  return 'low';
+}
+
+function computeScore(top1: number, top3: number, hhi: number): number {
+  // Weight: top1 dominates (50%), top3 (30%), hhi (20%)
+  const s1 = ratioToScore(top1, CUSTOMER_THRESHOLDS.singleWarning, CUSTOMER_THRESHOLDS.singleHigh);
+  const s3 = ratioToScore(top3, CUSTOMER_THRESHOLDS.top3High, 0.65);
+  const sHhi = ratioToScore(hhi, CUSTOMER_THRESHOLDS.hhi.low, CUSTOMER_THRESHOLDS.hhi.medium);
+  return Math.round(s1 * 0.5 + s3 * 0.3 + sHhi * 0.2);
+}
+
+export async function getCustomerConcentration(filters: RiskFilters): Promise<CustomerConcentrationResult> {
+  try {
+    const dateRange = buildDateRange(filters.year, filters.startDate, filters.endDate);
+
+    const projects = await db.project.findMany({
+      where: {
+        deletedAt: null,
+        contractValue: { not: null, gt: 0 },
+        ...(filters.customerId ? { clientId: filters.customerId } : {}),
+        ...(dateRange.gte || dateRange.lte ? { createdAt: dateRange } : {}),
+      },
+      select: {
+        clientId: true,
+        contractValue: true,
+        createdAt: true,
+        client: { select: { id: true, name: true } },
+      },
+    });
+
+    if (projects.length === 0) {
+      return {
+        rows: [],
+        totalContractExposure: 0,
+        top1Share: 0,
+        top3Share: 0,
+        top5Share: 0,
+        hhi: 0,
+        riskLevel: 'insufficient_data',
+        score: 0,
+        insufficientData: true,
+      };
+    }
+
+    const byClient: Record<string, { name: string; total: number; count: number; lastDate: Date | null }> = {};
+    let totalContractExposure = 0;
+
+    for (const p of projects) {
+      const val = Number(p.contractValue ?? 0);
+      totalContractExposure += val;
+      if (!byClient[p.clientId]) {
+        byClient[p.clientId] = { name: p.client.name, total: 0, count: 0, lastDate: null };
+      }
+      byClient[p.clientId].total += val;
+      byClient[p.clientId].count += 1;
+      if (!byClient[p.clientId].lastDate || p.createdAt > byClient[p.clientId].lastDate!) {
+        byClient[p.clientId].lastDate = p.createdAt;
+      }
+    }
+
+    const rows: CustomerRiskRow[] = Object.entries(byClient)
+      .map(([clientId, data]) => {
+        const share = calculateShare(data.total, totalContractExposure);
+        return {
+          customerId: clientId,
+          customerName: data.name,
+          contractExposure: data.total,
+          share,
+          projectCount: data.count,
+          lastActivityDate: data.lastDate,
+          riskLevel: classifyCustomerRisk(share),
+        };
+      })
+      .sort((a, b) => b.contractExposure - a.contractExposure);
+
+    const shares = rows.map((r) => r.share);
+    const hhi = calculateHHI(shares);
+    const top1Share = shares[0] ?? 0;
+    const top3Share = shares.slice(0, 3).reduce((s, v) => s + v, 0);
+    const top5Share = shares.slice(0, 5).reduce((s, v) => s + v, 0);
+
+    let riskLevel: RiskLevel =
+      hhi >= CUSTOMER_THRESHOLDS.hhi.medium ? 'high'
+      : hhi >= CUSTOMER_THRESHOLDS.hhi.low ? 'medium'
+      : 'low';
+
+    if (top1Share >= CUSTOMER_THRESHOLDS.singleHigh) riskLevel = 'high';
+    if (top3Share >= CUSTOMER_THRESHOLDS.top3High && riskLevel !== 'high') riskLevel = 'high';
+
+    const score = computeScore(top1Share, top3Share, hhi);
+
+    return {
+      rows,
+      totalContractExposure,
+      top1Share,
+      top3Share,
+      top5Share,
+      hhi,
+      riskLevel,
+      score,
+      insufficientData: false,
+    };
+  } catch (err) {
+    logger.error({ err, filters }, '[ConcentrationRisk] customer calculation failed');
+    return {
+      rows: [],
+      totalContractExposure: 0,
+      top1Share: 0,
+      top3Share: 0,
+      top5Share: 0,
+      hhi: 0,
+      riskLevel: 'insufficient_data',
+      score: 0,
+      insufficientData: true,
+    };
+  }
+}

--- a/src/lib/concentration-risk/helpers.ts
+++ b/src/lib/concentration-risk/helpers.ts
@@ -1,0 +1,106 @@
+import type { RiskLevel } from './types';
+
+export function safeDivide(numerator: number, denominator: number): number {
+  if (denominator === 0 || !isFinite(denominator)) return 0;
+  return numerator / denominator;
+}
+
+export function calculateShare(value: number, total: number): number {
+  return safeDivide(value, total);
+}
+
+export function calculateHHI(shares: number[]): number {
+  return shares.reduce((sum, s) => sum + s * s, 0);
+}
+
+export function calculateCoefficientOfVariation(values: number[]): number {
+  if (values.length < 2) return 0;
+  const mean = values.reduce((a, b) => a + b, 0) / values.length;
+  if (mean === 0) return 0;
+  const variance = values.reduce((sum, v) => sum + Math.pow(v - mean, 2), 0) / values.length;
+  const stdDev = Math.sqrt(variance);
+  return safeDivide(stdDev, mean);
+}
+
+export function calculateStdDev(values: number[]): number {
+  if (values.length < 2) return 0;
+  const mean = values.reduce((a, b) => a + b, 0) / values.length;
+  const variance = values.reduce((sum, v) => sum + Math.pow(v - mean, 2), 0) / values.length;
+  return Math.sqrt(variance);
+}
+
+export function classifyRisk(
+  value: number,
+  thresholds: { low?: number; medium?: number; high?: number },
+  direction: 'higher_is_worse' | 'lower_is_worse' = 'higher_is_worse'
+): RiskLevel {
+  if (direction === 'higher_is_worse') {
+    if (thresholds.high !== undefined && value >= thresholds.high) return 'high';
+    if (thresholds.medium !== undefined && value >= thresholds.medium) return 'medium';
+    return 'low';
+  }
+  if (thresholds.low !== undefined && value <= thresholds.low) return 'low';
+  if (thresholds.medium !== undefined && value <= thresholds.medium) return 'medium';
+  return 'high';
+}
+
+/** Convert a risk level to a 0-100 numeric score */
+export function riskLevelToScore(level: RiskLevel): number {
+  switch (level) {
+    case 'low': return 15;
+    case 'medium': return 55;
+    case 'high': return 75;
+    case 'critical': return 95;
+    case 'insufficient_data': return 0;
+  }
+}
+
+/** Map a raw 0-1 ratio to a 0-100 score, clamped */
+export function ratioToScore(ratio: number, lowThreshold: number, highThreshold: number): number {
+  const clamped = Math.min(ratio, 1);
+  if (clamped <= lowThreshold) return Math.round(safeDivide(clamped, lowThreshold) * 30);
+  if (clamped <= highThreshold) {
+    const pct = safeDivide(clamped - lowThreshold, highThreshold - lowThreshold);
+    return Math.round(30 + pct * 45);
+  }
+  const pct = Math.min(safeDivide(clamped - highThreshold, 1 - highThreshold), 1);
+  return Math.round(75 + pct * 25);
+}
+
+/** Classify overall score label */
+export function classifyOverallScore(score: number): RiskLevel {
+  if (score <= 30) return 'low';
+  if (score <= 60) return 'medium';
+  if (score <= 80) return 'high';
+  return 'critical';
+}
+
+/** Build a date range from year / startDate / endDate */
+export function buildDateRange(
+  year?: number,
+  startDate?: string,
+  endDate?: string
+): { gte?: Date; lte?: Date } {
+  if (startDate || endDate) {
+    return {
+      gte: startDate ? new Date(startDate) : undefined,
+      lte: endDate ? new Date(endDate) : undefined,
+    };
+  }
+  if (year) {
+    return {
+      gte: new Date(`${year}-01-01T00:00:00.000Z`),
+      lte: new Date(`${year}-12-31T23:59:59.999Z`),
+    };
+  }
+  const currentYear = new Date().getFullYear();
+  return {
+    gte: new Date(`${currentYear}-01-01T00:00:00.000Z`),
+    lte: new Date(`${currentYear}-12-31T23:59:59.999Z`),
+  };
+}
+
+export function formatMonthLabel(year: number, month: number): string {
+  const d = new Date(year, month - 1, 1);
+  return d.toLocaleDateString('en-SA-u-ca-gregory', { year: 'numeric', month: 'short' });
+}

--- a/src/lib/concentration-risk/overall-risk.ts
+++ b/src/lib/concentration-risk/overall-risk.ts
@@ -1,0 +1,85 @@
+import type {
+  RiskFilters,
+  OverallRiskResult,
+  ConcentrationRiskSummary,
+  DimensionScore,
+  RiskLevel,
+} from './types';
+import { getCustomerConcentration } from './customer-risk';
+import { getProjectConcentration } from './project-risk';
+import { getSegmentConcentration } from './segment-risk';
+import { getSupplierConcentration } from './supplier-risk';
+import { getResourceConcentration } from './resource-risk';
+import { getRevenueTimingConcentration } from './revenue-timing-risk';
+import { DIMENSION_WEIGHTS } from './risk-thresholds';
+import { classifyOverallScore } from './helpers';
+import { logger } from '@/lib/logger';
+
+function makeDimension(
+  name: string,
+  score: number,
+  weight: number,
+  riskLevel: RiskLevel
+): DimensionScore {
+  return {
+    name,
+    score,
+    weight,
+    riskLevel,
+    contributedScore: Math.round(score * weight),
+  };
+}
+
+export async function getOverallRisk(filters: RiskFilters): Promise<OverallRiskResult> {
+  const [customer, project, segment, supplier, resource, revenueTiming] = await Promise.all([
+    getCustomerConcentration(filters),
+    getProjectConcentration(filters),
+    getSegmentConcentration(filters),
+    getSupplierConcentration(filters),
+    getResourceConcentration(filters),
+    getRevenueTimingConcentration(filters),
+  ]);
+
+  const dimensions: DimensionScore[] = [
+    makeDimension('Customer Concentration', customer.score, DIMENSION_WEIGHTS.customer, customer.riskLevel),
+    makeDimension('Project Concentration', project.score, DIMENSION_WEIGHTS.project, project.riskLevel),
+    makeDimension('Segment Concentration', segment.score, DIMENSION_WEIGHTS.segment, segment.riskLevel),
+    makeDimension('Supplier Concentration', supplier.score, DIMENSION_WEIGHTS.supplier, supplier.riskLevel),
+    makeDimension('Operational Dependency', resource.score, DIMENSION_WEIGHTS.resource, resource.riskLevel),
+    makeDimension('Revenue Timing', revenueTiming.score, DIMENSION_WEIGHTS.revenueTiming, revenueTiming.riskLevel),
+  ];
+
+  const overallScore = Math.round(
+    dimensions.reduce((sum, d) => sum + d.score * d.weight, 0)
+  );
+
+  const riskLabel = classifyOverallScore(overallScore);
+
+  logger.info(
+    { overallScore, riskLabel, filters },
+    '[ConcentrationRisk] overall risk computed'
+  );
+
+  return { overallScore, riskLabel, dimensions, customer, project, segment, supplier, resource, revenueTiming };
+}
+
+export function buildSummary(result: OverallRiskResult): ConcentrationRiskSummary {
+  const anyInsufficient =
+    result.customer.insufficientData &&
+    result.project.insufficientData &&
+    result.supplier.insufficientData &&
+    result.revenueTiming.insufficientData;
+
+  return {
+    overallScore: result.overallScore,
+    riskLabel: result.riskLabel,
+    customerHhi: result.customer.hhi,
+    topCustomerShare: result.customer.top1Share,
+    largestProjectShare: result.project.largestShare,
+    topSupplierShare: result.supplier.top1Share,
+    revenueVolatilityCv: result.revenueTiming.cv,
+    criticalBottleneckShare: result.resource.topShare,
+    dimensions: result.dimensions,
+    insufficientData: anyInsufficient,
+  };
+}

--- a/src/lib/concentration-risk/project-risk.ts
+++ b/src/lib/concentration-risk/project-risk.ts
@@ -1,0 +1,96 @@
+import db from '@/lib/db';
+import { logger } from '@/lib/logger';
+import type { RiskFilters, ProjectConcentrationResult, ProjectRiskRow, RiskLevel } from './types';
+import { calculateShare, buildDateRange, ratioToScore } from './helpers';
+import { PROJECT_THRESHOLDS } from './risk-thresholds';
+
+function classifyProjectRisk(share: number): RiskLevel {
+  if (share >= PROJECT_THRESHOLDS.largestShare.medium) return 'high';
+  if (share >= PROJECT_THRESHOLDS.largestShare.low) return 'medium';
+  return 'low';
+}
+
+export async function getProjectConcentration(filters: RiskFilters): Promise<ProjectConcentrationResult> {
+  try {
+    const dateRange = buildDateRange(filters.year, filters.startDate, filters.endDate);
+
+    const projects = await db.project.findMany({
+      where: {
+        deletedAt: null,
+        contractValue: { not: null, gt: 0 },
+        ...(filters.customerId ? { clientId: filters.customerId } : {}),
+        ...(filters.projectId ? { id: filters.projectId } : {}),
+        ...(dateRange.gte || dateRange.lte ? { createdAt: dateRange } : {}),
+      },
+      select: {
+        id: true,
+        projectNumber: true,
+        name: true,
+        contractValue: true,
+        status: true,
+        client: { select: { name: true } },
+      },
+      orderBy: { contractValue: 'desc' },
+    });
+
+    if (projects.length === 0) {
+      return {
+        rows: [],
+        totalContractValue: 0,
+        largestShare: 0,
+        top3Share: 0,
+        top5Share: 0,
+        riskLevel: 'insufficient_data',
+        score: 0,
+        insufficientData: true,
+      };
+    }
+
+    const totalContractValue = projects.reduce((s, p) => s + Number(p.contractValue ?? 0), 0);
+
+    const rows: ProjectRiskRow[] = projects.map((p) => {
+      const contractValue = Number(p.contractValue ?? 0);
+      const share = calculateShare(contractValue, totalContractValue);
+      return {
+        projectId: p.id,
+        projectNumber: p.projectNumber,
+        projectName: p.name,
+        customerName: p.client.name,
+        contractValue,
+        share,
+        status: p.status,
+        riskLevel: classifyProjectRisk(share),
+      };
+    });
+
+    const largestShare = rows[0]?.share ?? 0;
+    const top3Share = rows.slice(0, 3).reduce((s, r) => s + r.share, 0);
+    const top5Share = rows.slice(0, 5).reduce((s, r) => s + r.share, 0);
+
+    const riskLevel: RiskLevel = classifyProjectRisk(largestShare);
+    const score = ratioToScore(largestShare, PROJECT_THRESHOLDS.largestShare.low, PROJECT_THRESHOLDS.largestShare.medium);
+
+    return {
+      rows,
+      totalContractValue,
+      largestShare,
+      top3Share,
+      top5Share,
+      riskLevel,
+      score,
+      insufficientData: false,
+    };
+  } catch (err) {
+    logger.error({ err, filters }, '[ConcentrationRisk] project calculation failed');
+    return {
+      rows: [],
+      totalContractValue: 0,
+      largestShare: 0,
+      top3Share: 0,
+      top5Share: 0,
+      riskLevel: 'insufficient_data',
+      score: 0,
+      insufficientData: true,
+    };
+  }
+}

--- a/src/lib/concentration-risk/resource-risk.ts
+++ b/src/lib/concentration-risk/resource-risk.ts
@@ -1,0 +1,145 @@
+import db from '@/lib/db';
+import { logger } from '@/lib/logger';
+import type { RiskFilters, ResourceConcentrationResult, ResourceRiskRow, RiskLevel, ResourceType } from './types';
+import { calculateShare, buildDateRange, ratioToScore } from './helpers';
+import { RESOURCE_THRESHOLDS } from './risk-thresholds';
+
+// Operational dependency concentration — measures production output per team/process.
+// Uses ProductionLog.processedQty grouped by processingTeam and processType.
+// This is NOT an HR blame tool: labels use "Operational Dependency" language.
+
+function classifyResourceRisk(share: number): RiskLevel {
+  if (share >= RESOURCE_THRESHOLDS.share.medium) return 'high';
+  if (share >= RESOURCE_THRESHOLDS.share.low) return 'medium';
+  return 'low';
+}
+
+function dependencyLabel(riskLevel: RiskLevel): RiskLevel {
+  return riskLevel;
+}
+
+export async function getResourceConcentration(filters: RiskFilters): Promise<ResourceConcentrationResult> {
+  try {
+    const dateRange = buildDateRange(filters.year, filters.startDate, filters.endDate);
+
+    const logs = await db.productionLog.findMany({
+      where: {
+        processedQty: { gt: 0 },
+        ...(filters.projectId ? { assemblyPart: { projectId: filters.projectId } } : {}),
+        ...(filters.departmentId ? {
+          assemblyPart: { project: { projectManagerId: filters.departmentId } },
+        } : {}),
+        ...(dateRange.gte || dateRange.lte ? { dateProcessed: dateRange } : {}),
+      },
+      select: {
+        processType: true,
+        processingTeam: true,
+        processedQty: true,
+        assemblyPart: {
+          select: {
+            singlePartWeight: true,
+            quantity: true,
+          },
+        },
+      },
+    });
+
+    if (logs.length === 0) {
+      return {
+        rows: [],
+        totalOutput: 0,
+        outputUnit: 'units',
+        topShare: 0,
+        riskLevel: 'insufficient_data',
+        score: 0,
+        insufficientData: true,
+      };
+    }
+
+    // Prefer weight (kg) where available, otherwise use quantity count
+    let useWeight = false;
+    const byTeam: Record<string, { output: number }> = {};
+    const byProcess: Record<string, { output: number }> = {};
+    let totalOutput = 0;
+
+    for (const log of logs) {
+      const weightKg =
+        log.assemblyPart.singlePartWeight != null
+          ? Number(log.assemblyPart.singlePartWeight) * log.processedQty
+          : null;
+
+      const output = weightKg ?? log.processedQty;
+      if (weightKg !== null) useWeight = true;
+
+      totalOutput += output;
+
+      const team = (log.processingTeam ?? 'Unassigned').trim();
+      if (!byTeam[team]) byTeam[team] = { output: 0 };
+      byTeam[team].output += output;
+
+      const process = log.processType ?? 'Unknown';
+      if (!byProcess[process]) byProcess[process] = { output: 0 };
+      byProcess[process].output += output;
+    }
+
+    const outputUnit = useWeight ? 'kg' : 'units';
+
+    const teamRows: ResourceRiskRow[] = Object.entries(byTeam)
+      .map(([name, data]) => {
+        const share = calculateShare(data.output, totalOutput);
+        const riskLevel = classifyResourceRisk(share);
+        return {
+          resourceType: 'team' as ResourceType,
+          resourceName: name,
+          output: data.output,
+          outputUnit,
+          share,
+          dependencyLevel: dependencyLabel(riskLevel),
+          riskLevel,
+        };
+      })
+      .sort((a, b) => b.output - a.output);
+
+    const processRows: ResourceRiskRow[] = Object.entries(byProcess)
+      .map(([name, data]) => {
+        const share = calculateShare(data.output, totalOutput);
+        const riskLevel = classifyResourceRisk(share);
+        return {
+          resourceType: 'process' as ResourceType,
+          resourceName: name,
+          output: data.output,
+          outputUnit,
+          share,
+          dependencyLevel: dependencyLabel(riskLevel),
+          riskLevel,
+        };
+      })
+      .sort((a, b) => b.output - a.output);
+
+    const rows = [...teamRows, ...processRows];
+    const topShare = rows[0]?.share ?? 0;
+    const riskLevel: RiskLevel = classifyResourceRisk(topShare);
+    const score = ratioToScore(topShare, RESOURCE_THRESHOLDS.share.low, RESOURCE_THRESHOLDS.share.medium);
+
+    return {
+      rows,
+      totalOutput,
+      outputUnit,
+      topShare,
+      riskLevel,
+      score,
+      insufficientData: false,
+    };
+  } catch (err) {
+    logger.error({ err, filters }, '[ConcentrationRisk] resource calculation failed');
+    return {
+      rows: [],
+      totalOutput: 0,
+      outputUnit: 'units',
+      topShare: 0,
+      riskLevel: 'insufficient_data',
+      score: 0,
+      insufficientData: true,
+    };
+  }
+}

--- a/src/lib/concentration-risk/revenue-timing-risk.ts
+++ b/src/lib/concentration-risk/revenue-timing-risk.ts
@@ -1,0 +1,111 @@
+import db from '@/lib/db';
+import { logger } from '@/lib/logger';
+import type { RiskFilters, RevenueTimingResult, MonthlyRevenuePoint, RiskLevel } from './types';
+import {
+  calculateCoefficientOfVariation,
+  calculateStdDev,
+  buildDateRange,
+  formatMonthLabel,
+  ratioToScore,
+} from './helpers';
+import { REVENUE_TIMING_THRESHOLDS } from './risk-thresholds';
+
+// Revenue timing uses ProjectPaymentReceipt.amount by receivedDate month.
+// This reflects actual cash receipts recorded in OTS.
+// TODO: When Dolibarr invoice data is mirrored into OTS, prefer invoice issue dates.
+
+export async function getRevenueTimingConcentration(filters: RiskFilters): Promise<RevenueTimingResult> {
+  try {
+    const dateRange = buildDateRange(filters.year, filters.startDate, filters.endDate);
+
+    const receipts = await db.projectPaymentReceipt.findMany({
+      where: {
+        amount: { gt: 0 },
+        ...(dateRange.gte || dateRange.lte ? { receivedDate: dateRange } : {}),
+        schedule: {
+          project: {
+            deletedAt: null,
+            ...(filters.customerId ? { clientId: filters.customerId } : {}),
+            ...(filters.projectId ? { id: filters.projectId } : {}),
+          },
+        },
+      },
+      select: {
+        amount: true,
+        receivedDate: true,
+      },
+    });
+
+    if (receipts.length === 0) {
+      return {
+        monthly: [],
+        averageMonthly: 0,
+        stdDev: 0,
+        cv: 0,
+        riskLevel: 'insufficient_data',
+        score: 0,
+        insufficientData: true,
+      };
+    }
+
+    // Group by year-month
+    const byMonth: Record<string, number> = {};
+    for (const r of receipts) {
+      const d = new Date(r.receivedDate);
+      const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+      byMonth[key] = (byMonth[key] ?? 0) + Number(r.amount);
+    }
+
+    // Fill all months in range so zero-revenue months are included in CV
+    const rangeStart = dateRange.gte ?? new Date(`${new Date().getFullYear()}-01-01`);
+    const rangeEnd = dateRange.lte ?? new Date(`${new Date().getFullYear()}-12-31`);
+
+    const monthly: MonthlyRevenuePoint[] = [];
+    const cur = new Date(rangeStart.getFullYear(), rangeStart.getMonth(), 1);
+    while (cur <= rangeEnd) {
+      const y = cur.getFullYear();
+      const m = cur.getMonth() + 1;
+      const key = `${y}-${String(m).padStart(2, '0')}`;
+      monthly.push({
+        year: y,
+        month: m,
+        label: formatMonthLabel(y, m),
+        amount: byMonth[key] ?? 0,
+      });
+      cur.setMonth(cur.getMonth() + 1);
+    }
+
+    const amounts = monthly.map((p) => p.amount);
+    const averageMonthly = amounts.reduce((a, b) => a + b, 0) / amounts.length;
+    const stdDev = calculateStdDev(amounts);
+    const cv = calculateCoefficientOfVariation(amounts);
+
+    const riskLevel: RiskLevel =
+      cv >= REVENUE_TIMING_THRESHOLDS.cv.medium ? 'high'
+      : cv >= REVENUE_TIMING_THRESHOLDS.cv.low ? 'medium'
+      : 'low';
+
+    const score = ratioToScore(cv, REVENUE_TIMING_THRESHOLDS.cv.low, REVENUE_TIMING_THRESHOLDS.cv.medium);
+
+    return {
+      monthly,
+      averageMonthly,
+      stdDev,
+      cv,
+      riskLevel,
+      score,
+      insufficientData: false,
+    };
+  } catch (err) {
+    logger.error({ err, filters }, '[ConcentrationRisk] revenue timing calculation failed');
+    return {
+      monthly: [],
+      averageMonthly: 0,
+      stdDev: 0,
+      cv: 0,
+      riskLevel: 'insufficient_data',
+      score: 0,
+      insufficientData: true,
+    };
+  }
+}

--- a/src/lib/concentration-risk/risk-thresholds.ts
+++ b/src/lib/concentration-risk/risk-thresholds.ts
@@ -1,0 +1,42 @@
+export const CUSTOMER_THRESHOLDS = {
+  hhi: { low: 0.15, medium: 0.25 },
+  singleWarning: 0.15,
+  singleHigh: 0.25,
+  top3High: 0.40,
+} as const;
+
+export const PROJECT_THRESHOLDS = {
+  largestShare: { low: 0.15, medium: 0.25 },
+} as const;
+
+export const SEGMENT_THRESHOLDS = {
+  largestShare: { medium: 0.35, high: 0.50 },
+} as const;
+
+export const SUPPLIER_THRESHOLDS = {
+  topShare: { low: 0.25, medium: 0.40 },
+} as const;
+
+export const RESOURCE_THRESHOLDS = {
+  share: { low: 0.25, medium: 0.40 },
+} as const;
+
+export const REVENUE_TIMING_THRESHOLDS = {
+  cv: { low: 0.30, medium: 0.60 },
+} as const;
+
+export const OVERALL_SCORE_LABELS = {
+  low: { max: 30, label: 'Low' },
+  medium: { max: 60, label: 'Medium' },
+  high: { max: 80, label: 'High' },
+  critical: { max: 100, label: 'Critical' },
+} as const;
+
+export const DIMENSION_WEIGHTS = {
+  customer: 0.25,
+  project: 0.20,
+  segment: 0.15,
+  supplier: 0.15,
+  resource: 0.15,
+  revenueTiming: 0.10,
+} as const;

--- a/src/lib/concentration-risk/segment-risk.ts
+++ b/src/lib/concentration-risk/segment-risk.ts
@@ -1,0 +1,102 @@
+import db from '@/lib/db';
+import { logger } from '@/lib/logger';
+import type { RiskFilters, SegmentConcentrationResult, SegmentRiskRow, RiskLevel } from './types';
+import { calculateShare, calculateHHI, buildDateRange, ratioToScore } from './helpers';
+import { SEGMENT_THRESHOLDS } from './risk-thresholds';
+
+const UNCLASSIFIED = 'Unclassified';
+
+function classifySegmentRisk(share: number): RiskLevel {
+  if (share >= SEGMENT_THRESHOLDS.largestShare.high) return 'high';
+  if (share >= SEGMENT_THRESHOLDS.largestShare.medium) return 'medium';
+  return 'low';
+}
+
+export async function getSegmentConcentration(filters: RiskFilters): Promise<SegmentConcentrationResult> {
+  try {
+    const dateRange = buildDateRange(filters.year, filters.startDate, filters.endDate);
+
+    const projects = await db.project.findMany({
+      where: {
+        deletedAt: null,
+        contractValue: { not: null, gt: 0 },
+        ...(filters.customerId ? { clientId: filters.customerId } : {}),
+        ...(filters.segment ? {
+          OR: [
+            { segment: { name: filters.segment } },
+            { projectNature: filters.segment },
+          ],
+        } : {}),
+        ...(dateRange.gte || dateRange.lte ? { createdAt: dateRange } : {}),
+      },
+      select: {
+        contractValue: true,
+        projectNature: true,
+        segment: { select: { name: true } },
+      },
+    });
+
+    if (projects.length === 0) {
+      return {
+        rows: [],
+        totalContractExposure: 0,
+        largestShare: 0,
+        hhi: 0,
+        riskLevel: 'insufficient_data',
+        score: 0,
+        insufficientData: true,
+      };
+    }
+
+    const bySegment: Record<string, { total: number; count: number }> = {};
+    let totalContractExposure = 0;
+
+    for (const p of projects) {
+      const segmentName = p.segment?.name ?? p.projectNature ?? UNCLASSIFIED;
+      const val = Number(p.contractValue ?? 0);
+      totalContractExposure += val;
+      if (!bySegment[segmentName]) bySegment[segmentName] = { total: 0, count: 0 };
+      bySegment[segmentName].total += val;
+      bySegment[segmentName].count += 1;
+    }
+
+    const rows: SegmentRiskRow[] = Object.entries(bySegment)
+      .map(([segment, data]) => {
+        const share = calculateShare(data.total, totalContractExposure);
+        return {
+          segment,
+          contractExposure: data.total,
+          share,
+          projectCount: data.count,
+          riskLevel: classifySegmentRisk(share),
+        };
+      })
+      .sort((a, b) => b.contractExposure - a.contractExposure);
+
+    const largestShare = rows[0]?.share ?? 0;
+    const hhi = calculateHHI(rows.map((r) => r.share));
+    const riskLevel: RiskLevel = classifySegmentRisk(largestShare);
+    const score = ratioToScore(largestShare, SEGMENT_THRESHOLDS.largestShare.medium, SEGMENT_THRESHOLDS.largestShare.high);
+
+    return {
+      rows,
+      totalContractExposure,
+      largestShare,
+      hhi,
+      riskLevel,
+      score,
+      insufficientData: false,
+    };
+  } catch (err) {
+    logger.error({ err, filters }, '[ConcentrationRisk] segment calculation failed');
+    return {
+      rows: [],
+      totalContractExposure: 0,
+      largestShare: 0,
+      hhi: 0,
+      riskLevel: 'insufficient_data',
+      score: 0,
+      insufficientData: true,
+    };
+  }
+}

--- a/src/lib/concentration-risk/supplier-risk.ts
+++ b/src/lib/concentration-risk/supplier-risk.ts
@@ -1,0 +1,105 @@
+import db from '@/lib/db';
+import { logger } from '@/lib/logger';
+import type { RiskFilters, SupplierConcentrationResult, SupplierRiskRow, RiskLevel } from './types';
+import { calculateShare, calculateHHI, buildDateRange, ratioToScore } from './helpers';
+import { SUPPLIER_THRESHOLDS } from './risk-thresholds';
+
+// TODO: When a dedicated PO/procurement module is added to OTS, replace this
+//       adapter with a direct PurchaseOrder model query.
+//       Currently using LcrEntry.amount + awardedToRaw as a procurement proxy.
+
+function classifySupplierRisk(share: number): RiskLevel {
+  if (share >= SUPPLIER_THRESHOLDS.topShare.medium) return 'high';
+  if (share >= SUPPLIER_THRESHOLDS.topShare.low) return 'medium';
+  return 'low';
+}
+
+export async function getSupplierConcentration(filters: RiskFilters): Promise<SupplierConcentrationResult> {
+  try {
+    const dateRange = buildDateRange(filters.year, filters.startDate, filters.endDate);
+
+    const entries = await db.lcrEntry.findMany({
+      where: {
+        isDeleted: false,
+        amount: { not: null, gt: 0 },
+        awardedToRaw: { not: null },
+        ...(filters.projectId ? { projectId: filters.projectId } : {}),
+        ...(dateRange.gte || dateRange.lte ? { buyingDate: dateRange } : {}),
+      },
+      select: {
+        awardedToRaw: true,
+        amount: true,
+        poNumber: true,
+      },
+    });
+
+    if (entries.length === 0) {
+      return {
+        rows: [],
+        totalSpend: 0,
+        top1Share: 0,
+        top3Share: 0,
+        hhi: 0,
+        riskLevel: 'insufficient_data',
+        score: 0,
+        insufficientData: true,
+      };
+    }
+
+    const bySupplier: Record<string, { spend: number; pos: Set<string> }> = {};
+    let totalSpend = 0;
+
+    for (const e of entries) {
+      const name = (e.awardedToRaw ?? 'Unknown').trim();
+      if (!name) continue;
+      const amount = Number(e.amount ?? 0);
+      totalSpend += amount;
+      if (!bySupplier[name]) bySupplier[name] = { spend: 0, pos: new Set() };
+      bySupplier[name].spend += amount;
+      if (e.poNumber) bySupplier[name].pos.add(e.poNumber);
+    }
+
+    const rows: SupplierRiskRow[] = Object.entries(bySupplier)
+      .map(([supplierName, data]) => {
+        const share = calculateShare(data.spend, totalSpend);
+        return {
+          supplierName,
+          spend: data.spend,
+          share,
+          poCount: data.pos.size,
+          riskLevel: classifySupplierRisk(share),
+        };
+      })
+      .sort((a, b) => b.spend - a.spend);
+
+    const shares = rows.map((r) => r.share);
+    const top1Share = shares[0] ?? 0;
+    const top3Share = shares.slice(0, 3).reduce((s, v) => s + v, 0);
+    const hhi = calculateHHI(shares);
+    const riskLevel: RiskLevel = classifySupplierRisk(top1Share);
+    const score = ratioToScore(top1Share, SUPPLIER_THRESHOLDS.topShare.low, SUPPLIER_THRESHOLDS.topShare.medium);
+
+    return {
+      rows,
+      totalSpend,
+      top1Share,
+      top3Share,
+      hhi,
+      riskLevel,
+      score,
+      insufficientData: false,
+    };
+  } catch (err) {
+    logger.error({ err, filters }, '[ConcentrationRisk] supplier calculation failed');
+    return {
+      rows: [],
+      totalSpend: 0,
+      top1Share: 0,
+      top3Share: 0,
+      hhi: 0,
+      riskLevel: 'insufficient_data',
+      score: 0,
+      insufficientData: true,
+    };
+  }
+}

--- a/src/lib/concentration-risk/types.ts
+++ b/src/lib/concentration-risk/types.ts
@@ -1,0 +1,182 @@
+export type RiskLevel = 'low' | 'medium' | 'high' | 'critical' | 'insufficient_data';
+
+export interface RiskFilters {
+  startDate?: string;
+  endDate?: string;
+  year?: number;
+  customerId?: string;
+  projectId?: string;
+  segment?: string;
+  supplierId?: string;
+  departmentId?: string;
+  riskLevel?: RiskLevel;
+}
+
+// ── Customer ──────────────────────────────────────────────────────────────────
+
+export interface CustomerRiskRow {
+  customerId: string;
+  customerName: string;
+  contractExposure: number;
+  share: number;
+  projectCount: number;
+  lastActivityDate: Date | null;
+  riskLevel: RiskLevel;
+}
+
+export interface CustomerConcentrationResult {
+  rows: CustomerRiskRow[];
+  totalContractExposure: number;
+  top1Share: number;
+  top3Share: number;
+  top5Share: number;
+  hhi: number;
+  riskLevel: RiskLevel;
+  score: number;
+  insufficientData: boolean;
+}
+
+// ── Project ───────────────────────────────────────────────────────────────────
+
+export interface ProjectRiskRow {
+  projectId: string;
+  projectNumber: string;
+  projectName: string;
+  customerName: string;
+  contractValue: number;
+  share: number;
+  status: string;
+  riskLevel: RiskLevel;
+}
+
+export interface ProjectConcentrationResult {
+  rows: ProjectRiskRow[];
+  totalContractValue: number;
+  largestShare: number;
+  top3Share: number;
+  top5Share: number;
+  riskLevel: RiskLevel;
+  score: number;
+  insufficientData: boolean;
+}
+
+// ── Segment ───────────────────────────────────────────────────────────────────
+
+export interface SegmentRiskRow {
+  segment: string;
+  contractExposure: number;
+  share: number;
+  projectCount: number;
+  riskLevel: RiskLevel;
+}
+
+export interface SegmentConcentrationResult {
+  rows: SegmentRiskRow[];
+  totalContractExposure: number;
+  largestShare: number;
+  hhi: number;
+  riskLevel: RiskLevel;
+  score: number;
+  insufficientData: boolean;
+}
+
+// ── Supplier ──────────────────────────────────────────────────────────────────
+
+export interface SupplierRiskRow {
+  supplierName: string;
+  spend: number;
+  share: number;
+  poCount: number;
+  riskLevel: RiskLevel;
+}
+
+export interface SupplierConcentrationResult {
+  rows: SupplierRiskRow[];
+  totalSpend: number;
+  top1Share: number;
+  top3Share: number;
+  hhi: number;
+  riskLevel: RiskLevel;
+  score: number;
+  insufficientData: boolean;
+}
+
+// ── Resource ──────────────────────────────────────────────────────────────────
+
+export type ResourceType = 'team' | 'process' | 'department' | 'employee';
+
+export interface ResourceRiskRow {
+  resourceType: ResourceType;
+  resourceName: string;
+  output: number;
+  outputUnit: string;
+  share: number;
+  dependencyLevel: RiskLevel;
+  riskLevel: RiskLevel;
+}
+
+export interface ResourceConcentrationResult {
+  rows: ResourceRiskRow[];
+  totalOutput: number;
+  outputUnit: string;
+  topShare: number;
+  riskLevel: RiskLevel;
+  score: number;
+  insufficientData: boolean;
+}
+
+// ── Revenue Timing ────────────────────────────────────────────────────────────
+
+export interface MonthlyRevenuePoint {
+  year: number;
+  month: number;
+  label: string;
+  amount: number;
+}
+
+export interface RevenueTimingResult {
+  monthly: MonthlyRevenuePoint[];
+  averageMonthly: number;
+  stdDev: number;
+  cv: number;
+  riskLevel: RiskLevel;
+  score: number;
+  insufficientData: boolean;
+}
+
+// ── Overall ───────────────────────────────────────────────────────────────────
+
+export interface DimensionScore {
+  name: string;
+  score: number;
+  weight: number;
+  riskLevel: RiskLevel;
+  contributedScore: number;
+}
+
+export interface OverallRiskResult {
+  overallScore: number;
+  riskLabel: RiskLevel;
+  dimensions: DimensionScore[];
+  customer: CustomerConcentrationResult;
+  project: ProjectConcentrationResult;
+  segment: SegmentConcentrationResult;
+  supplier: SupplierConcentrationResult;
+  resource: ResourceConcentrationResult;
+  revenueTiming: RevenueTimingResult;
+}
+
+// ── Summary (API response) ────────────────────────────────────────────────────
+
+export interface ConcentrationRiskSummary {
+  overallScore: number;
+  riskLabel: RiskLevel;
+  customerHhi: number;
+  topCustomerShare: number;
+  largestProjectShare: number;
+  topSupplierShare: number;
+  revenueVolatilityCv: number;
+  criticalBottleneckShare: number;
+  dimensions: DimensionScore[];
+  insufficientData: boolean;
+}

--- a/src/lib/navigation-permissions.ts
+++ b/src/lib/navigation-permissions.ts
@@ -162,6 +162,9 @@ export const NAVIGATION_PERMISSIONS: NavigationPermissionMap = {
   '/executive': ['executive.view'],
   '/ceo-arena/brainstorm': ['executive.view'],
 
+  // Concentration Risk Dashboard
+  '/concentration-risk': ['concentrationRisk.view'],
+
   // Ops Agent
   '/ops-agent': ['ops_agent.view', 'ops_agent.run', 'ops_agent.configure'],
 

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -326,6 +326,15 @@ export const PERMISSIONS: PermissionCategory[] = [
     ],
   },
   {
+    id: 'concentrationRisk',
+    name: 'Concentration Risk Dashboard',
+    permissions: [
+      { id: 'concentrationRisk.view', name: 'View Concentration Risk', description: 'Access the Concentration Risk Dashboard — customer, project, supplier and resource exposure analysis', category: 'concentrationRisk' },
+      { id: 'concentrationRisk.manage', name: 'Manage Concentration Risk', description: 'Configure risk thresholds and segment classifications', category: 'concentrationRisk' },
+      { id: 'concentrationRisk.export', name: 'Export Concentration Risk', description: 'Export risk reports to Excel / CSV', category: 'concentrationRisk' },
+    ],
+  },
+  {
     id: 'backups',
     name: 'Backup Management',
     permissions: [


### PR DESCRIPTION
Adds a full Concentration Risk Dashboard at /concentration-risk inside
the CEO Arena. Calculates and displays concentration exposure across six
dimensions: customer, project, segment, supplier, operational dependency,
and revenue timing.

Key changes:
- Six server-side risk services with HHI, share, CV calculations
- Deterministic overall score (0–100, weighted average of 6 dimensions)
- Eight API endpoints under /api/concentration-risk/*
- Executive summary cards, risk heatmap, per-dimension detail tabs
- Revenue timing Recharts bar chart with reference line
- CSV export endpoint requiring concentrationRisk.export permission
- RBAC: concentrationRisk.view / manage / export permissions
- Sidebar item in CEO Arena section (PieChart icon)
- ProjectSegment model + additive SQL migration (7 default segments)
- segmentId (nullable FK) added to Project model
- Unit tests covering HHI, share, CV, scoring, and edge cases
- Version 22.10.3 → 22.11.0

https://claude.ai/code/session_01WetcBGnu8X9HHpCt5UDtcL