### PR TITLE
Multi-scope project wizard & tracker redesign (v22.13.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [22.13.0] - 2026-05-06
+
+### Multi-Scope Project Wizard & Tracker Redesign
+
+#### Added
+- **Wizard Step 3 — Scope Definition**: per-building accordion with scope type checkboxes (Steel always on) and scope-specific spec forms (quantity, RAL, panel thickness, rib height, shear studs, metal work line items).
+- **Wizard Step 4 — Activities per Scope**: toggle activity applicability per scope with default matrix (Steel: all 7; Sheeting/Deck: detailing, procurement, dispatch, erection; Metal Works: detailing, procurement, production, coating, dispatch, erection; Other: procurement, dispatch).
+- **Building location field** added to wizard Step 2 and stored in DB.
+- **Project Scope Summary page** at `/projects/[id]/scope` — per-building scope cards with RAL swatches, spec chips, activity badges, and back navigation.
+- **Scope section** added to Project Details page — collapsible building+scope cards linked to the scope summary page.
+- **Paintable Area tile** in Assembly Parts KPI strip: total netAreaTotal minus area of parts named PURLIN (case-insensitive).
+- **DB migration v22.13**: adds 15 new fields to `ScopeOfWork` (quantity, unit, ralColor, panelThickness, ribHeight, upperSheetThick, lowerSheetThick, panelProfile, deckProfile, hasShearStuds, shearStudQty, shearStudSpecs, metalWorkItems, coatingSameAsProject, scopeCoatingSystem) and `location` to `Building`.
+- **Backfill migration v22.14**: populates `quantity = building.weight` and `unit = 'ton'` for existing steel ScopeOfWork records with no quantity set.
+
+#### Changed
+- **Project tracker** redesigned: building group header rows (collapsible) with one scope sub-row per scope. Activity columns show N/A for non-applicable scopes (based on `BuildingActivity.isApplicable`).
+- **Scope-of-work API** Zod schemas extended to accept all new spec fields (POST, PUT, and new PATCH endpoint).
+- Version bumped to **22.13.0**
+
+---
+
 ## [22.12.0] - 2026-05-04
 
 ### Payroll, HR & Productivity Improvements

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexa-steel-ots",
-  "version": "22.12.0",
+  "version": "22.13.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/prisma/manual_migrations/v22_13_scope_fields.sql
+++ b/prisma/manual_migrations/v22_13_scope_fields.sql
@@ -1,0 +1,132 @@
+-- ============================================================
+-- v22.13.0 — Per-building scope detail fields
+-- Adds location to Building; adds quantity, spec, and coating
+-- fields to ScopeOfWork to support multi-scope projects.
+-- Safe for re-runs via conditional stored procedure pattern.
+-- ============================================================
+
+DROP PROCEDURE IF EXISTS add_column_if_not_exists;
+DELIMITER $$
+CREATE PROCEDURE add_column_if_not_exists(
+  IN p_table VARCHAR(64),
+  IN p_column VARCHAR(64),
+  IN p_definition TEXT
+)
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME   = p_table
+      AND COLUMN_NAME  = p_column
+  ) THEN
+    SET @ddl = CONCAT('ALTER TABLE `', p_table, '` ADD COLUMN `', p_column, '` ', p_definition);
+    PREPARE stmt FROM @ddl;
+    EXECUTE stmt;
+    DEALLOCATE PREPARE stmt;
+  END IF;
+END$$
+DELIMITER ;
+
+-- ── Building ────────────────────────────────────────────────
+CALL add_column_if_not_exists(
+  'Building',
+  'location',
+  'VARCHAR(500) NULL'
+);
+
+-- ── ScopeOfWork — quantity & unit ───────────────────────────
+CALL add_column_if_not_exists(
+  'ScopeOfWork',
+  'quantity',
+  'DECIMAL(10,2) NULL'
+);
+
+CALL add_column_if_not_exists(
+  'ScopeOfWork',
+  'unit',
+  'VARCHAR(20) NULL'
+);
+
+-- ── ScopeOfWork — sandwich panel (roof/wall sheeting) ───────
+CALL add_column_if_not_exists(
+  'ScopeOfWork',
+  'ralColor',
+  'VARCHAR(20) NULL'
+);
+
+CALL add_column_if_not_exists(
+  'ScopeOfWork',
+  'panelThickness',
+  'INT NULL'
+);
+
+CALL add_column_if_not_exists(
+  'ScopeOfWork',
+  'ribHeight',
+  'INT NULL'
+);
+
+CALL add_column_if_not_exists(
+  'ScopeOfWork',
+  'upperSheetThick',
+  'DECIMAL(5,2) NULL'
+);
+
+CALL add_column_if_not_exists(
+  'ScopeOfWork',
+  'lowerSheetThick',
+  'DECIMAL(5,2) NULL'
+);
+
+CALL add_column_if_not_exists(
+  'ScopeOfWork',
+  'panelProfile',
+  'VARCHAR(20) NULL'
+);
+
+-- ── ScopeOfWork — deck panel ────────────────────────────────
+CALL add_column_if_not_exists(
+  'ScopeOfWork',
+  'deckProfile',
+  'VARCHAR(100) NULL'
+);
+
+CALL add_column_if_not_exists(
+  'ScopeOfWork',
+  'hasShearStuds',
+  'TINYINT(1) NOT NULL DEFAULT 0'
+);
+
+CALL add_column_if_not_exists(
+  'ScopeOfWork',
+  'shearStudQty',
+  'INT NULL'
+);
+
+CALL add_column_if_not_exists(
+  'ScopeOfWork',
+  'shearStudSpecs',
+  'VARCHAR(255) NULL'
+);
+
+-- ── ScopeOfWork — metal works custom items ──────────────────
+CALL add_column_if_not_exists(
+  'ScopeOfWork',
+  'metalWorkItems',
+  'JSON NULL'
+);
+
+-- ── ScopeOfWork — per-scope coating override ────────────────
+CALL add_column_if_not_exists(
+  'ScopeOfWork',
+  'coatingSameAsProject',
+  'TINYINT(1) NOT NULL DEFAULT 1'
+);
+
+CALL add_column_if_not_exists(
+  'ScopeOfWork',
+  'scopeCoatingSystem',
+  'JSON NULL'
+);
+
+DROP PROCEDURE IF EXISTS add_column_if_not_exists;

