### PR TITLE
feat: payroll OT formula, total salary tile, dolibarr field selector, project edit fix — v22.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [22.12.0] - 2026-05-04
+
+### Payroll, HR & Productivity Improvements
+
+#### Fixed
+- **Payroll overtime formula** — overtime is now calculated on **basic salary only** (was incorrectly using total monthly gross including all allowances). Aligns with Saudi Labor Law.
+- **Project edit page** — fixed Next.js 15 async `params` pattern; clicking "Edit Project" no longer redirects to the projects list for all roles.
+- **Task default status** — tasks created via the quick-add (+) button now start as **"In Progress"** instead of "Pending".
+
+#### Added
+- **Total Salary tile** in the employee Compensation tab — live read-only sum of basic + housing + transport + mobile + food + other allowances, updates as you type.
+- **Dolibarr sync field selector** — clicking "Sync from Dolibarr" now opens a dialog where you can select exactly which fields to update (grouped by Identity, Documents, Employment, Compensation, Banking). Unselected fields keep their OTS values, preventing accidental overwrites of local edits.
+
+#### Changed
+- **Payroll action buttons** moved to right-align for consistent toolbar layout.
+- Version bumped to **22.12.0**
+
+---
+
 ## [22.11.0] - 2026-05-03
 
 ### Concentration Risk Dashboard (CEO Arena)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 # Hexa Steel® Operations Tracking System (OTS™)
 
-**Version:** 22.5.3 | **Release Date:** April 29, 2026
+**Version:** 22.12.0 | **Release Date:** May 4, 2026
 
 A comprehensive Enterprise Resource Planning (ERP) system specifically designed for steel fabrication and construction projects. Built with Next.js 15, TypeScript, Prisma 6, and MySQL 8.
+
+### What's New in 22.12.0 — Payroll, HR & Productivity Improvements
+- **Overtime formula** fixed: now calculated on basic salary only (Saudi Labor Law compliance).
+- **Total Salary tile** added to employee Compensation tab.
+- **Dolibarr sync field selector**: choose which fields to update before syncing.
+- **Project edit** bug fixed for Next.js 15 async params.
+- **Task default status** changed to "In Progress" for quick-add tasks.
+- Payroll action buttons moved to right-align.
 
 ### What's New in 22.5.3 — Stability & Version Alignment
 - Confirms **22.5.2** features as stable: Account Invoice Report, orphan purge, and sidebar double-render fix.
@@ -521,7 +529,7 @@ Proprietary software — All rights reserved by Hexa Steel®.
 
 ---
 
-**Version**: 22.5.3
-**Last Updated**: April 29, 2026
+**Version**: 22.12.0
+**Last Updated**: May 4, 2026
 **Repository**: https://github.com/refedo/OTS
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexa-steel-ots",
-  "version": "22.11.0",
+  "version": "22.12.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/api/hr/employees/sync/route.ts
+++ b/src/app/api/hr/employees/sync/route.ts
@@ -16,9 +16,11 @@ import { checkPermission } from '@/lib/permission-checker';
 import {
   runDolibarrEmployeeSync,
   ReconciliationRequiredError,
+  SYNCABLE_FIELDS,
+  type SyncableField,
 } from '@/lib/services/hr/sync-dolibarr-employees';
 
-export async function POST() {
+export async function POST(req: Request) {
   const store = await cookies();
   const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
   const session = token ? await verifySession(token) : null;
@@ -27,8 +29,20 @@ export async function POST() {
   const canSync = await checkPermission('hr.employee.sync');
   if (!canSync) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
 
+  let selectedFields: SyncableField[] | undefined;
   try {
-    const result = await runDolibarrEmployeeSync({ triggeredById: session.sub });
+    const body = await req.json().catch(() => ({}));
+    if (Array.isArray(body.selectedFields) && body.selectedFields.length > 0) {
+      selectedFields = body.selectedFields.filter((f: unknown): f is SyncableField =>
+        typeof f === 'string' && (SYNCABLE_FIELDS as readonly string[]).includes(f)
+      );
+    }
+  } catch {
+    // no body or invalid JSON — run full sync
+  }
+
+  try {
+    const result = await runDolibarrEmployeeSync({ triggeredById: session.sub, selectedFields });
     return NextResponse.json(result);
   } catch (error) {
     if (error instanceof ReconciliationRequiredError) {

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -282,7 +282,7 @@ export async function POST(req: Request) {
       taskData.priority = priorityMap[parsed.data.priority] || 'Medium';
     }
     
-    if (parsed.data.status) taskData.status = parsed.data.status;
+    taskData.status = parsed.data.status ?? 'In Progress';
     
     // Auto-mark as private if user is assigning to themselves, or if explicitly set
     if (parsed.data.isPrivate !== undefined) {

--- a/src/app/changelog/_page-client.tsx
+++ b/src/app/changelog/_page-client.tsx
@@ -23,10 +23,65 @@ type ChangelogVersion = {
 // Version order: Most recent first
 const hardcodedVersions: ChangelogVersion[] = [
   {
+    version: '22.12.0',
+    date: 'May 4, 2026',
+    type: 'minor',
+    status: 'current',
+    mainTitle: 'Payroll, HR & Productivity Improvements',
+    highlights: [
+      'Overtime now calculated on basic salary only (Saudi Labor Law compliance) — was incorrectly using total monthly gross.',
+      'Employee Compensation tab gains a live Total Salary tile summing all components.',
+      'Dolibarr sync gains a field selector dialog — choose exactly which fields to update, preventing accidental overwrites of local edits.',
+      'Project edit page fixed for Next.js 15 — no more redirect to projects list on click.',
+      'Tasks created via the quick-add (+) button now start as "In Progress" by default.',
+    ],
+    changes: {
+      added: [
+        'Total Salary tile in employee Compensation tab: live read-only sum of basic + housing + transport + mobile + food + other allowances, updates as you type.',
+        'Dolibarr sync field selector: clicking "Sync from Dolibarr" opens a dialog to select which fields to update, grouped by Identity, Documents, Employment, Compensation, and Banking.',
+      ],
+      fixed: [
+        'Payroll overtime formula: overtime now uses basic salary only for hourly rate calculation (Saudi Labor Law compliance).',
+        'Project edit page: updated to Next.js 15 async params pattern — clicking "Edit Project" no longer silently redirects all users to the projects list.',
+        'Task default status: tasks created via quick-add (+) now start as "In Progress" instead of "Pending".',
+      ],
+      changed: [
+        'Payroll action buttons moved to right-align for consistent toolbar layout.',
+        'Version bumped to 22.12.0',
+      ],
+    },
+  },
+  {
+    version: '22.11.0',
+    date: 'May 3, 2026',
+    type: 'minor',
+    status: 'previous',
+    mainTitle: 'Concentration Risk Dashboard (CEO Arena)',
+    highlights: [
+      'New Concentration Risk Dashboard in CEO Arena with six risk dimensions: customer, project, segment, supplier, operational dependency, revenue timing.',
+      'Executive Risk Summary cards, Risk Heatmap, and per-dimension detail tabs.',
+      'Revenue Timing Chart with Recharts BarChart and CV interpretation.',
+      'CSV export, full RBAC, and sidebar entry.',
+    ],
+    changes: {
+      added: [
+        'Concentration Risk Dashboard at /concentration-risk with RBAC (concentrationRisk.view, concentrationRisk.manage, concentrationRisk.export).',
+        'Six risk dimensions with deterministic scoring 0–100: customer (HHI + top shares), project (largest %), segment (HHI), supplier (LCR spend), operational dependency, revenue timing (CV).',
+        'Revenue Timing Chart (Recharts BarChart with reference line and CV interpretation).',
+        'CSV Export at GET /api/concentration-risk/export.',
+        'ProjectSegment model + migration seeding 7 default segments; nullable segmentId FK on Project.',
+      ],
+      fixed: [],
+      changed: [
+        'Version bumped to 22.11.0',
+      ],
+    },
+  },
+  {
     version: '22.10.3',
     date: 'May 3, 2026',
     type: 'patch',
-    status: 'current',
+    status: 'previous',
     mainTitle: 'IMS PDF Polish — White Logo, Form References, Full Field Coverage',
     highlights: [
       'PDF logo aspect ratio fixed: dynamic sizing from natural image dimensions instead of hardcoded 20×15mm — logos no longer distorted.',

--- a/src/app/projects/[id]/edit/page.tsx
+++ b/src/app/projects/[id]/edit/page.tsx
@@ -14,7 +14,8 @@ export const metadata: Metadata = {
 };
 
 
-export default async function EditProjectPage({ params }: { params: { id: string } }) {
+export default async function EditProjectPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
   const cookieName = process.env.COOKIE_NAME || 'ots_session';
   const store = await cookies();
   const token = store.get(cookieName)?.value;
@@ -26,12 +27,12 @@ export default async function EditProjectPage({ params }: { params: { id: string
 
   const hasPermission = await checkPermission('projects.edit');
   if (!hasPermission) {
-    redirect('/projects');
+    redirect(`/projects/${id}`);
   }
 
   // Fetch the project
   const projectData = await db.project.findUnique({
-    where: { id: params.id },
+    where: { id },
     include: {
       client: true,
       projectManager: true,
@@ -103,7 +104,7 @@ export default async function EditProjectPage({ params }: { params: { id: string
       <div className="container mx-auto p-6 lg:p-8 space-y-8 max-lg:pt-20 max-w-6xl">
         {/* Header */}
         <div className="flex items-center gap-4">
-          <Link href={`/projects/${params.id}`}>
+          <Link href={`/projects/${id}`}>
             <Button variant="ghost" size="icon">
               <ArrowLeft className="size-5" />
             </Button>

--- a/src/components/hr/employee-form.tsx
+++ b/src/components/hr/employee-form.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { Button } from '@/components/ui/button';
@@ -227,6 +227,12 @@ export function EmployeeForm({
       transferType: (initial as Record<string, unknown>)?.transferType as string ?? '',
     },
   });
+
+  const salaryFields = useWatch({
+    control: form.control,
+    name: ['basicSalary', 'housingAllowance', 'transportAllowance', 'mobileAllowance', 'foodAllowance', 'otherAllowances'],
+  });
+  const totalSalary = salaryFields.reduce((sum, v) => sum + (parseFloat(v as string) || 0), 0);
 
   const onSubmit = async (values: FormValues) => {
     setSubmitting(true);
@@ -637,6 +643,14 @@ export function EmployeeForm({
                 <div>
                   <Label>Other allowances</Label>
                   <Input {...form.register('otherAllowances')} />
+                </div>
+                <div className="col-span-2">
+                  <div className="rounded-lg bg-slate-50 border border-slate-200 px-4 py-3 flex items-center justify-between">
+                    <span className="text-sm font-medium text-slate-600">Total Salary (SAR)</span>
+                    <span className="text-lg font-bold text-slate-800">
+                      {totalSalary.toLocaleString('en-SA-u-ca-gregory', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                    </span>
+                  </div>
                 </div>
                 <div className="col-span-2 border-t pt-4 mt-2">
                   <div className="flex items-center gap-2 mb-3">

--- a/src/components/hr/employee-sync-client.tsx
+++ b/src/components/hr/employee-sync-client.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
-import { Loader2, RefreshCw, AlertTriangle } from 'lucide-react';
+import { Loader2, RefreshCw, AlertTriangle, Settings2 } from 'lucide-react';
 
 type LogRow = {
   id: string;
@@ -36,18 +36,84 @@ const STATUS_COLOURS: Record<string, string> = {
   RUNNING: 'bg-blue-100 text-blue-800',
 };
 
+const ALL_FIELDS: Array<{ key: string; label: string; group: string }> = [
+  { key: 'fullNameEn', label: 'Full Name (English)', group: 'Identity' },
+  { key: 'fullNameAr', label: 'Full Name (Arabic)', group: 'Identity' },
+  { key: 'nationalId', label: 'National ID', group: 'Identity' },
+  { key: 'nationality', label: 'Nationality', group: 'Identity' },
+  { key: 'gender', label: 'Gender', group: 'Identity' },
+  { key: 'maritalStatus', label: 'Marital Status', group: 'Identity' },
+  { key: 'passportNumber', label: 'Passport Number', group: 'Documents' },
+  { key: 'iqamaUrl', label: 'Iqama URL', group: 'Documents' },
+  { key: 'passportUrl', label: 'Passport URL', group: 'Documents' },
+  { key: 'boarderNumber', label: 'Boarder Number', group: 'Documents' },
+  { key: 'sponsorNumber', label: 'Sponsor Number', group: 'Documents' },
+  { key: 'dateOfJoining', label: 'Date of Joining', group: 'Employment' },
+  { key: 'dateOfLeaving', label: 'Date of Leaving', group: 'Employment' },
+  { key: 'status', label: 'Employment Status', group: 'Employment' },
+  { key: 'occupation', label: 'Occupation (EN)', group: 'Employment' },
+  { key: 'occupationAr', label: 'Occupation (AR)', group: 'Employment' },
+  { key: 'department', label: 'Department', group: 'Employment' },
+  { key: 'employeeNo', label: 'Employee Number', group: 'Employment' },
+  { key: 'contractType', label: 'Contract Type', group: 'Employment' },
+  { key: 'contractEndDate', label: 'Contract End Date', group: 'Employment' },
+  { key: 'contractDuration', label: 'Contract Duration', group: 'Employment' },
+  { key: 'workingLocation', label: 'Working Location', group: 'Employment' },
+  { key: 'transferType', label: 'Transfer Type', group: 'Employment' },
+  { key: 'gosiSubscriptionNo', label: 'GOSI Subscription #', group: 'Employment' },
+  { key: 'basicSalary', label: 'Basic Salary', group: 'Compensation' },
+  { key: 'bankName', label: 'Bank Name', group: 'Banking' },
+  { key: 'bankIban', label: 'IBAN', group: 'Banking' },
+];
+
+const GROUPS = ['Identity', 'Documents', 'Employment', 'Compensation', 'Banking'];
+
 export function EmployeeSyncClient({ logs, reconciliationComplete }: Props) {
   const router = useRouter();
   const [syncing, setSyncing] = useState(false);
   const [result, setResult] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [showFieldSelector, setShowFieldSelector] = useState(false);
+  const [selectedFields, setSelectedFields] = useState<Set<string>>(
+    () => new Set(ALL_FIELDS.map(f => f.key))
+  );
+
+  const toggleField = (key: string) => {
+    setSelectedFields(prev => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  const toggleGroup = (group: string) => {
+    const groupKeys = ALL_FIELDS.filter(f => f.group === group).map(f => f.key);
+    const allSelected = groupKeys.every(k => selectedFields.has(k));
+    setSelectedFields(prev => {
+      const next = new Set(prev);
+      for (const k of groupKeys) {
+        if (allSelected) next.delete(k);
+        else next.add(k);
+      }
+      return next;
+    });
+  };
 
   const onSync = async () => {
     setSyncing(true);
     setError(null);
     setResult(null);
+    setShowFieldSelector(false);
     try {
-      const res = await fetch('/api/hr/employees/sync', { method: 'POST' });
+      const body = selectedFields.size === ALL_FIELDS.length
+        ? {}
+        : { selectedFields: Array.from(selectedFields) };
+      const res = await fetch('/api/hr/employees/sync', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
       const data = await res.json();
       if (!res.ok) {
         throw new Error(data.error || data.message || `Sync failed (HTTP ${res.status})`);
@@ -73,7 +139,7 @@ export function EmployeeSyncClient({ logs, reconciliationComplete }: Props) {
           </p>
         </div>
         {reconciliationComplete ? (
-          <Button onClick={onSync} disabled={syncing} size="lg">
+          <Button onClick={() => setShowFieldSelector(true)} disabled={syncing} size="lg">
             {syncing ? (
               <Loader2 className="mr-2 h-4 w-4 animate-spin" />
             ) : (
@@ -102,6 +168,73 @@ export function EmployeeSyncClient({ logs, reconciliationComplete }: Props) {
             </div>
           </CardContent>
         </Card>
+      )}
+
+      {/* Field Selector Dialog */}
+      {showFieldSelector && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="bg-white rounded-2xl shadow-xl w-full max-w-2xl mx-4 max-h-[90vh] flex flex-col">
+            <div className="flex items-center justify-between px-6 py-4 border-b">
+              <div>
+                <h2 className="text-lg font-semibold flex items-center gap-2">
+                  <Settings2 className="h-5 w-5 text-slate-500" />
+                  Select Fields to Sync
+                </h2>
+                <p className="text-sm text-muted-foreground mt-0.5">
+                  Choose which fields will be updated from Dolibarr. Unselected fields keep their current OTS values.
+                </p>
+              </div>
+            </div>
+            <div className="overflow-y-auto flex-1 px-6 py-4 space-y-5">
+              {GROUPS.map(group => {
+                const groupFields = ALL_FIELDS.filter(f => f.group === group);
+                const allSelected = groupFields.every(f => selectedFields.has(f.key));
+                const someSelected = groupFields.some(f => selectedFields.has(f.key));
+                return (
+                  <div key={group}>
+                    <div className="flex items-center gap-2 mb-2">
+                      <input
+                        type="checkbox"
+                        checked={allSelected}
+                        ref={el => { if (el) el.indeterminate = !allSelected && someSelected; }}
+                        onChange={() => toggleGroup(group)}
+                        className="h-4 w-4 rounded"
+                      />
+                      <span className="text-sm font-semibold text-slate-700">{group}</span>
+                    </div>
+                    <div className="ml-6 grid grid-cols-2 gap-1.5">
+                      {groupFields.map(f => (
+                        <label key={f.key} className="flex items-center gap-2 cursor-pointer">
+                          <input
+                            type="checkbox"
+                            checked={selectedFields.has(f.key)}
+                            onChange={() => toggleField(f.key)}
+                            className="h-3.5 w-3.5 rounded"
+                          />
+                          <span className="text-sm text-slate-600">{f.label}</span>
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+            <div className="px-6 py-4 border-t flex items-center justify-between gap-3">
+              <span className="text-sm text-muted-foreground">
+                {selectedFields.size} of {ALL_FIELDS.length} fields selected
+              </span>
+              <div className="flex gap-2">
+                <Button variant="outline" onClick={() => setShowFieldSelector(false)}>
+                  Cancel
+                </Button>
+                <Button onClick={onSync} disabled={selectedFields.size === 0}>
+                  <RefreshCw className="h-4 w-4 mr-2" />
+                  Run Sync
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
       )}
 
       {result && (
@@ -143,7 +276,7 @@ export function EmployeeSyncClient({ logs, reconciliationComplete }: Props) {
                 )}
                 {logs.map((l) => (
                   <tr key={l.id} className="border-b">
-                    <td className="p-2">{new Date(l.startedAt).toLocaleString()}</td>
+                    <td className="p-2">{new Date(l.startedAt).toLocaleString('en-SA-u-ca-gregory')}</td>
                     <td className="p-2">
                       <span
                         className={`px-2 py-0.5 rounded text-xs ${STATUS_COLOURS[l.status] ?? ''}`}

--- a/src/components/hr/payroll-period-detail-client.tsx
+++ b/src/components/hr/payroll-period-detail-client.tsx
@@ -347,7 +347,7 @@ export function PayrollPeriodDetailClient({
 
         {/* Action Buttons */}
         <div className="rounded-2xl border bg-white shadow-sm p-4">
-          <div className="flex flex-wrap gap-2 items-center">
+          <div className="flex flex-wrap gap-2 items-center justify-end">
             {canRecalc && (
               <Button
                 onClick={() => run('calculate', `/api/hr/payroll-periods/${period.id}/calculate`)}

--- a/src/lib/services/hr/payroll-calculator.ts
+++ b/src/lib/services/hr/payroll-calculator.ts
@@ -221,7 +221,9 @@ export async function calculatePayrollPeriod(
     const { withPermission, withoutPermission } = sumAbsences(attendanceRows);
 
     const dailyRate = computeDailyRate(monthlyGross, settings, calendarDays, workingDaysInMonth);
-    const hourlyRate = emp.standardDailyHours > 0 ? dailyRate / emp.standardDailyHours : 0;
+    // Overtime is calculated on basic salary only (Saudi Labor Law compliance)
+    const basicDailyRate = computeDailyRate(basic, settings, calendarDays, workingDaysInMonth);
+    const hourlyRate = emp.standardDailyHours > 0 ? basicDailyRate / emp.standardDailyHours : 0;
 
     const unpaidLeaveDeduction = round2(leaves.unpaid * dailyRate);
     const halfPaidDeduction = round2(leaves.halfPaid * dailyRate * 0.5);

--- a/src/lib/services/hr/sync-dolibarr-employees.ts
+++ b/src/lib/services/hr/sync-dolibarr-employees.ts
@@ -236,9 +236,21 @@ function projectFromDolibarr(
 // SYNC ENTRY POINT
 // ============================================================================
 
+export const SYNCABLE_FIELDS = [
+  'fullNameEn', 'fullNameAr', 'nationalId', 'dateOfJoining', 'dateOfLeaving',
+  'status', 'occupation', 'department', 'basicSalary', 'bankName', 'bankIban',
+  'nationality', 'employeeNo', 'boarderNumber', 'maritalStatus', 'occupationAr',
+  'gosiSubscriptionNo', 'contractEndDate', 'contractDuration', 'passportNumber',
+  'iqamaUrl', 'passportUrl', 'sponsorNumber', 'contractType', 'workingLocation',
+  'transferType', 'gender',
+] as const;
+
+export type SyncableField = typeof SYNCABLE_FIELDS[number];
+
 export interface RunSyncOptions {
   triggeredById: string;
   client?: DolibarrClient;
+  selectedFields?: SyncableField[];
 }
 
 export async function runDolibarrEmployeeSync(
@@ -346,35 +358,10 @@ export async function runDolibarrEmployeeSync(
             lastSyncedFromDolibarrAt: new Date(),
             updatedById: opts.triggeredById,
           };
-          const fields: Array<keyof typeof projection> = [
-            'fullNameEn',
-            'fullNameAr',
-            'nationalId',
-            'dateOfJoining',
-            'dateOfLeaving',
-            'status',
-            'occupation',
-            'department',
-            'basicSalary',
-            'bankName',
-            'bankIban',
-            'nationality',
-            'employeeNo',
-            'boarderNumber',
-            'maritalStatus',
-            'occupationAr',
-            'gosiSubscriptionNo',
-            'contractEndDate',
-            'contractDuration',
-            'passportNumber',
-            'iqamaUrl',
-            'passportUrl',
-            'sponsorNumber',
-            'contractType',
-            'workingLocation',
-            'transferType',
-            'gender',
-          ];
+          const allFields: Array<keyof typeof projection> = [...SYNCABLE_FIELDS];
+          const fields = opts.selectedFields
+            ? allFields.filter(f => opts.selectedFields!.includes(f as SyncableField))
+            : allFields;
           let anyChange = false;
           for (const field of fields) {
             if (edited.includes(field as string)) {

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -9,8 +9,8 @@ const { version: pkgVersion } = require('../../package.json') as { version: stri
 
 export const APP_VERSION = {
   version: pkgVersion,
-  date: 'April 29, 2026',
-  type: 'patch' as const,
+  date: 'May 4, 2026',
+  type: 'minor' as const,
   name: 'Hexa Steel Operation Tracking System',
 };
 


### PR DESCRIPTION
- Overtime calc: use basic salary only for hourly rate (Saudi Labor Law compliance)
- Employee compensation tab: live Total Salary tile (basic + all allowances)
- Dolibarr sync: field selector dialog — choose which fields update, prevent overwrites
- Project edit page: fix Next.js 15 async params (was redirecting all users to /projects)
- Tasks quick-add: default status changed from Pending to In Progress
- Payroll action buttons: moved to right-align
- Version bumped to 22.12.0

https://claude.ai/code/session_015ieQmtjmSFCnKUQzMuZDwi