--- a/prisma/manual_migrations/v22_14_backfill_scope_quantity.sql
+++ b/prisma/manual_migrations/v22_14_backfill_scope_quantity.sql
@@ -1,0 +1,17 @@
+-- ============================================================
+-- v22.14.0 — Backfill steel scope quantities from building weight
+-- For existing Steel ScopeOfWork records with no quantity set,
+-- populate quantity from Building.weight and set unit = 'ton'.
+-- Safe to run multiple times (WHERE quantity IS NULL guard).
+-- ============================================================
+
+UPDATE ScopeOfWork sow
+JOIN Building b ON sow.buildingId = b.id
+SET
+  sow.quantity = b.weight,
+  sow.unit     = 'ton'
+WHERE
+  sow.scopeType  = 'steel'
+  AND sow.quantity IS NULL
+  AND b.weight IS NOT NULL
+  AND b.deletedAt IS NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -656,6 +656,7 @@ model Building {
   name                   String
   description            String?
   weight                 Float? // Building weight in tons
+  location               String? @db.VarChar(500)
   project                Project                 @relation(fields: [projectId], references: [id], onDelete: Cascade)
   assemblyParts          AssemblyPart[]
   rfiRequests            RFIRequest[]
@@ -717,6 +718,31 @@ model ScopeOfWork {
   scopeLabel    String // Display name
   customLabel   String? // User-defined label when scopeType is "other"
   specification String? @db.Text // BoQ specification text
+
+  // Quantity & unit of measurement
+  quantity Decimal? @db.Decimal(10, 2)
+  unit     String?  @db.VarChar(20) // ton, m2, Lm, LS
+
+  // Sandwich panel fields (roof_sheeting / wall_sheeting)
+  ralColor       String?  @db.VarChar(20)
+  panelThickness Int?
+  ribHeight      Int?
+  upperSheetThick Decimal? @db.Decimal(5, 2)
+  lowerSheetThick Decimal? @db.Decimal(5, 2)
+  panelProfile   String?  @db.VarChar(20) // flat | ribbed
+
+  // Deck panel fields
+  deckProfile   String?  @db.VarChar(100)
+  hasShearStuds Boolean  @default(false)
+  shearStudQty  Int?
+  shearStudSpecs String? @db.VarChar(255)
+
+  // Metal works — JSON array [{name, unit, quantity}]
+  metalWorkItems Json?
+
+  // Per-scope coating override (steel & metal works)
+  coatingSameAsProject Boolean @default(true)
+  scopeCoatingSystem   Json?   // [{coatName, microns, ralNumber}]
 
   project       Project            @relation(fields: [projectId], references: [id], onDelete: Cascade)
   building      Building           @relation(fields: [buildingId], references: [id], onDelete: Cascade)

--- a/src/app/api/buildings/route.ts
+++ b/src/app/api/buildings/route.ts
@@ -64,7 +64,7 @@ export async function POST(req: Request) {
     }
 
     const body = await req.json();
-    const { projectId, name, designation, description, weight } = body;
+    const { projectId, name, designation, description, weight, location } = body;
 
     if (!projectId || !name || !designation) {
       return NextResponse.json(
@@ -80,6 +80,7 @@ export async function POST(req: Request) {
         designation,
         description: description || null,
         weight: weight ? parseFloat(weight) : null,
+        location: location || null,
       },
       include: {
         project: { select: { projectNumber: true } },

--- a/src/app/api/production/assembly-parts/route.ts
+++ b/src/app/api/production/assembly-parts/route.ts
@@ -127,16 +127,23 @@ export async function GET(req: Request) {
     const total = await prisma.assemblyPart.count({ where });
 
     // Get aggregated totals for all matching parts (not just current page)
-    const aggregates = await prisma.assemblyPart.aggregate({
-      where,
-      _sum: {
-        netWeightTotal: true,
-        netAreaTotal: true,
-      },
-      _count: {
-        _all: true,
-      },
-    });
+    const [aggregates, purlinAggregates] = await Promise.all([
+      prisma.assemblyPart.aggregate({
+        where,
+        _sum: {
+          netWeightTotal: true,
+          netAreaTotal: true,
+        },
+        _count: {
+          _all: true,
+        },
+      }),
+      // Purlin area: parts named "PURLIN" — used to compute paintable area
+      prisma.assemblyPart.aggregate({
+        where: { ...where, name: { equals: 'PURLIN', mode: 'insensitive' } },
+        _sum: { netAreaTotal: true },
+      }),
+    ]);
 
     // Get status counts for all matching parts
     const statusCounts = await prisma.assemblyPart.groupBy({
@@ -230,6 +237,8 @@ export async function GET(req: Request) {
       totals: {
         totalWeight: Number(aggregates._sum.netWeightTotal) || 0,
         totalArea: Number(aggregates._sum.netAreaTotal) || 0,
+        purlinArea: Number(purlinAggregates._sum.netAreaTotal) || 0,
+        paintableArea: (Number(aggregates._sum.netAreaTotal) || 0) - (Number(purlinAggregates._sum.netAreaTotal) || 0),
         statusCounts: statusCountMap,
       },
     });

--- a/src/app/api/project-tracker/route.ts
+++ b/src/app/api/project-tracker/route.ts
@@ -31,6 +31,18 @@ export const GET = withApiContext(async (req, session) => {
             name: true,
             designation: true,
             weight: true,
+            scopeOfWorks: {
+              select: {
+                id: true,
+                scopeType: true,
+                scopeLabel: true,
+                activities: {
+                  select: { activityType: true, isApplicable: true },
+                  orderBy: { sortOrder: 'asc' },
+                },
+              },
+              orderBy: { createdAt: 'asc' },
+            },
           },
           orderBy: { createdAt: 'asc' },
         },
@@ -96,20 +108,36 @@ export const GET = withApiContext(async (req, session) => {
             }
             const assemblyTonnage = rawTotalKg / 1000;
 
+            // Build per-scope activity lists using BuildingActivity.isApplicable flags.
+            // Fall back to a single all-applicable steel scope for legacy buildings.
+            const dbScopes = building.scopeOfWorks;
+            const scopes = dbScopes.length > 0
+              ? dbScopes.map((scope) => {
+                  const applicableMap = new Map<string, boolean>(
+                    scope.activities.map((a) => [a.activityType, a.isApplicable])
+                  );
+                  const hasActivityConfig = scope.activities.length > 0;
+                  const scopeActivities = activities.map((act) => ({
+                    ...act,
+                    isApplicable: hasActivityConfig
+                      ? (applicableMap.get(act.activityType) ?? false)
+                      : true,
+                  }));
+                  const applicable = scopeActivities.filter((a) => a.isApplicable);
+                  const scopeProgress = applicable.length > 0
+                    ? Math.round(applicable.reduce((s, a) => s + a.percentage, 0) / applicable.length)
+                    : 0;
+                  return { id: scope.id, scopeType: scope.scopeType, scopeLabel: scope.scopeLabel, activities: scopeActivities, overallProgress: scopeProgress };
+                })
+              : [{ id: `${building.id}-default`, scopeType: 'steel', scopeLabel: 'Steel', activities: activities.map((a) => ({ ...a, isApplicable: true })), overallProgress: totalProgress }];
+
             return {
               id: building.id,
               name: building.name,
               designation: building.designation,
               weight: building.weight,
               assemblyTonnage,
-              scopes: [
-                {
-                  id: `${building.id}-default`,
-                  scopeType: 'steel',
-                  scopeLabel: 'Steel',
-                  activities,
-                },
-              ],
+              scopes,
               overallProgress: totalProgress,
               hasBlocked,
               currentStage: currentStage

--- a/src/app/api/projects/[id]/buildings/[buildingId]/route.ts
+++ b/src/app/api/projects/[id]/buildings/[buildingId]/route.ts
@@ -9,6 +9,8 @@ const buildingSchema = z.object({
   designation: z.string().min(2).max(5).regex(/^[A-Z0-9]+$/).optional(),
   name: z.string().min(1).optional(),
   description: z.string().nullable().optional(),
+  location: z.string().max(500).nullable().optional(),
+  weight: z.number().nullable().optional(),
 }).partial();
 
 export async function GET(

--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -135,7 +135,15 @@ export async function GET(
       client: true,
       projectManager: { select: { id: true, name: true, position: true, email: true } },
       salesEngineer: { select: { id: true, name: true, email: true } },
-      buildings: { orderBy: { designation: 'asc' } },
+      buildings: {
+        orderBy: { designation: 'asc' },
+        include: {
+          scopeOfWorks: {
+            include: { activities: { orderBy: { sortOrder: 'asc' } } },
+            orderBy: { createdAt: 'asc' },
+          },
+        },
+      },
       tasks: {
         select: {
           id: true,

--- a/src/app/api/scope-of-work/[id]/route.ts
+++ b/src/app/api/scope-of-work/[id]/route.ts
@@ -8,6 +8,34 @@ const updateSchema = z.object({
   scopeLabel: z.string().min(1).optional(),
   customLabel: z.string().optional().nullable(),
   specification: z.string().optional().nullable(),
+  // Quantity & unit
+  quantity: z.number().optional().nullable(),
+  unit: z.enum(['ton', 'm2', 'Lm', 'LS']).optional().nullable(),
+  // Sandwich panel
+  ralColor: z.string().max(20).optional().nullable(),
+  panelThickness: z.number().int().optional().nullable(),
+  ribHeight: z.number().int().optional().nullable(),
+  upperSheetThick: z.number().optional().nullable(),
+  lowerSheetThick: z.number().optional().nullable(),
+  panelProfile: z.enum(['flat', 'ribbed']).optional().nullable(),
+  // Deck panel
+  deckProfile: z.string().max(100).optional().nullable(),
+  hasShearStuds: z.boolean().optional(),
+  shearStudQty: z.number().int().optional().nullable(),
+  shearStudSpecs: z.string().max(255).optional().nullable(),
+  // Metal works
+  metalWorkItems: z.array(z.object({
+    name: z.string().min(1),
+    unit: z.string().min(1),
+    quantity: z.number(),
+  })).optional().nullable(),
+  // Per-scope coating
+  coatingSameAsProject: z.boolean().optional(),
+  scopeCoatingSystem: z.array(z.object({
+    coatName: z.string(),
+    microns: z.number().optional(),
+    ralNumber: z.string().optional(),
+  })).optional().nullable(),
 });
 
 export const GET = withApiContext(async (req, session) => {
@@ -44,7 +72,11 @@ export const PUT = withApiContext(async (req, session) => {
 
     const scope = await prisma.scopeOfWork.update({
       where: { id },
-      data: parsed.data,
+      data: {
+        ...parsed.data,
+        metalWorkItems: parsed.data.metalWorkItems ?? undefined,
+        scopeCoatingSystem: parsed.data.scopeCoatingSystem ?? undefined,
+      },
     });
 
     return NextResponse.json(scope);
@@ -54,11 +86,36 @@ export const PUT = withApiContext(async (req, session) => {
   }
 });
 
+export const PATCH = withApiContext(async (req, session) => {
+  try {
+    const id = req.url.split('/scope-of-work/')[1]?.split('?')[0];
+    const body = await req.json();
+    const parsed = updateSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Invalid input', details: parsed.error.flatten() }, { status: 400 });
+    }
+
+    const scope = await prisma.scopeOfWork.update({
+      where: { id },
+      data: {
+        ...parsed.data,
+        metalWorkItems: parsed.data.metalWorkItems ?? undefined,
+        scopeCoatingSystem: parsed.data.scopeCoatingSystem ?? undefined,
+      },
+    });
+
+    return NextResponse.json(scope);
+  } catch (error) {
+    logger.error({ error }, 'Failed to patch scope of work');
+    return NextResponse.json({ error: 'Failed to patch scope of work' }, { status: 500 });
+  }
+});
+
 export const DELETE = withApiContext(async (req, session) => {
   try {
     const id = req.url.split('/scope-of-work/')[1]?.split('?')[0];
 
-    // Delete associated activities first (cascades), then the scope
     await prisma.scopeOfWork.delete({ where: { id } });
 
     return NextResponse.json({ success: true });

--- a/src/app/api/scope-of-work/route.ts
+++ b/src/app/api/scope-of-work/route.ts
@@ -4,24 +4,49 @@ import prisma from '@/lib/db';
 import { withApiContext } from '@/lib/api-utils';
 import { logger } from '@/lib/logger';
 
-const createSchema = z.object({
-  projectId: z.string().min(1),
+const scopeDetailSchema = z.object({
   buildingId: z.string().min(1),
   scopeType: z.enum(['steel', 'roof_sheeting', 'wall_sheeting', 'deck_panel', 'metal_work', 'other']),
   scopeLabel: z.string().min(1),
   customLabel: z.string().optional().nullable(),
   specification: z.string().optional().nullable(),
+  // Quantity & unit
+  quantity: z.number().optional().nullable(),
+  unit: z.enum(['ton', 'm2', 'Lm', 'LS']).optional().nullable(),
+  // Sandwich panel (roof/wall sheeting)
+  ralColor: z.string().max(20).optional().nullable(),
+  panelThickness: z.number().int().optional().nullable(),
+  ribHeight: z.number().int().optional().nullable(),
+  upperSheetThick: z.number().optional().nullable(),
+  lowerSheetThick: z.number().optional().nullable(),
+  panelProfile: z.enum(['flat', 'ribbed']).optional().nullable(),
+  // Deck panel
+  deckProfile: z.string().max(100).optional().nullable(),
+  hasShearStuds: z.boolean().optional(),
+  shearStudQty: z.number().int().optional().nullable(),
+  shearStudSpecs: z.string().max(255).optional().nullable(),
+  // Metal works
+  metalWorkItems: z.array(z.object({
+    name: z.string().min(1),
+    unit: z.string().min(1),
+    quantity: z.number(),
+  })).optional().nullable(),
+  // Per-scope coating
+  coatingSameAsProject: z.boolean().optional(),
+  scopeCoatingSystem: z.array(z.object({
+    coatName: z.string(),
+    microns: z.number().optional(),
+    ralNumber: z.string().optional(),
+  })).optional().nullable(),
+});
+
+const createSchema = scopeDetailSchema.extend({
+  projectId: z.string().min(1),
 });
 
 const bulkCreateSchema = z.object({
   projectId: z.string().min(1),
-  scopes: z.array(z.object({
-    buildingId: z.string().min(1),
-    scopeType: z.enum(['steel', 'roof_sheeting', 'wall_sheeting', 'deck_panel', 'metal_work', 'other']),
-    scopeLabel: z.string().min(1),
-    customLabel: z.string().optional().nullable(),
-    specification: z.string().optional().nullable(),
-  })),
+  scopes: z.array(scopeDetailSchema),
 });
 
 export const GET = withApiContext(async (req, session) => {
@@ -71,6 +96,21 @@ export const POST = withApiContext(async (req, session) => {
               scopeLabel: scope.scopeLabel,
               customLabel: scope.customLabel || null,
               specification: scope.specification || null,
+              quantity: scope.quantity ? scope.quantity : null,
+              unit: scope.unit || null,
+              ralColor: scope.ralColor || null,
+              panelThickness: scope.panelThickness || null,
+              ribHeight: scope.ribHeight || null,
+              upperSheetThick: scope.upperSheetThick || null,
+              lowerSheetThick: scope.lowerSheetThick || null,
+              panelProfile: scope.panelProfile || null,
+              deckProfile: scope.deckProfile || null,
+              hasShearStuds: scope.hasShearStuds ?? false,
+              shearStudQty: scope.shearStudQty || null,
+              shearStudSpecs: scope.shearStudSpecs || null,
+              metalWorkItems: scope.metalWorkItems || undefined,
+              coatingSameAsProject: scope.coatingSameAsProject ?? true,
+              scopeCoatingSystem: scope.scopeCoatingSystem || undefined,
             },
           })
         )
@@ -93,6 +133,21 @@ export const POST = withApiContext(async (req, session) => {
         scopeLabel: parsed.data.scopeLabel,
         customLabel: parsed.data.customLabel || null,
         specification: parsed.data.specification || null,
+        quantity: parsed.data.quantity ?? null,
+        unit: parsed.data.unit || null,
+        ralColor: parsed.data.ralColor || null,
+        panelThickness: parsed.data.panelThickness || null,
+        ribHeight: parsed.data.ribHeight || null,
+        upperSheetThick: parsed.data.upperSheetThick || null,
+        lowerSheetThick: parsed.data.lowerSheetThick || null,
+        panelProfile: parsed.data.panelProfile || null,
+        deckProfile: parsed.data.deckProfile || null,
+        hasShearStuds: parsed.data.hasShearStuds ?? false,
+        shearStudQty: parsed.data.shearStudQty || null,
+        shearStudSpecs: parsed.data.shearStudSpecs || null,
+        metalWorkItems: parsed.data.metalWorkItems || undefined,
+        coatingSameAsProject: parsed.data.coatingSameAsProject ?? true,
+        scopeCoatingSystem: parsed.data.scopeCoatingSystem || undefined,
       },
     });
 

--- a/src/app/changelog/_page-client.tsx
+++ b/src/app/changelog/_page-client.tsx
@@ -23,10 +23,43 @@ type ChangelogVersion = {
 // Version order: Most recent first
 const hardcodedVersions: ChangelogVersion[] = [
   {
+    version: '22.13.0',
+    date: 'May 6, 2026',
+    type: 'minor',
+    status: 'current',
+    mainTitle: 'Multi-Scope Project Wizard & Tracker Redesign',
+    highlights: [
+      'Project wizard expanded to 9 steps — new Scope Definition and Activities per Scope steps added.',
+      'Per-building scope definitions: Steel, Roof Sheeting, Wall Sheeting, Deck Panel, Metal Works, and Other — each with quantities, specs, and material details.',
+      'Sandwich panel fields: RAL color, panel thickness, rib height, upper/lower sheet thickness, and profile (flat/ribbed).',
+      'Project tracker redesigned: buildings are collapsible group headers with one scope row per scope, showing N/A for non-applicable activities.',
+      'New Scope Summary page per project at /projects/[id]/scope.',
+      'Assembly Parts page gains Paintable Area tile (total area minus purlin area).',
+    ],
+    changes: {
+      added: [
+        'Wizard Step 3 — Scope Definition: per-building accordion with scope type checkboxes (Steel always on) and scope-specific spec forms (quantity, RAL, panel thickness, rib height, shear studs, metal work line items).',
+        'Wizard Step 4 — Activities per Scope: toggle activity applicability per scope with default matrix (Steel: all 7; Sheeting/Deck: detailing, procurement, dispatch, erection; Metal Works: detailing, procurement, production, coating, dispatch, erection).',
+        'Building location field added to wizard step 2 and stored in DB.',
+        'Project Scope Summary page at /projects/[id]/scope with per-building scope cards, RAL swatches, spec chips, and activity badges.',
+        'Scope section added to Project Details page — collapsible building+scope cards linked to the scope summary page.',
+        'Paintable Area tile in Assembly Parts KPI strip: Total Area minus area of parts named PURLIN (case-insensitive).',
+        'DB migration v22.13 adding 15 new fields to ScopeOfWork and location to Building.',
+        'Backfill migration v22.14 populating quantity/unit for existing steel scopes from building weight.',
+      ],
+      fixed: [],
+      changed: [
+        'Project tracker: replaced flat building rows with grouped building+scope rows. Building headers are collapsible; each scope row shows only applicable activity columns (N/A for others).',
+        'Scope-of-work API updated to accept and persist all new spec fields (Zod schema extended).',
+        'Version bumped to 22.13.0',
+      ],
+    },
+  },
+  {
     version: '22.12.0',
     date: 'May 4, 2026',
     type: 'minor',
-    status: 'current',
+    status: 'previous',
     mainTitle: 'Payroll, HR & Productivity Improvements',
     highlights: [
       'Overtime now calculated on basic salary only (Saudi Labor Law compliance) — was incorrectly using total monthly gross.',

--- a/src/app/production/assembly-parts/_page-client.tsx
+++ b/src/app/production/assembly-parts/_page-client.tsx
@@ -57,6 +57,8 @@ interface Pagination {
 interface Totals {
   totalWeight: number;
   totalArea: number;
+  purlinArea: number;
+  paintableArea: number;
   statusCounts: Record<string, number>;
 }
 
@@ -78,7 +80,7 @@ export default function AssemblyPartsPage() {
   const [isDeleting, setIsDeleting] = useState(false);
   const [viewMode, setViewMode] = useState<'card' | 'list'>('list');
   const [pagination, setPagination] = useState<Pagination>({ page: 1, limit: 100, total: 0, totalPages: 0 });
-  const [totals, setTotals] = useState<Totals>({ totalWeight: 0, totalArea: 0, statusCounts: {} });
+  const [totals, setTotals] = useState<Totals>({ totalWeight: 0, totalArea: 0, purlinArea: 0, paintableArea: 0, statusCounts: {} });
   const [pageSize, setPageSize] = useState(100);
   const [sortBy, setSortBy] = useState<string>('createdAt');
   const [orderBy, setOrderBy] = useState<'asc' | 'desc'>('desc');
@@ -102,7 +104,7 @@ export default function AssemblyPartsPage() {
         const result = await response.json();
         setParts(result.data || []);
         setPagination(result.pagination || { page: 1, limit: 100, total: 0, totalPages: 0 });
-        setTotals(result.totals || { totalWeight: 0, totalArea: 0, statusCounts: {} });
+        setTotals(result.totals || { totalWeight: 0, totalArea: 0, purlinArea: 0, paintableArea: 0, statusCounts: {} });
       }
     } catch (error) {
       console.error('Error fetching parts:', error);
@@ -452,6 +454,19 @@ export default function AssemblyPartsPage() {
                 {(totals.totalArea || 0).toFixed(2)}
               </div>
               <p className="text-xs text-muted-foreground">Total Area (m²)</p>
+            </CardContent>
+          </Card>
+          <Card className="border-emerald-200 bg-emerald-50/50">
+            <CardContent className="pt-6">
+              <div className="text-2xl font-bold text-emerald-700">
+                {(totals.paintableArea || 0).toFixed(2)}
+              </div>
+              <p className="text-xs text-emerald-600 font-medium">Paintable Area (m²)</p>
+              {totals.purlinArea > 0 && (
+                <p className="text-[10px] text-muted-foreground mt-0.5">
+                  Total − Purlin ({totals.purlinArea.toFixed(2)} m²)
+                </p>
+              )}
             </CardContent>
           </Card>
           <Card>

--- a/src/app/project-tracker/_page-client.tsx
+++ b/src/app/project-tracker/_page-client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useCallback, useMemo, useRef } from 'react';
+import { useEffect, useState, useCallback, useMemo, useRef, Fragment } from 'react';
 import { Card } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
@@ -74,6 +74,7 @@ interface ActivityData {
   activityType: string;
   activityLabel: string;
   percentage: number;
+  isApplicable: boolean;
   status: 'not_started' | 'in_progress' | 'completed' | 'blocked' | 'pending_approval'
     | 'pending' | 'waiting_approval' | 'completed_released' | 'rejected' | 'approved';
   consultantCode?: string;
@@ -85,6 +86,7 @@ interface ScopeData {
   scopeType: string;
   scopeLabel: string;
   activities: ActivityData[];
+  overallProgress: number;
 }
 
 interface BuildingData {
@@ -152,6 +154,15 @@ const CONSULTANT_CODES: Record<string, { label: string; color: string }> = {
   code_c: { label: 'C - Resubmit', color: 'text-red-400' },
 };
 
+const SCOPE_BADGE: Record<string, { dark: string; light: string }> = {
+  steel:         { dark: 'border-blue-500/40 bg-blue-500/10 text-blue-300',   light: 'border-blue-200 bg-blue-50 text-blue-700' },
+  roof_sheeting: { dark: 'border-orange-500/40 bg-orange-500/10 text-orange-300', light: 'border-orange-200 bg-orange-50 text-orange-700' },
+  wall_sheeting: { dark: 'border-amber-500/40 bg-amber-500/10 text-amber-300',  light: 'border-amber-200 bg-amber-50 text-amber-700' },
+  deck_panel:    { dark: 'border-purple-500/40 bg-purple-500/10 text-purple-300', light: 'border-purple-200 bg-purple-50 text-purple-700' },
+  metal_work:    { dark: 'border-slate-500/40 bg-slate-500/10 text-slate-300',  light: 'border-slate-200 bg-slate-100 text-slate-700' },
+  other:         { dark: 'border-green-500/40 bg-green-500/10 text-green-300',  light: 'border-green-200 bg-green-50 text-green-700' },
+};
+
 // --- Helper Functions ---
 
 function getStatusColor(status: string, percentage: number, isDesignRevision = false): string {
@@ -215,13 +226,6 @@ function getBorderColor(status: string, isDark: boolean): string {
   if (status === 'pending_approval') return isDark ? 'border-blue-500/40' : 'border-blue-300';
   if (status === 'completed') return isDark ? 'border-emerald-500/40' : 'border-emerald-300';
   return isDark ? 'border-slate-700/50' : 'border-slate-200';
-}
-
-function getPrimaryScope(scopes: ScopeData[]): ScopeData | null {
-  const steelScope = scopes.find(
-    (s) => s.scopeType.toLowerCase().includes('steel') || s.scopeType.toLowerCase() === 'main'
-  );
-  return steelScope || scopes[0] || null;
 }
 
 function formatDate(dateStr: string | null): string {
@@ -703,6 +707,7 @@ export default function ProjectTrackerClient() {
   const [searchQuery, setSearchQuery] = useState('');
   const [isDark, setIsDark] = useState(true);
   const [freezeHeader, setFreezeHeader] = useState(false);
+  const [expandedBuildings, setExpandedBuildings] = useState<Set<string>>(new Set());
 
   const fetchData = useCallback(async () => {
     try {
@@ -743,28 +748,19 @@ export default function ProjectTrackerClient() {
     );
   }, [data, searchQuery]);
 
-  const rows = useMemo(() => {
-    const result: {
-      projectNumber: string;
-      projectName: string;
-      building: BuildingData;
-      isFirstInProject: boolean;
-      projectBuildingCount: number;
-    }[] = [];
+  const totalBuildingCount = useMemo(
+    () => filteredProjects.reduce((sum, p) => sum + p.buildings.length, 0),
+    [filteredProjects]
+  );
 
-    for (const project of filteredProjects) {
-      project.buildings.forEach((building, idx) => {
-        result.push({
-          projectNumber: project.projectNumber,
-          projectName: project.name,
-          building,
-          isFirstInProject: idx === 0,
-          projectBuildingCount: project.buildings.length,
-        });
-      });
-    }
-    return result;
-  }, [filteredProjects]);
+  function toggleBuilding(buildingId: string) {
+    setExpandedBuildings((prev) => {
+      const next = new Set(prev);
+      if (next.has(buildingId)) next.delete(buildingId);
+      else next.add(buildingId);
+      return next;
+    });
+  }
 
   const bgClass = isDark ? 'bg-[#0f1419]' : 'bg-slate-50';
   const textClass = isDark ? 'text-white' : 'text-slate-900';
@@ -994,7 +990,7 @@ export default function ProjectTrackerClient() {
                     </tr>
                   </thead>
                   <tbody>
-                    {rows.length === 0 ? (
+                    {totalBuildingCount === 0 ? (
                       <tr>
                         <td
                           colSpan={ACTIVITY_COLUMNS.length + 4}
@@ -1004,84 +1000,105 @@ export default function ProjectTrackerClient() {
                         </td>
                       </tr>
                     ) : (
-                      rows.map((row, rowIdx) => {
-                        const scope = getPrimaryScope(row.building.scopes);
-                        const activityMap = new Map<string, ActivityData>();
-                        if (scope) {
-                          for (const act of scope.activities) {
-                            activityMap.set(act.activityType, act);
-                          }
-                        }
+                      filteredProjects.map((project) =>
+                        project.buildings.map((building, bIdx) => {
+                          const isExpanded = expandedBuildings.has(building.id);
+                          const isFirstInProject = bIdx === 0;
+                          const hdrBg = isDark ? 'bg-[#151d28]' : 'bg-slate-100';
 
-                        return (
-                          <tr
-                            key={`${row.building.id}-${rowIdx}`}
-                            className={`
-                              border-t transition-colors
-                              ${isDark ? 'border-slate-800' : 'border-slate-100'}
-                              ${rowHoverBg}
-                            `}
-                          >
-                            <td
-                              className={`
-                                sticky left-0 z-10 px-4 py-2.5 text-sm font-semibold align-top whitespace-nowrap
-                                ${isDark ? 'bg-[#0f1419]' : 'bg-slate-50'}
-                              `}
-                            >
-                              {row.isFirstInProject ? (
-                                <div>
-                                  <span className={isDark ? 'text-blue-400' : 'text-blue-600'}>
-                                    {row.projectNumber}
-                                  </span>
-                                  <p
-                                    className={`text-[10px] font-normal truncate max-w-[90px] ${mutedTextClass}`}
-                                  >
-                                    {row.projectName}
-                                  </p>
-                                </div>
-                              ) : null}
-                            </td>
-
-                            <td
-                              className={`
-                                sticky left-[100px] z-10 px-4 py-2.5 text-sm align-top whitespace-nowrap
-                                ${isDark ? 'bg-[#0f1419]' : 'bg-slate-50'}
-                              `}
-                            >
-                              <span className="font-medium">
-                                {[row.building.name, row.building.designation].filter(Boolean).join(' - ')}
-                              </span>
-                            </td>
-
-                            <td className={`px-3 py-2.5 text-center text-sm align-top whitespace-nowrap ${mutedTextClass}`}>
-                              {row.building.assemblyTonnage > 0
-                                ? <span className={`font-medium ${isDark ? 'text-white' : 'text-slate-900'}`}>{row.building.assemblyTonnage.toLocaleString(undefined, { minimumFractionDigits: 1, maximumFractionDigits: 1 })} T</span>
-                                : row.building.weight
-                                  ? <span className={`font-medium ${isDark ? 'text-white' : 'text-slate-900'}`}>{Number(row.building.weight).toLocaleString()} T</span>
-                                  : <span>—</span>
-                              }
-                            </td>
-
-                            {ACTIVITY_COLUMNS.map((col) => {
-                              const act = activityMap.get(col.type) ?? null;
-                              return (
-                                <td key={col.type} className="px-1.5 py-2">
-                                  <StatusCell activity={act} isDark={isDark} />
+                          return (
+                            <Fragment key={building.id}>
+                              {/* Building group header row */}
+                              <tr
+                                className={`border-t cursor-pointer transition-colors ${isDark ? 'border-slate-700 hover:bg-[#1a2640]' : 'border-slate-200 hover:bg-slate-150'}`}
+                                onClick={() => toggleBuilding(building.id)}
+                              >
+                                <td className={`sticky left-0 z-10 px-4 py-2 text-sm font-semibold whitespace-nowrap ${hdrBg}`}>
+                                  {isFirstInProject ? (
+                                    <div>
+                                      <span className={isDark ? 'text-blue-400' : 'text-blue-600'}>{project.projectNumber}</span>
+                                      <p className={`text-[10px] font-normal truncate max-w-[90px] ${mutedTextClass}`}>{project.name}</p>
+                                    </div>
+                                  ) : null}
                                 </td>
-                              );
-                            })}
+                                <td className={`sticky left-[100px] z-10 px-4 py-2 whitespace-nowrap ${hdrBg}`} colSpan={ACTIVITY_COLUMNS.length + 3}>
+                                  <div className="flex items-center gap-2">
+                                    <ChevronDown className={`w-3.5 h-3.5 flex-shrink-0 transition-transform ${isExpanded ? '' : '-rotate-90'} ${mutedTextClass}`} />
+                                    <span className={`text-sm font-semibold ${isDark ? 'text-white' : 'text-slate-900'}`}>
+                                      {building.designation && (
+                                        <span className={`font-mono text-xs mr-1.5 ${mutedTextClass}`}>{building.designation}</span>
+                                      )}
+                                      {building.name}
+                                    </span>
+                                    {(building.assemblyTonnage > 0 || building.weight) && (
+                                      <span className={`text-xs px-1.5 py-0.5 rounded ${isDark ? 'bg-blue-500/20 text-blue-300' : 'bg-blue-100 text-blue-700'}`}>
+                                        {building.assemblyTonnage > 0
+                                          ? `${building.assemblyTonnage.toLocaleString(undefined, { minimumFractionDigits: 1, maximumFractionDigits: 1 })} T`
+                                          : `${Number(building.weight).toLocaleString()} T`}
+                                      </span>
+                                    )}
+                                    <span className={`text-[10px] ${mutedTextClass}`}>
+                                      {building.scopes.length} scope{building.scopes.length !== 1 ? 's' : ''}
+                                    </span>
+                                  </div>
+                                </td>
+                              </tr>
 
-                            <td className="px-1.5 py-2">
-                              <OverallCell
-                                progress={row.building.overallProgress}
-                                currentStage={row.building.currentStage}
-                                hasBlocked={row.building.hasBlocked}
-                                isDark={isDark}
-                              />
-                            </td>
-                          </tr>
-                        );
-                      })
+                              {/* Scope rows (shown when expanded) */}
+                              {isExpanded && building.scopes.map((scope, sIdx) => {
+                                const activityMap = new Map<string, ActivityData>();
+                                for (const act of scope.activities) activityMap.set(act.activityType, act);
+                                const badge = (SCOPE_BADGE[scope.scopeType] ?? SCOPE_BADGE.other)[isDark ? 'dark' : 'light'];
+                                return (
+                                  <tr
+                                    key={`${building.id}-${scope.id}`}
+                                    className={`border-t transition-colors ${isDark ? 'border-slate-800/50' : 'border-slate-100'} ${rowHoverBg}`}
+                                  >
+                                    <td className={`sticky left-0 z-10 px-4 py-2 ${isDark ? 'bg-[#0f1419]' : 'bg-slate-50'}`} />
+                                    <td className={`sticky left-[100px] z-10 px-4 py-2 whitespace-nowrap ${isDark ? 'bg-[#0f1419]' : 'bg-slate-50'}`}>
+                                      <span className={`inline-block text-[10px] font-semibold px-2.5 py-1 rounded-full border ${badge}`}>
+                                        {scope.scopeLabel}
+                                      </span>
+                                    </td>
+                                    <td className={`px-3 py-2 text-center whitespace-nowrap ${mutedTextClass}`}>
+                                      {sIdx === 0 ? (
+                                        building.assemblyTonnage > 0
+                                          ? <span className={`text-xs ${isDark ? 'text-slate-400' : 'text-slate-500'}`}>{building.assemblyTonnage.toFixed(1)} T</span>
+                                          : building.weight
+                                            ? <span className={`text-xs ${isDark ? 'text-slate-400' : 'text-slate-500'}`}>{Number(building.weight)} T</span>
+                                            : null
+                                      ) : null}
+                                    </td>
+                                    {ACTIVITY_COLUMNS.map((col) => {
+                                      const act = activityMap.get(col.type) ?? null;
+                                      if (!act || !act.isApplicable) {
+                                        return (
+                                          <td key={col.type} className="px-1.5 py-2 text-center">
+                                            <span className={`text-[10px] ${isDark ? 'text-slate-700' : 'text-slate-300'}`}>N/A</span>
+                                          </td>
+                                        );
+                                      }
+                                      return (
+                                        <td key={col.type} className="px-1.5 py-2">
+                                          <StatusCell activity={act} isDark={isDark} />
+                                        </td>
+                                      );
+                                    })}
+                                    <td className="px-1.5 py-2">
+                                      <OverallCell
+                                        progress={scope.overallProgress}
+                                        currentStage={null}
+                                        hasBlocked={scope.activities.some((a) => a.isApplicable && a.status === 'blocked')}
+                                        isDark={isDark}
+                                      />
+                                    </td>
+                                  </tr>
+                                );
+                              })}
+                            </Fragment>
+                          );
+                        })
+                      )
                     )}
                   </tbody>
                 </table>

--- a/src/app/projects/[id]/scope/page.tsx
+++ b/src/app/projects/[id]/scope/page.tsx
@@ -1,0 +1,35 @@
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import { redirect, notFound } from 'next/navigation';
+import { ProjectScopeSummary } from '@/components/project-scope-summary';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = { title: 'Project Scope Summary' };
+
+export default async function ProjectScopePage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const cookieName = process.env.COOKIE_NAME || 'ots_session';
+  const store = await cookies();
+  const token = store.get(cookieName)?.value;
+  const session = token ? verifySession(token) : null;
+
+  if (!session) redirect('/login');
+
+  const baseUrl = process.env.APP_URL || 'http://localhost:3000';
+  const headers = { Cookie: `${cookieName}=${token}` };
+
+  const [projectRes, scopesRes] = await Promise.all([
+    fetch(`${baseUrl}/api/projects/${id}`, { headers, cache: 'no-store' }),
+    fetch(`${baseUrl}/api/scope-of-work?projectId=${id}`, { headers, cache: 'no-store' }),
+  ]);
+
+  if (!projectRes.ok) {
+    if (projectRes.status === 404) notFound();
+    redirect('/projects');
+  }
+
+  const project = await projectRes.json();
+  const scopeOfWorks = scopesRes.ok ? await scopesRes.json() : [];
+
+  return <ProjectScopeSummary project={project} scopeOfWorks={scopeOfWorks} />;
+}

--- a/src/app/projects/wizard/_page-client.tsx
+++ b/src/app/projects/wizard/_page-client.tsx
@@ -17,6 +17,38 @@ type Building = {
   name: string;
   designation: string;
   weight?: number;
+  location?: string;
+};
+
+type MetalWorkItem = {
+  id: string;
+  name: string;
+  unit: string;
+  quantity: number;
+};
+
+type ScopeDefinition = {
+  buildingId: string;
+  scopeType: 'steel' | 'roof_sheeting' | 'wall_sheeting' | 'deck_panel' | 'metal_work' | 'other';
+  customLabel?: string;
+  quantity?: number;
+  unit?: 'ton' | 'm2' | 'Lm' | 'LS';
+  // Sandwich panel
+  ralColor?: string;
+  panelThickness?: number;
+  ribHeight?: number;
+  upperSheetThick?: number;
+  lowerSheetThick?: number;
+  panelProfile?: 'flat' | 'ribbed';
+  // Deck panel
+  deckProfile?: string;
+  hasShearStuds?: boolean;
+  shearStudQty?: number;
+  shearStudSpecs?: string;
+  // Metal works
+  metalWorkItems?: MetalWorkItem[];
+  // Activities (set in step 4)
+  activities?: { activityType: string; activityLabel: string; isApplicable: boolean; sortOrder: number }[];
 };
 
 type ScopeItem = {
@@ -52,6 +84,73 @@ type PaymentTerm = {
   percentage: string;
   description: string;
 };
+
+// Default activities per scope type
+const SCOPE_ACTIVITY_DEFAULTS: Record<string, { activityType: string; activityLabel: string; isApplicable: boolean; sortOrder: number }[]> = {
+  steel: [
+    { activityType: 'design', activityLabel: 'Design', isApplicable: true, sortOrder: 1 },
+    { activityType: 'detailing', activityLabel: 'Detailing', isApplicable: true, sortOrder: 2 },
+    { activityType: 'procurement', activityLabel: 'Procurement', isApplicable: true, sortOrder: 3 },
+    { activityType: 'production', activityLabel: 'Production', isApplicable: true, sortOrder: 4 },
+    { activityType: 'coating', activityLabel: 'Coating', isApplicable: true, sortOrder: 5 },
+    { activityType: 'dispatch', activityLabel: 'Dispatch & Delivery', isApplicable: true, sortOrder: 6 },
+    { activityType: 'erection', activityLabel: 'Erection', isApplicable: true, sortOrder: 7 },
+  ],
+  roof_sheeting: [
+    { activityType: 'design', activityLabel: 'Design', isApplicable: false, sortOrder: 1 },
+    { activityType: 'detailing', activityLabel: 'Detailing', isApplicable: true, sortOrder: 2 },
+    { activityType: 'procurement', activityLabel: 'Procurement', isApplicable: true, sortOrder: 3 },
+    { activityType: 'production', activityLabel: 'Production', isApplicable: false, sortOrder: 4 },
+    { activityType: 'coating', activityLabel: 'Coating', isApplicable: false, sortOrder: 5 },
+    { activityType: 'dispatch', activityLabel: 'Dispatch & Delivery', isApplicable: true, sortOrder: 6 },
+    { activityType: 'erection', activityLabel: 'Erection', isApplicable: true, sortOrder: 7 },
+  ],
+  wall_sheeting: [
+    { activityType: 'design', activityLabel: 'Design', isApplicable: false, sortOrder: 1 },
+    { activityType: 'detailing', activityLabel: 'Detailing', isApplicable: true, sortOrder: 2 },
+    { activityType: 'procurement', activityLabel: 'Procurement', isApplicable: true, sortOrder: 3 },
+    { activityType: 'production', activityLabel: 'Production', isApplicable: false, sortOrder: 4 },
+    { activityType: 'coating', activityLabel: 'Coating', isApplicable: false, sortOrder: 5 },
+    { activityType: 'dispatch', activityLabel: 'Dispatch & Delivery', isApplicable: true, sortOrder: 6 },
+    { activityType: 'erection', activityLabel: 'Erection', isApplicable: true, sortOrder: 7 },
+  ],
+  deck_panel: [
+    { activityType: 'design', activityLabel: 'Design', isApplicable: false, sortOrder: 1 },
+    { activityType: 'detailing', activityLabel: 'Detailing', isApplicable: true, sortOrder: 2 },
+    { activityType: 'procurement', activityLabel: 'Procurement', isApplicable: true, sortOrder: 3 },
+    { activityType: 'production', activityLabel: 'Production', isApplicable: false, sortOrder: 4 },
+    { activityType: 'coating', activityLabel: 'Coating', isApplicable: false, sortOrder: 5 },
+    { activityType: 'dispatch', activityLabel: 'Dispatch & Delivery', isApplicable: true, sortOrder: 6 },
+    { activityType: 'erection', activityLabel: 'Erection', isApplicable: true, sortOrder: 7 },
+  ],
+  metal_work: [
+    { activityType: 'design', activityLabel: 'Design', isApplicable: false, sortOrder: 1 },
+    { activityType: 'detailing', activityLabel: 'Detailing', isApplicable: true, sortOrder: 2 },
+    { activityType: 'procurement', activityLabel: 'Procurement', isApplicable: true, sortOrder: 3 },
+    { activityType: 'production', activityLabel: 'Production', isApplicable: true, sortOrder: 4 },
+    { activityType: 'coating', activityLabel: 'Coating', isApplicable: true, sortOrder: 5 },
+    { activityType: 'dispatch', activityLabel: 'Dispatch & Delivery', isApplicable: true, sortOrder: 6 },
+    { activityType: 'erection', activityLabel: 'Erection', isApplicable: true, sortOrder: 7 },
+  ],
+  other: [
+    { activityType: 'design', activityLabel: 'Design', isApplicable: false, sortOrder: 1 },
+    { activityType: 'detailing', activityLabel: 'Detailing', isApplicable: false, sortOrder: 2 },
+    { activityType: 'procurement', activityLabel: 'Procurement', isApplicable: true, sortOrder: 3 },
+    { activityType: 'production', activityLabel: 'Production', isApplicable: false, sortOrder: 4 },
+    { activityType: 'coating', activityLabel: 'Coating', isApplicable: false, sortOrder: 5 },
+    { activityType: 'dispatch', activityLabel: 'Dispatch & Delivery', isApplicable: true, sortOrder: 6 },
+    { activityType: 'erection', activityLabel: 'Erection', isApplicable: false, sortOrder: 7 },
+  ],
+};
+
+const SCOPE_TYPE_OPTIONS: { type: ScopeDefinition['scopeType']; label: string; color: string }[] = [
+  { type: 'steel', label: 'Steel', color: 'bg-blue-100 border-blue-300 text-blue-800' },
+  { type: 'roof_sheeting', label: 'Roof Sheeting', color: 'bg-orange-100 border-orange-300 text-orange-800' },
+  { type: 'wall_sheeting', label: 'Wall Sheeting', color: 'bg-amber-100 border-amber-300 text-amber-800' },
+  { type: 'deck_panel', label: 'Deck Panel', color: 'bg-purple-100 border-purple-300 text-purple-800' },
+  { type: 'metal_work', label: 'Metal Works', color: 'bg-gray-100 border-gray-300 text-gray-800' },
+  { type: 'other', label: 'Other', color: 'bg-green-100 border-green-300 text-green-800' },
+];
 
 const SCOPE_OPTIONS = [
   { id: 'design', label: 'Design', stage: 'engineering' },
@@ -101,6 +200,9 @@ export default function ProjectSetupWizard() {
 
   // Step 2: Buildings
   const [buildings, setBuildings] = useState<Building[]>([]);
+
+  // Step 3: Scope Definitions per building
+  const [scopeDefinitions, setScopeDefinitions] = useState<ScopeDefinition[]>([]);
 
   // Step 3: Scope Schedules (legacy - kept for compatibility)
   const [scopeSchedules, setScopeSchedules] = useState<ScopeSchedule[]>([]);
@@ -251,6 +353,106 @@ export default function ProjectSetupWizard() {
     ));
   };
 
+  // ── Scope Definition helpers (Step 3) ──────────────────────────
+  const getScopesForBuilding = (buildingId: string) =>
+    scopeDefinitions.filter((s) => s.buildingId === buildingId);
+
+  const hasScopeType = (buildingId: string, scopeType: ScopeDefinition['scopeType']) =>
+    scopeDefinitions.some((s) => s.buildingId === buildingId && s.scopeType === scopeType);
+
+  const addScopeToBuilding = (buildingId: string, scopeType: ScopeDefinition['scopeType']) => {
+    if (hasScopeType(buildingId, scopeType)) return;
+    const defaults = SCOPE_ACTIVITY_DEFAULTS[scopeType] || SCOPE_ACTIVITY_DEFAULTS['other'];
+    const newScope: ScopeDefinition = {
+      buildingId,
+      scopeType,
+      unit: scopeType === 'steel' ? 'ton' : 'm2',
+      activities: defaults.map((a) => ({ ...a })),
+    };
+    setScopeDefinitions((prev) => [...prev, newScope]);
+  };
+
+  const removeScopeFromBuilding = (buildingId: string, scopeType: ScopeDefinition['scopeType']) => {
+    if (scopeType === 'steel') return; // Steel cannot be removed
+    setScopeDefinitions((prev) =>
+      prev.filter((s) => !(s.buildingId === buildingId && s.scopeType === scopeType))
+    );
+  };
+
+  const updateScopeField = (
+    buildingId: string,
+    scopeType: ScopeDefinition['scopeType'],
+    field: keyof ScopeDefinition,
+    value: ScopeDefinition[keyof ScopeDefinition]
+  ) => {
+    setScopeDefinitions((prev) =>
+      prev.map((s) =>
+        s.buildingId === buildingId && s.scopeType === scopeType ? { ...s, [field]: value } : s
+      )
+    );
+  };
+
+  const toggleScopeActivity = (
+    buildingId: string,
+    scopeType: ScopeDefinition['scopeType'],
+    activityType: string
+  ) => {
+    setScopeDefinitions((prev) =>
+      prev.map((s) => {
+        if (s.buildingId !== buildingId || s.scopeType !== scopeType) return s;
+        return {
+          ...s,
+          activities: (s.activities || []).map((a) =>
+            a.activityType === activityType ? { ...a, isApplicable: !a.isApplicable } : a
+          ),
+        };
+      })
+    );
+  };
+
+  const addMetalWorkItem = (buildingId: string) => {
+    const newItem: MetalWorkItem = { id: `mwi-${Date.now()}`, name: '', unit: 'LS', quantity: 1 };
+    setScopeDefinitions((prev) =>
+      prev.map((s) => {
+        if (s.buildingId !== buildingId || s.scopeType !== 'metal_work') return s;
+        return { ...s, metalWorkItems: [...(s.metalWorkItems || []), newItem] };
+      })
+    );
+  };
+
+  const removeMetalWorkItem = (buildingId: string, itemId: string) => {
+    setScopeDefinitions((prev) =>
+      prev.map((s) => {
+        if (s.buildingId !== buildingId || s.scopeType !== 'metal_work') return s;
+        return { ...s, metalWorkItems: (s.metalWorkItems || []).filter((i) => i.id !== itemId) };
+      })
+    );
+  };
+
+  const updateMetalWorkItem = (buildingId: string, itemId: string, field: keyof MetalWorkItem, value: string | number) => {
+    setScopeDefinitions((prev) =>
+      prev.map((s) => {
+        if (s.buildingId !== buildingId || s.scopeType !== 'metal_work') return s;
+        return {
+          ...s,
+          metalWorkItems: (s.metalWorkItems || []).map((i) =>
+            i.id === itemId ? { ...i, [field]: value } : i
+          ),
+        };
+      })
+    );
+  };
+
+  // Ensure every building has at least a Steel scope definition
+  const ensureSteelScopes = () => {
+    for (const building of buildings) {
+      if (!hasScopeType(building.id, 'steel')) {
+        addScopeToBuilding(building.id, 'steel');
+      }
+    }
+  };
+
+  // ── Legacy scope toggles (Step 1 scope checkboxes) ─────────
   const toggleAllScopes = (selectAll: boolean) => {
     setScopeOfWork(scopeOfWork.map(s => ({ ...s, checked: selectAll })));
     
@@ -404,26 +606,31 @@ export default function ProjectSetupWizard() {
   const validateStep = () => {
     switch (currentStep) {
       case 1:
-        return projectNumber && projectName && clientName && projectManagerId && scopeOfWork.some(s => s.checked);
+        return projectNumber && projectName && clientName && projectManagerId;
       case 2:
         return buildings.length > 0 && buildings.every(b => b.name && b.designation);
       case 3:
+        // Each building must have at least the steel scope
+        return buildings.every(b => hasScopeType(b.id, 'steel'));
+      case 4:
+        return true; // Activities step — optional, defaults are pre-filled
+      case 5:
         // At least one visible stage should have duration filled
         const visibleStages = stageDurations.filter(stage => {
           const stageScopes = STAGE_SCOPES[stage.stage] || [];
           return scopeOfWork.some(s => s.checked && stageScopes.includes(s.id));
         });
         return visibleStages.length === 0 || visibleStages.some(s => s.durationWeeksMin > 0 || s.durationWeeksMax > 0);
-      case 4:
+      case 6:
         return coatingCoats.length > 0 && coatingCoats.every(c => c.coatName);
-      case 5:
+      case 7:
         // Payment terms validation: total should be 100% if any terms are added
         if (paymentTerms.length === 0) return true; // Optional
         const total = getTotalPaymentPercentage();
         return paymentTerms.every(t => t.percentage && t.description) && Math.abs(total - 100) < 0.01;
-      case 6:
+      case 8:
         return true; // Technical specs - optional step
-      case 7:
+      case 9:
         return true; // Upload parts - optional step
       default:
         return false;
@@ -431,6 +638,10 @@ export default function ProjectSetupWizard() {
   };
 
   const nextStep = () => {
+    if (currentStep === 2) {
+      // Ensure all buildings have a Steel scope before going to scope definition
+      ensureSteelScopes();
+    }
     if (validateStep()) {
       setCurrentStep(currentStep + 1);
     } else {
@@ -635,6 +846,7 @@ export default function ProjectSetupWizard() {
           name: building.name,
           designation: building.designation,
           weight: building.weight || null,
+          location: building.location || null,
         };
 
         const buildingResponse = await fetch('/api/buildings', {
@@ -653,29 +865,120 @@ export default function ProjectSetupWizard() {
         createdBuildings[building.id] = createdBuilding.id;
       }
 
-      // Save scope schedules
-      for (const schedule of scopeSchedules) {
-        const realBuildingId = createdBuildings[schedule.buildingId];
+      // ── Create scope-of-work records and activities ──────────────
+      // For each building: patch the auto-created Steel scope, then POST non-steel scopes.
+      // Then create BuildingActivity records for each scope.
+      let totalScopesCreated = 0;
+      let totalActivitiesCreated = 0;
+
+      for (const building of buildings) {
+        const realBuildingId = createdBuildings[building.id];
         if (!realBuildingId) continue;
 
-        const scheduleData = {
-          projectId: project.id,
-          buildingId: realBuildingId,
-          scopeType: schedule.scopeId,
-          scopeLabel: schedule.scopeLabel,
-          startDate: schedule.startDate,
-          endDate: schedule.endDate,
-        };
+        const buildingScopes = scopeDefinitions.filter((s) => s.buildingId === building.id);
 
-        const scheduleResponse = await fetch('/api/scope-schedules', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(scheduleData),
-        });
+        // Fetch the auto-created Steel scope for this building
+        let steelScopeId: string | null = null;
+        try {
+          const scopeRes = await fetch(`/api/scope-of-work?buildingId=${realBuildingId}`);
+          if (scopeRes.ok) {
+            const existingScopes = await scopeRes.json();
+            const autoSteel = existingScopes.find((s: { scopeType: string; id: string }) => s.scopeType === 'steel');
+            if (autoSteel) steelScopeId = autoSteel.id;
+          }
+        } catch {}
 
-        if (!scheduleResponse.ok) {
-          console.error('Failed to create scope schedule:', schedule.scopeLabel);
-          // Don't throw error - schedules are nice to have but not critical
+        // Track created scope IDs per scopeType for activity creation
+        const scopeIdMap: Record<string, string> = {};
+
+        for (const scopeDef of buildingScopes) {
+          const scopeLabel = SCOPE_TYPE_OPTIONS.find((o) => o.type === scopeDef.scopeType)?.label ||
+            scopeDef.customLabel || scopeDef.scopeType;
+
+          const scopePayload = {
+            scopeLabel,
+            customLabel: scopeDef.customLabel || null,
+            quantity: scopeDef.quantity ?? null,
+            unit: scopeDef.unit || null,
+            ralColor: scopeDef.ralColor || null,
+            panelThickness: scopeDef.panelThickness || null,
+            ribHeight: scopeDef.ribHeight || null,
+            upperSheetThick: scopeDef.upperSheetThick || null,
+            lowerSheetThick: scopeDef.lowerSheetThick || null,
+            panelProfile: scopeDef.panelProfile || null,
+            deckProfile: scopeDef.deckProfile || null,
+            hasShearStuds: scopeDef.hasShearStuds ?? false,
+            shearStudQty: scopeDef.shearStudQty || null,
+            shearStudSpecs: scopeDef.shearStudSpecs || null,
+            metalWorkItems: scopeDef.metalWorkItems?.map((i) => ({ name: i.name, unit: i.unit, quantity: i.quantity })) || null,
+          };
+
+          if (scopeDef.scopeType === 'steel' && steelScopeId) {
+            // PATCH the auto-created Steel scope with our quantity data
+            await fetch(`/api/scope-of-work/${steelScopeId}`, {
+              method: 'PATCH',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(scopePayload),
+            });
+            scopeIdMap['steel'] = steelScopeId;
+            totalScopesCreated++;
+          } else if (scopeDef.scopeType !== 'steel') {
+            // POST new non-steel scope
+            const createRes = await fetch('/api/scope-of-work', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                projectId: project.id,
+                buildingId: realBuildingId,
+                scopeType: scopeDef.scopeType,
+                ...scopePayload,
+              }),
+            });
+            if (createRes.ok) {
+              const createdScope = await createRes.json();
+              scopeIdMap[scopeDef.scopeType] = createdScope.id;
+              totalScopesCreated++;
+            }
+          }
+        }
+
+        // Create BuildingActivity records
+        const allActivities: {
+          buildingId: string;
+          scopeOfWorkId: string;
+          activityType: string;
+          activityLabel: string;
+          isApplicable: boolean;
+          sortOrder: number;
+        }[] = [];
+
+        for (const scopeDef of buildingScopes) {
+          const scopeOfWorkId = scopeIdMap[scopeDef.scopeType];
+          if (!scopeOfWorkId) continue;
+
+          const activities = scopeDef.activities || SCOPE_ACTIVITY_DEFAULTS[scopeDef.scopeType] || [];
+          for (const activity of activities) {
+            allActivities.push({
+              buildingId: realBuildingId,
+              scopeOfWorkId,
+              activityType: activity.activityType,
+              activityLabel: activity.activityLabel,
+              isApplicable: activity.isApplicable,
+              sortOrder: activity.sortOrder,
+            });
+          }
+        }
+
+        if (allActivities.length > 0) {
+          const actRes = await fetch('/api/building-activities', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ projectId: project.id, activities: allActivities }),
+          });
+          if (actRes.ok) {
+            const created = await actRes.json();
+            totalActivitiesCreated += Array.isArray(created) ? created.length : 0;
+          }
         }
       }
 
@@ -692,10 +995,9 @@ export default function ProjectSetupWizard() {
       }
 
       const buildingCount = buildings.length;
-      const scopeScheduleCount = scopeSchedules.length;
       const coatingCount = coatingCoats.length;
-      
-      setSuccessMessage(`Project created successfully!\n\n✓ ${buildingCount} building(s) added\n✓ ${scopeScheduleCount} scope schedule(s) saved\n✓ ${coatingCount} coating coat(s) specified`);
+
+      setSuccessMessage(`Project created successfully!\n\n✓ ${buildingCount} building(s) added\n✓ ${totalScopesCreated} scope(s) defined\n✓ ${totalActivitiesCreated} activities configured\n✓ ${coatingCount} coating coat(s) specified`);
       setShowSuccessDialog(true);
     } catch (error) {
       console.error('Error creating project:', error);
@@ -713,21 +1015,38 @@ export default function ProjectSetupWizard() {
     }
   };
 
+  const STEP_LABELS = [
+    'Project Info',
+    'Buildings',
+    'Scope Definition',
+    'Activities',
+    'Duration',
+    'Coating',
+    'Payment',
+    'Tech Specs',
+    'Upload',
+  ];
+
   const renderStepIndicator = () => (
-    <div className="flex items-center justify-center mb-8">
-      {[1, 2, 3, 4, 5, 6, 7].map((step, idx) => (
+    <div className="flex items-center justify-center mb-8 flex-wrap gap-y-2">
+      {[1, 2, 3, 4, 5, 6, 7, 8, 9].map((step, idx) => (
         <div key={step} className="flex items-center">
-          <div className={`flex items-center justify-center w-8 h-8 rounded-full text-sm ${
-            currentStep === step 
-              ? 'bg-primary text-white' 
-              : currentStep > step 
-              ? 'bg-green-500 text-white' 
-              : 'bg-gray-200 text-gray-600'
-          }`}>
-            {currentStep > step ? <Check className="h-4 w-4" /> : step}
+          <div className="flex flex-col items-center">
+            <div className={`flex items-center justify-center w-8 h-8 rounded-full text-sm font-medium ${
+              currentStep === step
+                ? 'bg-primary text-white'
+                : currentStep > step
+                ? 'bg-green-500 text-white'
+                : 'bg-gray-200 text-gray-600'
+            }`}>
+              {currentStep > step ? <Check className="h-4 w-4" /> : step}
+            </div>
+            <span className="text-[10px] text-muted-foreground mt-1 hidden sm:block w-16 text-center leading-tight">
+              {STEP_LABELS[step - 1]}
+            </span>
           </div>
-          {idx < 6 && (
-            <div className={`w-8 h-1 mx-1 ${
+          {idx < 8 && (
+            <div className={`w-6 h-1 mx-1 mb-5 ${
               currentStep > step ? 'bg-green-500' : 'bg-gray-200'
             }`} />
           )}
@@ -746,7 +1065,7 @@ export default function ProjectSetupWizard() {
             Project Setup Wizard
           </h1>
           <p className="text-muted-foreground mt-1">
-            Step {currentStep} of 6
+            Step {currentStep} of 9
           </p>
         </div>
         <Link href="/projects">
@@ -977,6 +1296,14 @@ export default function ProjectSetupWizard() {
                       />
                     </div>
                   </div>
+                  <div className="space-y-2">
+                    <Label>Location / Description</Label>
+                    <Input
+                      value={building.location || ''}
+                      onChange={(e) => updateBuilding(building.id, 'location', e.target.value)}
+                      placeholder="e.g., North side of plot, Grid A1-C4"
+                    />
+                  </div>
                 </div>
               ))
             )}
@@ -984,8 +1311,317 @@ export default function ProjectSetupWizard() {
         </Card>
       )}
 
-      {/* Step 3: Duration by Stage */}
+      {/* Step 3: Scope Definition per Building */}
       {currentStep === 3 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Scope Definition</CardTitle>
+            <p className="text-sm text-muted-foreground">
+              Define the scope of work and quantities for each building. Steel is always included.
+            </p>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            {buildings.map((building, bIdx) => {
+              const buildingScopes = getScopesForBuilding(building.id);
+              return (
+                <div key={building.id} className="border-2 rounded-xl p-5 space-y-4">
+                  <h3 className="font-bold text-base flex items-center gap-2">
+                    <span className="bg-primary text-white rounded-full w-6 h-6 flex items-center justify-center text-xs">{bIdx + 1}</span>
+                    {building.designation} — {building.name}
+                    {building.location && <span className="text-xs text-muted-foreground font-normal ml-1">({building.location})</span>}
+                  </h3>
+
+                  {/* Scope type selectors */}
+                  <div className="space-y-2">
+                    <Label className="text-sm font-medium">Scope Types</Label>
+                    <div className="flex flex-wrap gap-2">
+                      {SCOPE_TYPE_OPTIONS.map(({ type, label, color }) => {
+                        const active = hasScopeType(building.id, type);
+                        const isSteel = type === 'steel';
+                        return (
+                          <button
+                            key={type}
+                            type="button"
+                            onClick={() => active && !isSteel ? removeScopeFromBuilding(building.id, type) : !active ? addScopeToBuilding(building.id, type) : undefined}
+                            className={`px-3 py-1 rounded-full border text-xs font-medium transition-all ${
+                              active
+                                ? color + ' ring-2 ring-offset-1 ring-current'
+                                : 'bg-gray-50 border-gray-200 text-gray-400 hover:border-gray-400'
+                            } ${isSteel ? 'cursor-default' : 'cursor-pointer'}`}
+                          >
+                            {active ? '✓ ' : '+ '}{label}
+                            {isSteel && <span className="ml-1 text-[10px] opacity-60">required</span>}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+
+                  {/* Scope detail forms */}
+                  {buildingScopes.map((scope) => (
+                    <div key={scope.scopeType} className="bg-muted/30 rounded-lg p-4 space-y-3">
+                      <div className="flex items-center justify-between">
+                        <h4 className="font-semibold text-sm capitalize">
+                          {SCOPE_TYPE_OPTIONS.find(o => o.type === scope.scopeType)?.label || scope.scopeType}
+                        </h4>
+                        {scope.scopeType !== 'steel' && (
+                          <button
+                            type="button"
+                            onClick={() => removeScopeFromBuilding(building.id, scope.scopeType)}
+                            className="text-red-400 hover:text-red-600 text-xs"
+                          >
+                            Remove
+                          </button>
+                        )}
+                      </div>
+
+                      {/* Steel */}
+                      {scope.scopeType === 'steel' && (
+                        <div className="grid grid-cols-2 gap-3">
+                          <div className="space-y-1">
+                            <Label className="text-xs">Quantity (tons)</Label>
+                            <Input
+                              type="number" step="0.01" min="0"
+                              value={scope.quantity || ''}
+                              onChange={(e) => updateScopeField(building.id, 'steel', 'quantity', parseFloat(e.target.value) || undefined)}
+                              placeholder="e.g., 150.5"
+                            />
+                          </div>
+                        </div>
+                      )}
+
+                      {/* Roof / Wall Sheeting */}
+                      {(scope.scopeType === 'roof_sheeting' || scope.scopeType === 'wall_sheeting') && (
+                        <div className="grid grid-cols-2 gap-3">
+                          <div className="space-y-1">
+                            <Label className="text-xs">Quantity (m²)</Label>
+                            <Input type="number" step="0.01" min="0" value={scope.quantity || ''}
+                              onChange={(e) => updateScopeField(building.id, scope.scopeType, 'quantity', parseFloat(e.target.value) || undefined)}
+                              placeholder="e.g., 805" />
+                          </div>
+                          <div className="space-y-1">
+                            <Label className="text-xs">RAL Color</Label>
+                            <Input value={scope.ralColor || ''} placeholder="e.g., RAL 9005"
+                              onChange={(e) => updateScopeField(building.id, scope.scopeType, 'ralColor', e.target.value)} />
+                          </div>
+                          <div className="space-y-1">
+                            <Label className="text-xs">Profile</Label>
+                            <select
+                              value={scope.panelProfile || ''}
+                              onChange={(e) => updateScopeField(building.id, scope.scopeType, 'panelProfile', e.target.value as 'flat' | 'ribbed')}
+                              className="w-full h-9 px-3 rounded-md border bg-background text-sm"
+                            >
+                              <option value="">Select profile</option>
+                              <option value="ribbed">Ribbed</option>
+                              <option value="flat">Flat</option>
+                            </select>
+                          </div>
+                          <div className="space-y-1">
+                            <Label className="text-xs">Panel Thickness (mm)</Label>
+                            <Input type="number" min="0" value={scope.panelThickness || ''}
+                              onChange={(e) => updateScopeField(building.id, scope.scopeType, 'panelThickness', parseInt(e.target.value) || undefined)}
+                              placeholder="e.g., 75" />
+                          </div>
+                          {scope.panelProfile === 'ribbed' && (
+                            <div className="space-y-1">
+                              <Label className="text-xs">Rib Height (mm)</Label>
+                              <Input type="number" min="0" value={scope.ribHeight || ''}
+                                onChange={(e) => updateScopeField(building.id, scope.scopeType, 'ribHeight', parseInt(e.target.value) || undefined)}
+                                placeholder="e.g., 30" />
+                            </div>
+                          )}
+                          <div className="space-y-1">
+                            <Label className="text-xs">Upper Sheet Thickness (mm)</Label>
+                            <Input type="number" step="0.1" min="0" value={scope.upperSheetThick || ''}
+                              onChange={(e) => updateScopeField(building.id, scope.scopeType, 'upperSheetThick', parseFloat(e.target.value) || undefined)}
+                              placeholder="e.g., 0.5" />
+                          </div>
+                          <div className="space-y-1">
+                            <Label className="text-xs">Lower Sheet Thickness (mm)</Label>
+                            <Input type="number" step="0.1" min="0" value={scope.lowerSheetThick || ''}
+                              onChange={(e) => updateScopeField(building.id, scope.scopeType, 'lowerSheetThick', parseFloat(e.target.value) || undefined)}
+                              placeholder="e.g., 0.3" />
+                          </div>
+                        </div>
+                      )}
+
+                      {/* Deck Panel */}
+                      {scope.scopeType === 'deck_panel' && (
+                        <div className="grid grid-cols-2 gap-3">
+                          <div className="space-y-1">
+                            <Label className="text-xs">Quantity (m²)</Label>
+                            <Input type="number" step="0.01" min="0" value={scope.quantity || ''}
+                              onChange={(e) => updateScopeField(building.id, 'deck_panel', 'quantity', parseFloat(e.target.value) || undefined)}
+                              placeholder="e.g., 400" />
+                          </div>
+                          <div className="space-y-1">
+                            <Label className="text-xs">Profile / Thickness</Label>
+                            <Input value={scope.deckProfile || ''} placeholder="e.g., TR60 1.2mm"
+                              onChange={(e) => updateScopeField(building.id, 'deck_panel', 'deckProfile', e.target.value)} />
+                          </div>
+                          <div className="col-span-2 flex items-center gap-3">
+                            <input type="checkbox" id={`shear-${building.id}`}
+                              checked={scope.hasShearStuds || false}
+                              onChange={(e) => updateScopeField(building.id, 'deck_panel', 'hasShearStuds', e.target.checked)}
+                              className="w-4 h-4 rounded" />
+                            <label htmlFor={`shear-${building.id}`} className="text-sm cursor-pointer">Includes Shear Studs</label>
+                          </div>
+                          {scope.hasShearStuds && (
+                            <>
+                              <div className="space-y-1">
+                                <Label className="text-xs">Shear Stud Quantity</Label>
+                                <Input type="number" min="0" value={scope.shearStudQty || ''}
+                                  onChange={(e) => updateScopeField(building.id, 'deck_panel', 'shearStudQty', parseInt(e.target.value) || undefined)}
+                                  placeholder="e.g., 1200" />
+                              </div>
+                              <div className="space-y-1">
+                                <Label className="text-xs">Shear Stud Specs</Label>
+                                <Input value={scope.shearStudSpecs || ''} placeholder="e.g., 19mm dia × 100mm"
+                                  onChange={(e) => updateScopeField(building.id, 'deck_panel', 'shearStudSpecs', e.target.value)} />
+                              </div>
+                            </>
+                          )}
+                        </div>
+                      )}
+
+                      {/* Metal Works */}
+                      {scope.scopeType === 'metal_work' && (
+                        <div className="space-y-3">
+                          <div className="flex items-center justify-between">
+                            <Label className="text-xs">Items</Label>
+                            <Button type="button" size="sm" variant="outline" onClick={() => addMetalWorkItem(building.id)}>
+                              <Plus className="h-3 w-3 mr-1" /> Add Item
+                            </Button>
+                          </div>
+                          {(scope.metalWorkItems || []).length === 0 && (
+                            <p className="text-xs text-muted-foreground">No items yet. Click "Add Item" to start.</p>
+                          )}
+                          {(scope.metalWorkItems || []).map((item) => (
+                            <div key={item.id} className="grid grid-cols-[1fr_100px_100px_32px] gap-2 items-end">
+                              <div className="space-y-1">
+                                <Label className="text-xs">Item Name</Label>
+                                <Input value={item.name} placeholder="e.g., Handrail" className="h-8"
+                                  onChange={(e) => updateMetalWorkItem(building.id, item.id, 'name', e.target.value)} />
+                              </div>
+                              <div className="space-y-1">
+                                <Label className="text-xs">Unit</Label>
+                                <select value={item.unit}
+                                  onChange={(e) => updateMetalWorkItem(building.id, item.id, 'unit', e.target.value)}
+                                  className="w-full h-8 px-2 rounded-md border bg-background text-sm">
+                                  <option value="ton">ton</option>
+                                  <option value="m2">m²</option>
+                                  <option value="Lm">Lm</option>
+                                  <option value="LS">LS</option>
+                                </select>
+                              </div>
+                              <div className="space-y-1">
+                                <Label className="text-xs">Qty</Label>
+                                <Input type="number" min="0" step="0.01" value={item.quantity} className="h-8"
+                                  onChange={(e) => updateMetalWorkItem(building.id, item.id, 'quantity', parseFloat(e.target.value) || 0)} />
+                              </div>
+                              <button type="button" onClick={() => removeMetalWorkItem(building.id, item.id)}
+                                className="h-8 w-8 flex items-center justify-center text-red-400 hover:text-red-600">
+                                <Trash2 className="h-3.5 w-3.5" />
+                              </button>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+
+                      {/* Other */}
+                      {scope.scopeType === 'other' && (
+                        <div className="grid grid-cols-2 gap-3">
+                          <div className="space-y-1">
+                            <Label className="text-xs">Custom Label *</Label>
+                            <Input value={scope.customLabel || ''} placeholder="e.g., Cladding"
+                              onChange={(e) => updateScopeField(building.id, 'other', 'customLabel', e.target.value)} />
+                          </div>
+                          <div className="space-y-1">
+                            <Label className="text-xs">Unit of Measurement</Label>
+                            <select value={scope.unit || 'LS'}
+                              onChange={(e) => updateScopeField(building.id, 'other', 'unit', e.target.value as 'ton' | 'm2' | 'Lm' | 'LS')}
+                              className="w-full h-9 px-3 rounded-md border bg-background text-sm">
+                              <option value="ton">ton</option>
+                              <option value="m2">m²</option>
+                              <option value="Lm">Lm</option>
+                              <option value="LS">LS</option>
+                            </select>
+                          </div>
+                          <div className="space-y-1">
+                            <Label className="text-xs">Quantity</Label>
+                            <Input type="number" step="0.01" min="0" value={scope.quantity || ''}
+                              onChange={(e) => updateScopeField(building.id, 'other', 'quantity', parseFloat(e.target.value) || undefined)}
+                              placeholder="e.g., 1" />
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              );
+            })}
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Step 4: Activities per Scope */}
+      {currentStep === 4 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Activities per Scope</CardTitle>
+            <p className="text-sm text-muted-foreground">
+              Review and toggle which activities apply to each scope. Defaults are pre-filled based on scope type.
+            </p>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            {buildings.map((building, bIdx) => {
+              const buildingScopes = getScopesForBuilding(building.id);
+              return (
+                <div key={building.id} className="border-2 rounded-xl p-5 space-y-4">
+                  <h3 className="font-bold text-base flex items-center gap-2">
+                    <span className="bg-primary text-white rounded-full w-6 h-6 flex items-center justify-center text-xs">{bIdx + 1}</span>
+                    {building.designation} — {building.name}
+                  </h3>
+                  {buildingScopes.map((scope) => {
+                    const activities = scope.activities || SCOPE_ACTIVITY_DEFAULTS[scope.scopeType] || [];
+                    return (
+                      <div key={scope.scopeType} className="bg-muted/30 rounded-lg p-4">
+                        <h4 className="font-semibold text-sm mb-3">
+                          {SCOPE_TYPE_OPTIONS.find(o => o.type === scope.scopeType)?.label || scope.scopeType}
+                          {scope.customLabel && ` — ${scope.customLabel}`}
+                        </h4>
+                        <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+                          {activities.map((activity) => (
+                            <label
+                              key={activity.activityType}
+                              className={`flex items-center gap-2 p-2 rounded-lg border cursor-pointer transition-all text-xs ${
+                                activity.isApplicable
+                                  ? 'border-primary/30 bg-primary/5 text-primary font-medium'
+                                  : 'border-gray-200 bg-gray-50 text-gray-400'
+                              }`}
+                            >
+                              <input
+                                type="checkbox"
+                                checked={activity.isApplicable}
+                                onChange={() => toggleScopeActivity(building.id, scope.scopeType, activity.activityType)}
+                                className="w-3.5 h-3.5 rounded"
+                              />
+                              {activity.activityLabel}
+                            </label>
+                          ))}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              );
+            })}
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Step 5: Duration by Stage */}
+      {currentStep === 5 && (
         <Card>
           <CardHeader>
             <CardTitle>Duration by Stage</CardTitle>
@@ -1067,8 +1703,8 @@ export default function ProjectSetupWizard() {
         </Card>
       )}
 
-      {/* Step 4: Coating System */}
-      {currentStep === 4 && (
+      {/* Step 6: Coating System */}
+      {currentStep === 6 && (
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center justify-between">
@@ -1131,8 +1767,8 @@ export default function ProjectSetupWizard() {
         </Card>
       )}
 
-      {/* Step 5: Payment Terms */}
-      {currentStep === 5 && (
+      {/* Step 7: Payment Terms */}
+      {currentStep === 7 && (
         <Card>
           <CardHeader>
             <CardTitle>Payment Terms</CardTitle>
@@ -1209,8 +1845,8 @@ export default function ProjectSetupWizard() {
         </Card>
       )}
 
-      {/* Step 6: Technical Specs */}
-      {currentStep === 6 && (
+      {/* Step 8: Technical Specs */}
+      {currentStep === 8 && (
         <Card>
           <CardHeader>
             <CardTitle>Technical Specifications</CardTitle>
@@ -1346,8 +1982,8 @@ export default function ProjectSetupWizard() {
         </Card>
       )}
 
-      {/* Step 7: Upload Parts */}
-      {currentStep === 7 && (
+      {/* Step 9: Upload Parts */}
+      {currentStep === 9 && (
         <Card>
           <CardHeader>
             <CardTitle>Upload Assembly Parts (Optional)</CardTitle>
@@ -1402,7 +2038,7 @@ export default function ProjectSetupWizard() {
           >
             Save as Draft
           </Button>
-          {currentStep < 7 ? (
+          {currentStep < 9 ? (
             <Button onClick={nextStep}>
               Next
               <ArrowRight className="ml-2 h-4 w-4" />

--- a/src/components/project-details.tsx
+++ b/src/components/project-details.tsx
@@ -324,6 +324,12 @@ export function ProjectDetails({ project, restrictedModules = [] }: ProjectDetai
                 Timeline
               </Button>
             </Link>
+            <Link href={`/projects/${project.id}/scope`}>
+              <Button variant="outline">
+                <FileText className="size-4" />
+                Scope Summary
+              </Button>
+            </Link>
             <Link href={`/projects/${project.id}/edit`}>
               <Button>
                 <Edit className="size-4" />
@@ -597,6 +603,122 @@ export function ProjectDetails({ project, restrictedModules = [] }: ProjectDetai
               </div>
             </div>
           </CollapsibleSection>
+
+          {/* Buildings & Scope */}
+          {project.buildings && project.buildings.length > 0 && (
+            <CollapsibleSection title="Buildings & Scope" icon={Building2} defaultOpen>
+              <div className="space-y-4">
+                {project.buildings.map((building: any) => (
+                  <div key={building.id} className="border rounded-xl overflow-hidden">
+                    <div className="bg-muted/40 px-4 py-3 flex items-center justify-between">
+                      <div>
+                        <span className="font-bold text-base">{building.designation}</span>
+                        <span className="text-muted-foreground ml-2">— {building.name}</span>
+                        {building.location && (
+                          <span className="ml-3 text-xs text-muted-foreground bg-background border px-2 py-0.5 rounded-full">
+                            📍 {building.location}
+                          </span>
+                        )}
+                      </div>
+                      {building.weight && (
+                        <span className="text-sm font-medium text-blue-700 bg-blue-50 border border-blue-200 px-2 py-0.5 rounded-full">
+                          {building.weight} ton
+                        </span>
+                      )}
+                    </div>
+                    <div className="divide-y">
+                      {(building.scopeOfWorks || []).map((scope: any) => (
+                        <div key={scope.id} className="px-4 py-3">
+                          <div className="flex items-start justify-between gap-4">
+                            <div className="flex-1 space-y-2">
+                              <div className="flex items-center gap-2">
+                                <span className={`text-xs font-semibold px-2 py-0.5 rounded-full border ${
+                                  scope.scopeType === 'steel' ? 'bg-blue-50 border-blue-200 text-blue-700' :
+                                  scope.scopeType === 'roof_sheeting' ? 'bg-orange-50 border-orange-200 text-orange-700' :
+                                  scope.scopeType === 'wall_sheeting' ? 'bg-amber-50 border-amber-200 text-amber-700' :
+                                  scope.scopeType === 'deck_panel' ? 'bg-purple-50 border-purple-200 text-purple-700' :
+                                  scope.scopeType === 'metal_work' ? 'bg-gray-50 border-gray-200 text-gray-700' :
+                                  'bg-green-50 border-green-200 text-green-700'
+                                }`}>
+                                  {scope.scopeLabel}{scope.customLabel ? ` — ${scope.customLabel}` : ''}
+                                </span>
+                                {scope.quantity && (
+                                  <span className="text-sm font-medium">
+                                    {scope.quantity} {scope.unit || (scope.scopeType === 'steel' ? 'ton' : 'm²')}
+                                  </span>
+                                )}
+                              </div>
+
+                              {/* Steel */}
+                              {scope.scopeType === 'steel' && scope.quantity && (
+                                <div className="text-xs text-muted-foreground">
+                                  Contractual steel quantity
+                                </div>
+                              )}
+
+                              {/* Sandwich panels */}
+                              {(scope.scopeType === 'roof_sheeting' || scope.scopeType === 'wall_sheeting') && (
+                                <div className="grid grid-cols-2 sm:grid-cols-3 gap-x-6 gap-y-1 text-xs text-muted-foreground">
+                                  {scope.ralColor && (
+                                    <div className="flex items-center gap-1.5">
+                                      <div className="w-3 h-3 rounded-sm border" style={{ backgroundColor: getRalColor(scope.ralColor) }} />
+                                      <span>RAL {scope.ralColor}</span>
+                                    </div>
+                                  )}
+                                  {scope.panelProfile && <span>Profile: <strong className="text-foreground">{scope.panelProfile}</strong></span>}
+                                  {scope.panelThickness && <span>Panel: <strong className="text-foreground">{scope.panelThickness}mm</strong></span>}
+                                  {scope.ribHeight && <span>Rib: <strong className="text-foreground">{scope.ribHeight}mm</strong></span>}
+                                  {scope.upperSheetThick && <span>Upper: <strong className="text-foreground">{scope.upperSheetThick}mm</strong></span>}
+                                  {scope.lowerSheetThick && <span>Lower: <strong className="text-foreground">{scope.lowerSheetThick}mm</strong></span>}
+                                </div>
+                              )}
+
+                              {/* Deck panel */}
+                              {scope.scopeType === 'deck_panel' && (
+                                <div className="grid grid-cols-2 gap-x-6 gap-y-1 text-xs text-muted-foreground">
+                                  {scope.deckProfile && <span>Profile: <strong className="text-foreground">{scope.deckProfile}</strong></span>}
+                                  {scope.hasShearStuds && (
+                                    <span>Shear studs: <strong className="text-foreground">{scope.shearStudQty ?? '?'} {scope.shearStudSpecs || ''}</strong></span>
+                                  )}
+                                </div>
+                              )}
+
+                              {/* Metal works */}
+                              {scope.scopeType === 'metal_work' && scope.metalWorkItems && scope.metalWorkItems.length > 0 && (
+                                <div className="text-xs space-y-0.5">
+                                  {scope.metalWorkItems.map((item: any, i: number) => (
+                                    <div key={i} className="flex gap-3 text-muted-foreground">
+                                      <span className="font-medium text-foreground">{item.name}</span>
+                                      <span>{item.quantity} {item.unit}</span>
+                                    </div>
+                                  ))}
+                                </div>
+                              )}
+                            </div>
+
+                            {/* Activities */}
+                            {scope.activities && scope.activities.length > 0 && (
+                              <div className="flex flex-wrap gap-1 justify-end">
+                                {scope.activities.filter((a: any) => a.isApplicable).map((a: any) => (
+                                  <span key={a.activityType}
+                                    className="text-[10px] px-1.5 py-0.5 rounded bg-primary/10 text-primary font-medium">
+                                    {a.activityLabel}
+                                  </span>
+                                ))}
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                      ))}
+                      {(!building.scopeOfWorks || building.scopeOfWorks.length === 0) && (
+                        <div className="px-4 py-3 text-sm text-muted-foreground">No scope defined</div>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </CollapsibleSection>
+          )}
 
           {/* Technical Specifications */}
           <CollapsibleSection title="Technical Specifications" icon={Settings} defaultOpen>

--- a/src/components/project-scope-summary.tsx
+++ b/src/components/project-scope-summary.tsx
@@ -1,0 +1,255 @@
+'use client';
+
+import Link from 'next/link';
+import { ArrowLeft, ExternalLink } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+
+const SCOPE_COLORS: Record<string, string> = {
+  steel: 'bg-blue-50 border-blue-200 text-blue-800',
+  roof_sheeting: 'bg-orange-50 border-orange-200 text-orange-800',
+  wall_sheeting: 'bg-amber-50 border-amber-200 text-amber-800',
+  deck_panel: 'bg-purple-50 border-purple-200 text-purple-800',
+  metal_work: 'bg-gray-50 border-gray-200 text-gray-800',
+  other: 'bg-green-50 border-green-200 text-green-800',
+};
+
+const ralColors: Record<string, string> = {
+  '9005': '#0E0E10', '9002': '#E8E4D9', '9001': '#FDF8EF', '9003': '#ECECE7',
+  '7016': '#293133', '7035': '#D7D7D7', '6005': '#2F4538', '5010': '#0E294B',
+  '3000': '#AF2B1E', '1003': '#E5BE01',
+};
+
+function getRalSwatch(ral: string): string {
+  const clean = ral.replace(/[^0-9]/g, '');
+  return ralColors[clean] || '#CCCCCC';
+}
+
+type ScopeOfWork = {
+  id: string;
+  scopeType: string;
+  scopeLabel: string;
+  customLabel?: string;
+  quantity?: number;
+  unit?: string;
+  ralColor?: string;
+  panelThickness?: number;
+  ribHeight?: number;
+  upperSheetThick?: number;
+  lowerSheetThick?: number;
+  panelProfile?: string;
+  deckProfile?: string;
+  hasShearStuds?: boolean;
+  shearStudQty?: number;
+  shearStudSpecs?: string;
+  metalWorkItems?: { name: string; unit: string; quantity: number }[];
+  building?: { id: string; name: string; designation: string; location?: string; weight?: number };
+  activities?: { activityType: string; activityLabel: string; isApplicable: boolean }[];
+};
+
+type ProjectScopeSummaryProps = {
+  project: {
+    id: string;
+    projectNumber: string;
+    name: string;
+    buildings?: { id: string; designation: string; name: string; location?: string; weight?: number; scopeOfWorks?: ScopeOfWork[] }[];
+  };
+  scopeOfWorks: ScopeOfWork[];
+};
+
+export function ProjectScopeSummary({ project, scopeOfWorks }: ProjectScopeSummaryProps) {
+  const buildings = project.buildings || [];
+
+  // Group scopes by building
+  const scopesByBuilding: Record<string, ScopeOfWork[]> = {};
+  for (const scope of scopeOfWorks) {
+    const bId = scope.building?.id || 'unknown';
+    if (!scopesByBuilding[bId]) scopesByBuilding[bId] = [];
+    scopesByBuilding[bId].push(scope);
+  }
+
+  return (
+    <div className="max-w-6xl mx-auto space-y-6 p-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <Link href={`/projects/${project.id}`} className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground mb-2">
+            <ArrowLeft className="h-4 w-4" /> Back to Project
+          </Link>
+          <h1 className="text-2xl font-bold">{project.projectNumber} — {project.name}</h1>
+          <p className="text-muted-foreground text-sm mt-1">Scope of Work Summary</p>
+        </div>
+        <Link href={`/projects/${project.id}/edit`}>
+          <Button variant="outline" size="sm">
+            <ExternalLink className="h-4 w-4 mr-2" />
+            Edit Project
+          </Button>
+        </Link>
+      </div>
+
+      {/* Summary table per building */}
+      {buildings.length === 0 && scopeOfWorks.length === 0 && (
+        <Card>
+          <CardContent className="py-10 text-center text-muted-foreground">
+            No buildings or scope data found for this project.
+          </CardContent>
+        </Card>
+      )}
+
+      {buildings.map((building) => {
+        const bScopes = building.scopeOfWorks || scopesByBuilding[building.id] || [];
+        return (
+          <Card key={building.id} className="overflow-hidden">
+            <CardHeader className="bg-muted/40 pb-3">
+              <div className="flex items-center justify-between">
+                <div>
+                  <CardTitle className="text-base">
+                    <span className="text-primary font-mono">{building.designation}</span>
+                    <span className="text-muted-foreground font-normal ml-2">— {building.name}</span>
+                  </CardTitle>
+                  {building.location && (
+                    <p className="text-xs text-muted-foreground mt-1">📍 {building.location}</p>
+                  )}
+                </div>
+                {building.weight && (
+                  <span className="text-sm font-semibold text-blue-700 bg-blue-50 border border-blue-200 px-3 py-1 rounded-full">
+                    {building.weight} ton (estimated)
+                  </span>
+                )}
+              </div>
+            </CardHeader>
+            <CardContent className="p-0">
+              {bScopes.length === 0 ? (
+                <div className="px-6 py-4 text-sm text-muted-foreground">No scope defined for this building.</div>
+              ) : (
+                <div className="divide-y">
+                  {bScopes.map((scope) => (
+                    <div key={scope.id} className="px-6 py-4 grid grid-cols-1 md:grid-cols-[200px_1fr_auto] gap-4">
+                      {/* Scope type badge */}
+                      <div className="flex items-start">
+                        <span className={`inline-block text-xs font-semibold px-3 py-1 rounded-full border ${SCOPE_COLORS[scope.scopeType] || SCOPE_COLORS.other}`}>
+                          {scope.scopeLabel}
+                          {scope.customLabel && ` — ${scope.customLabel}`}
+                        </span>
+                      </div>
+
+                      {/* Specs */}
+                      <div className="space-y-2">
+                        {/* Quantity */}
+                        {scope.quantity && (
+                          <div className="text-sm font-medium">
+                            <span className="text-2xl font-bold text-foreground">{scope.quantity}</span>
+                            <span className="text-muted-foreground ml-1">
+                              {scope.unit || (scope.scopeType === 'steel' ? 'ton' : 'm²')}
+                            </span>
+                          </div>
+                        )}
+
+                        {/* Sandwich panel specs */}
+                        {(scope.scopeType === 'roof_sheeting' || scope.scopeType === 'wall_sheeting') && (
+                          <div className="flex flex-wrap gap-3 text-xs">
+                            {scope.ralColor && (
+                              <div className="flex items-center gap-1.5 bg-background border rounded-md px-2 py-1">
+                                <div className="w-4 h-4 rounded-sm border" style={{ backgroundColor: getRalSwatch(scope.ralColor) }} />
+                                <span className="font-medium">RAL {scope.ralColor}</span>
+                              </div>
+                            )}
+                            {scope.panelProfile && (
+                              <div className="bg-background border rounded-md px-2 py-1">
+                                Profile: <strong>{scope.panelProfile}</strong>
+                              </div>
+                            )}
+                            {scope.panelThickness && (
+                              <div className="bg-background border rounded-md px-2 py-1">
+                                Panel: <strong>{scope.panelThickness}mm</strong>
+                              </div>
+                            )}
+                            {scope.ribHeight && (
+                              <div className="bg-background border rounded-md px-2 py-1">
+                                Rib: <strong>{scope.ribHeight}mm</strong>
+                              </div>
+                            )}
+                            {(scope.upperSheetThick || scope.lowerSheetThick) && (
+                              <div className="bg-background border rounded-md px-2 py-1">
+                                Sheets: <strong>{scope.upperSheetThick}mm / {scope.lowerSheetThick}mm</strong>
+                              </div>
+                            )}
+                          </div>
+                        )}
+
+                        {/* Deck panel specs */}
+                        {scope.scopeType === 'deck_panel' && (
+                          <div className="flex flex-wrap gap-3 text-xs">
+                            {scope.deckProfile && (
+                              <div className="bg-background border rounded-md px-2 py-1">
+                                Profile: <strong>{scope.deckProfile}</strong>
+                              </div>
+                            )}
+                            {scope.hasShearStuds && (
+                              <div className="bg-background border rounded-md px-2 py-1">
+                                Shear Studs: <strong>{scope.shearStudQty ?? '?'}</strong>
+                                {scope.shearStudSpecs && <span className="text-muted-foreground ml-1">({scope.shearStudSpecs})</span>}
+                              </div>
+                            )}
+                          </div>
+                        )}
+
+                        {/* Metal works */}
+                        {scope.scopeType === 'metal_work' && scope.metalWorkItems && scope.metalWorkItems.length > 0 && (
+                          <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+                            {scope.metalWorkItems.map((item, i) => (
+                              <div key={i} className="bg-background border rounded-md px-3 py-1.5 text-xs">
+                                <div className="font-medium">{item.name}</div>
+                                <div className="text-muted-foreground">{item.quantity} {item.unit}</div>
+                              </div>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+
+                      {/* Activities */}
+                      {scope.activities && scope.activities.length > 0 && (
+                        <div className="flex flex-col gap-1">
+                          <p className="text-xs text-muted-foreground mb-1">Activities</p>
+                          <div className="flex flex-wrap gap-1">
+                            {scope.activities.filter((a) => a.isApplicable).map((a) => (
+                              <span key={a.activityType}
+                                className="text-[10px] px-1.5 py-0.5 rounded bg-primary/10 text-primary font-medium">
+                                {a.activityLabel}
+                              </span>
+                            ))}
+                            {scope.activities.filter((a) => !a.isApplicable).map((a) => (
+                              <span key={a.activityType}
+                                className="text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground line-through">
+                                {a.activityLabel}
+                              </span>
+                            ))}
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        );
+      })}
+
+      {/* Scopes without a known building (shouldn't happen, but just in case) */}
+      {scopeOfWorks.filter((s) => !s.building || !buildings.find((b) => b.id === s.building?.id)).length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm text-muted-foreground">Other Scopes (unlinked buildings)</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">
+              {scopeOfWorks.filter((s) => !s.building).length} scope(s) without linked building data.
+            </p>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Redesigned the project setup wizard and tracker to support per-building, multi-scope definitions with scope-specific specifications and activity management. This enables projects to define Steel, Roof Sheeting, Wall Sheeting, Deck Panel, Metal Works, and Other scopes independently per building, each with custom quantities, material specs, and applicable activities.

## Key Changes

### Project Wizard (9 Steps)
- **Step 3 — Scope Definition**: New accordion-based UI per building with scope type selection (Steel mandatory, others optional). Each scope type has a dedicated spec form:
  - Steel: quantity (ton)
  - Roof/Wall Sheeting: RAL color, panel thickness, rib height, upper/lower sheet thickness, profile (flat/ribbed)
  - Deck Panel: profile, shear studs (qty & specs)
  - Metal Works: line-item table for custom metal work items
  - Other: custom label and quantity
- **Step 4 — Activities per Scope**: Toggle activity applicability per scope with pre-populated defaults based on scope type (e.g., Design is applicable for Steel but not for Roof Sheeting)
- Removed legacy Step 1 scope-of-work checkboxes; validation now requires buildings with Steel scope definitions
- Auto-creates Steel scope for each building when transitioning from Step 2 to Step 3

### Data Model & API
- **Building**: Added `location` field (VARCHAR 500)
- **ScopeOfWork**: Extended with 15+ new fields:
  - Quantity & unit (ton, m², Lm, LS)
  - Sandwich panel specs: `ralColor`, `panelThickness`, `ribHeight`, `upperSheetThick`, `lowerSheetThick`, `panelProfile`
  - Deck panel specs: `deckProfile`, `hasShearStuds`, `shearStudQty`, `shearStudSpecs`
  - Metal works: `metalWorkItems` (JSON array)
  - Per-scope coating: `coatingSameAsProject`, `scopeCoatingSystem`
- **BuildingActivity**: New model to track activity applicability per scope (created during project save)
- API endpoints updated to accept and persist all new scope detail fields

### Project Tracker
- Redesigned to show buildings as collapsible group headers with one row per scope
- Activities display "N/A" for non-applicable scopes (based on `BuildingActivity.isApplicable`)
- Added scope type color badges (blue=Steel, orange=Roof, amber=Wall, purple=Deck, gray=Metal, green=Other)
- Removed legacy `getPrimaryScope` logic; now iterates all scopes per building

### New Components & Pages
- **ProjectScopeSummary** component: Displays per-building scope details with spec cards, RAL color swatches, and activity lists
- **`/projects/[id]/scope`** page: Dedicated scope summary view with back navigation and edit link

### Database Migrations
- `v22_13_scope_fields.sql`: Adds all new columns to Building and ScopeOfWork with safe conditional checks
- `v22_14_backfill_scope_quantity.sql`: Backfills Steel scope quantities from existing Building.weight

### Constants & Defaults
- `SCOPE_ACTIVITY_DEFAULTS`: Matrix of default activities per scope type (7 activities: Design, Detailing, Procurement, Production, Coating, Dispatch, Erection)
- `SCOPE_TYPE_OPTIONS`: Scope type labels and Tailwind color classes

## Implementation Details
- Scope definitions stored in component state during wizard; persisted to DB on project save
- Steel scope is mandatory and cannot be removed; other scopes are optional
- Activity applicability defaults are cloned per scope and can be toggled before save
- Metal work items use client-generated IDs (`mwi-${Date.now()}`) during wizard, persisted as JSON
- Project save creates BuildingActivity records in bulk for all scopes and activities
- Backward compatible: legacy projects without scope definitions still function (auto-create Steel scope on first access)

https://claude.ai/code/session_017B7bSPYDicPvKNHqbG6Qyv