### PR TITLE
fix(23.0.1): 404 fix, sidebar modules, activity unification & task SoW column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [23.0.1] - 2026-05-07
+
+### 404 Fix, Sidebar Modules, Activity Unification & Task SoW Column
+
+#### Fixed
+- **Subcontractor-contracts 404** — `/subcontractor-contracts` now redirects to `/supply-chain/subcontractors`.
+- **Project Card missing from sidebar** — `/project-card` added to `NAVIGATION_PERMISSIONS` with `projects.view` / `projects.view_all`.
+- **SC Contracts missing from sidebar (CEO/Admin)** — `auth/me` now returns fully-resolved permissions as `navPermissions` for `isAdmin` users; new modules are always visible to admins regardless of DB role cache.
+- **Project tracker Delivery column showing 0%/N/A** — `TRACKER_COLUMNS` type and `PRODUCTION_PROCESS_TYPES` key updated from `dispatch` to `delivery`.
+
+#### Added
+- **Scope of Work column** in tasks flat-list table — shown between Building and Main Activity columns, displaying the SoW scope label for each task.
+- **DB migration v23.0.1** — renames `BuildingActivity.activityType` `dispatch` → `delivery`; renames `Task.mainActivity` `delivery_logistics` → `delivery`.
+
+#### Changed
+- **Unified activity name** — `dispatch` renamed to `delivery` across TRACKER_COLUMNS, wizard SCOPE_ACTIVITY_DEFAULTS, building-activities API, EWS engine, planning stages, google-sheets-sync, and project-tracker client.
+- **Unified activity name** — `delivery_logistics` renamed to `delivery` in MAIN_ACTIVITIES and SUB_ACTIVITIES (activity-constants.ts).
+- Version bumped to **23.0.1**
+
+---
+
 ## [23.0.0] - 2026-05-07
 
 ### Subcontractor Contracts Module

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexa-steel-ots",
-  "version": "23.0.0",
+  "version": "23.0.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/prisma/manual_migrations/v23_0_1_unify_activity_names.sql
+++ b/prisma/manual_migrations/v23_0_1_unify_activity_names.sql
@@ -1,0 +1,17 @@
+-- v23.0.1: Unify activity names — rename 'dispatch' → 'delivery' across BuildingActivity
+-- and 'delivery_logistics' → 'delivery' in Task.mainActivity
+
+-- Rename dispatch → delivery in BuildingActivity.activityType
+UPDATE BuildingActivity
+SET activityType = 'delivery'
+WHERE activityType = 'dispatch';
+
+-- Rename delivery_logistics → delivery in Task.mainActivity
+UPDATE Task
+SET mainActivity = 'delivery'
+WHERE mainActivity = 'delivery_logistics';
+
+-- Also update any activityLabel references in BuildingActivity
+UPDATE BuildingActivity
+SET activityLabel = 'Delivery'
+WHERE activityType = 'delivery' AND (activityLabel = 'Dispatch' OR activityLabel = 'Dispatch & Delivery');

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -25,8 +25,9 @@ export async function GET() {
   });
 
   // navPermissions reflects the role's selected permissions for sidebar visibility.
-  // Admins still get full API access above, but sidebar respects role deselections.
-  const navPermissions = (user.role.permissions as string[]) || [];
+  // Admins get all resolved permissions so new modules are always visible.
+  // Non-admins respect their role's explicit permission selections.
+  const navPermissions = user.isAdmin ? permissions : (user.role.permissions as string[]) || [];
 
   return NextResponse.json({
     id: user.id,

--- a/src/app/api/building-activities/route.ts
+++ b/src/app/api/building-activities/route.ts
@@ -7,7 +7,7 @@ import { logger } from '@/lib/logger';
 const ACTIVITY_TYPES = [
   'arch_approval', 'material_approval', 'design', 'design_approval',
   'anchor_bolts', 'surveying_as_built', 'detailing', 'detailing_approval',
-  'procurement', 'production', 'coating', 'dispatch', 'erection',
+  'procurement', 'production', 'coating', 'delivery', 'erection',
 ] as const;
 
 const bulkCreateSchema = z.object({

--- a/src/app/api/production/fix-process-types/route.ts
+++ b/src/app/api/production/fix-process-types/route.ts
@@ -56,6 +56,7 @@ const CANONICAL_MAP: Record<string, string> = {
   'erect': 'Erection',
 
   // Dispatched to Sandblasting
+  'delivery': 'Dispatched to Sandblasting',
   'dispatch': 'Dispatched to Sandblasting',
   'dispatched to sandblasting': 'Dispatched to Sandblasting',
   'dispatch to sandblasting': 'Dispatched to Sandblasting',

--- a/src/app/api/system/latest-version/route.ts
+++ b/src/app/api/system/latest-version/route.ts
@@ -8,26 +8,27 @@ const { version: pkgVersion } = require('../../../../../package.json') as { vers
 const CURRENT_VERSION = {
   version: pkgVersion,
   date: 'May 7, 2026',
-  type: 'minor' as const,
-  mainTitle: 'Project Card',
+  type: 'patch' as const,
+  mainTitle: '404 Fix, Sidebar Modules & Activity Unification',
   highlights: [
-    'New Project Card page — full project overview with project & building navigation, technical specs, coating, stage durations, and scope aggregation.',
-    'Switch projects and buildings using arrow buttons or dropdowns without leaving the page.',
-    'Aggregated "All Buildings" view shows combined tonnage, area, and scopes across the entire project.',
+    '/subcontractor-contracts now redirects to /supply-chain/subcontractors instead of returning 404.',
+    'Project Card and SC Contracts now appear in sidebar for admin/CEO users.',
+    'Activity names unified across all modules: "Dispatch" renamed to "Delivery" system-wide.',
+    'Tasks table gains a Scope of Work column between Building and Main Activity.',
   ],
   changes: {
     added: [
-      'Project Card page at /projects/[id]/buildings with project selector (dropdown + prev/next arrows) and building tabs (All + per-building + prev/next arrows).',
-      'Technical Information section: cranes, third-party inspection, incoterm, welding process/WPS/PQR, NDT, applicable codes.',
-      'Coating System section: paint coats, galvanization microns, RAL top-coat colour chip.',
-      'Stage Durations section: engineering / operations / site week ranges displayed as visual progress bars.',
-      'Aggregated scope view when "All Buildings" selected: groups scopes by type with total quantities.',
-      'Buildings Breakdown collapsible card listing all buildings with tonnage, area, and scope badges.',
-      '/project-card sidebar shortcut — redirects to first active project\'s card.',
+      '/subcontractor-contracts redirect page.',
+      'Scope of Work column in tasks table between Building and Main Activity.',
+      'DB migration v23.0.1: dispatch→delivery in BuildingActivity; delivery_logistics→delivery in Task.mainActivity.',
     ],
-    fixed: [],
+    fixed: [
+      'Project Card and SC Contracts missing from sidebar (admin/CEO).',
+      'Project tracker Delivery column showing 0% — TRACKER_COLUMNS updated from dispatch to delivery.',
+    ],
     changed: [
-      'Buildings page renamed to "Project Card" in sidebar and page title.',
+      'Activity "dispatch" renamed to "delivery" across all system modules.',
+      'Activity "delivery_logistics" renamed to "delivery" in task activity constants.',
     ],
   },
 };

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -96,6 +96,9 @@ export async function GET(
       building: {
         select: { id: true, designation: true, name: true },
       },
+      scopeOfWork: {
+        select: { id: true, scopeType: true, scopeLabel: true },
+      },
       department: {
         select: { id: true, name: true },
       },
@@ -362,6 +365,9 @@ export async function PATCH(
       },
       building: {
         select: { id: true, designation: true, name: true },
+      },
+      scopeOfWork: {
+        select: { id: true, scopeType: true, scopeLabel: true },
       },
       department: {
         select: { id: true, name: true },

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -163,6 +163,9 @@ export async function GET(req: Request) {
       building: {
         select: { id: true, designation: true, name: true },
       },
+      scopeOfWork: {
+        select: { id: true, scopeType: true, scopeLabel: true },
+      },
       department: {
         select: { id: true, name: true },
       },
@@ -322,6 +325,9 @@ export async function POST(req: Request) {
         },
         building: {
           select: { id: true, designation: true, name: true },
+        },
+        scopeOfWork: {
+          select: { id: true, scopeType: true, scopeLabel: true },
         },
         department: {
           select: { id: true, name: true },

--- a/src/app/changelog/_page-client.tsx
+++ b/src/app/changelog/_page-client.tsx
@@ -23,10 +23,41 @@ type ChangelogVersion = {
 // Version order: Most recent first
 const hardcodedVersions: ChangelogVersion[] = [
   {
+    version: '23.0.1',
+    date: 'May 7, 2026',
+    type: 'patch',
+    status: 'current',
+    mainTitle: '404 Fix, Sidebar Modules, Activity Unification & Task SoW Column',
+    highlights: [
+      'Fixed /subcontractor-contracts returning 404 — now redirects to /supply-chain/subcontractors.',
+      'Project Card and SC Contracts now appear in sidebar for admin/CEO users — navigation permissions patched and admin navPermissions resolution fixed.',
+      'Unified activity name: "Dispatch" renamed to "Delivery" across all modules (tracker, wizard, task activities, EWS, planning, DB migration).',
+      'Tasks table gains a Scope of Work column between Building and Main Activity — shows which SoW scope the task belongs to.',
+      'DB migration v23.0.1: renames BuildingActivity.activityType dispatch→delivery and Task.mainActivity delivery_logistics→delivery.',
+    ],
+    changes: {
+      added: [
+        '/subcontractor-contracts redirect page — navigates to /supply-chain/subcontractors to fix 404 for bookmarked URLs.',
+        'Scope of Work column in tasks flat-list table between Building and Main Activity columns.',
+        'DB migration v23.0.1: renames dispatch→delivery in BuildingActivity; renames delivery_logistics→delivery in Task.mainActivity.',
+      ],
+      fixed: [
+        'Project Card sidebar entry missing — /project-card added to NAVIGATION_PERMISSIONS with projects.view/projects.view_all.',
+        'SC Contracts sidebar entry missing for admin/CEO — auth/me now returns full resolved permissions as navPermissions for isAdmin users, ensuring all new modules are visible.',
+        'Project tracker showing 0% / N/A for delivery column — TRACKER_COLUMNS type and PRODUCTION_PROCESS_TYPES key updated from "dispatch" to "delivery".',
+      ],
+      changed: [
+        'Activity name unified: "dispatch" → "delivery" in TRACKER_COLUMNS, wizard SCOPE_ACTIVITY_DEFAULTS, building-activities API, EWS engine, planning stages, google-sheets-sync, and project-tracker client.',
+        'Activity name unified: "delivery_logistics" → "delivery" in MAIN_ACTIVITIES and SUB_ACTIVITIES (activity-constants.ts).',
+        'Version bumped to 23.0.1',
+      ],
+    },
+  },
+  {
     version: '23.0.0',
     date: 'May 7, 2026',
     type: 'major',
-    status: 'current',
+    status: 'previous',
     mainTitle: 'Subcontractor Contracts Module',
     highlights: [
       'New Subcontractor Contracts module — full lifecycle for COGS/installation subcontractors: create, approve, activate, progress certificates, and dashboard.',
@@ -57,6 +88,69 @@ const hardcodedVersions: ChangelogVersion[] = [
       fixed: [],
       changed: [
         'Version bumped to 23.0.0 (major release).',
+      ],
+    },
+  },
+  {
+    version: '22.15.0',
+    date: 'May 7, 2026',
+    type: 'minor',
+    status: 'previous',
+    mainTitle: 'Project Card',
+    highlights: [
+      'New Project Card page at /projects/[id]/buildings — comprehensive per-building viewer with technical info, coating system, stage durations, and scope aggregation.',
+      'Project selector with previous/next arrow navigation; building tabs with "All" aggregate view.',
+      'Technical Information: cranes, third-party inspection, incoterm, erection subcontractor, structure type, welding details, NDT, applicable codes, area/tonne ratio.',
+      'Coating System: coating name, coats, galvanization microns, paint DFT, top-coat RAL chip.',
+      'Stage Durations: engineering, operations, and site week ranges with visual progress bars.',
+      '/project-card sidebar shortcut redirects to first active project (falls back to any project, then /projects).',
+    ],
+    changes: {
+      added: [
+        'Project Card page at /projects/[id]/buildings with full building detail view.',
+        'Project selector dropdown + previous/next arrows to navigate between all projects.',
+        'Building tab strip with previous/next navigation; "All" tab aggregates quantities across buildings.',
+        'Technical Information section: cranes, 3rd-party inspection (required + responsibility), incoterm, erection subcontractor, structure type, welding process/WPS/PQR, NDT test, applicable codes, area/m²-per-tonne.',
+        'Coating System section: coating name, coats count, galvanization microns, paint coats with DFT, top-coat RAL colour chip.',
+        'Stage Durations section: engineering, operations, site week ranges as visual progress bars with planned start/end dates.',
+        'Buildings Breakdown card: collapsible list of all buildings with tonnage, area, scope badges; clicking switches to that building.',
+        '/project-card route: sidebar shortcut redirecting to first active project\'s buildings page.',
+      ],
+      fixed: [],
+      changed: [
+        'Version bumped to 22.15.0',
+      ],
+    },
+  },
+  {
+    version: '22.14.0',
+    date: 'May 7, 2026',
+    type: 'patch',
+    status: 'previous',
+    mainTitle: 'Bug Fixes, Task Scope & Building Details',
+    highlights: [
+      'Assembly parts API: fixed PostgreSQL-only mode insensitive and missing soft-delete filter.',
+      'Project tracker API: fixed 500 error from missing ScopeOfWork/BuildingActivity tables — added missing migrations to startup list.',
+      'Project edit mode: min/max week duration fields now render in edit mode.',
+      'Building Details page at /projects/[id]/buildings with per-building cards: assembly tonnage, total area, paintable area, coating system, panel specs, and scope badges.',
+      'Task scope column: scopeOfWorkId FK added to Task; auto-selects steel scope for single-scope buildings.',
+    ],
+    changes: {
+      added: [
+        'Building Details page at /projects/[id]/buildings: per-building assembly tonnage, total area, paintable area (total − purlin), coating system with RAL color, sandwich panel specs (wall/roof: thickness, upper/lower sheet, rib height, profile), deck panel specs, and scope badges.',
+        'Task scopeOfWorkId FK: added to Task table; create/edit form auto-selects steel scope for single-scope buildings, shows dropdown when multiple scopes exist; existing tasks backfilled to steel scope.',
+        'Scope of work inline editing from project detail page: edit quantity, unit, RAL color, and specification per scope row.',
+        'Project tracker expansion: steel-only buildings render as flat rows (no accordion); all buildings expand by default; Expand All / Collapse All buttons in header.',
+        'add_scope_of_work.sql and all v22.13 migrations added to startup-migrations list.',
+      ],
+      fixed: [
+        'Assembly parts API: removed PostgreSQL-only mode: insensitive from Prisma purlin aggregate query (MySQL is case-insensitive by default); added missing deletedAt: null filter.',
+        'Project tracker API: 500 error from ScopeOfWork/BuildingActivity tables not existing on production — migrations now run on server start.',
+        'Project edit mode duration fields: min/max week fields for engineering, operations, and site now render in edit mode.',
+        'Project edit tabs: scope definition/edit tab removed; 4 tabs remain.',
+      ],
+      changed: [
+        'Version bumped to 22.14.0',
       ],
     },
   },

--- a/src/app/planning/_page-client.tsx
+++ b/src/app/planning/_page-client.tsx
@@ -57,7 +57,7 @@ const SCOPE_OPTIONS = [
   { id: 'painting', label: 'Painting' },
   { id: 'roofSheeting', label: 'Roof Sheeting' },
   { id: 'wallSheeting', label: 'Wall Sheeting' },
-  { id: 'delivery', label: 'Delivery & Logistics' },
+  { id: 'delivery', label: 'Delivery' },
   { id: 'erection', label: 'Erection' },
 ];
 

--- a/src/app/project-tracker/_page-client.tsx
+++ b/src/app/project-tracker/_page-client.tsx
@@ -133,7 +133,7 @@ const ACTIVITY_COLUMNS = [
   { type: 'procurement',   label: 'PROCUREMENT',   color: 'text-amber-400' },
   { type: 'production',    label: 'PRODUCTION',    color: 'text-orange-400' },
   { type: 'coating',       label: 'COATING',       color: 'text-pink-400' },
-  { type: 'dispatch',      label: 'DISPATCH',      color: 'text-lime-400' },
+  { type: 'delivery',      label: 'DELIVERY',      color: 'text-lime-400' },
   { type: 'erection',      label: 'ERECTION',      color: 'text-emerald-400' },
 ] as const;
 
@@ -385,7 +385,7 @@ function DetailPopover({
       {/* Production details */}
       {activity.details.production && (
         <div className={`rounded-md p-2 border ${isDark ? 'border-slate-700 bg-slate-800/50' : 'border-slate-200 bg-slate-50'}`}>
-          {activity.activityType === 'dispatch' ? (
+          {activity.activityType === 'delivery' ? (
             <div className="space-y-1.5">
               <div className="flex items-center justify-between">
                 <span className={muted}>

--- a/src/app/projects/wizard/_page-client.tsx
+++ b/src/app/projects/wizard/_page-client.tsx
@@ -93,7 +93,7 @@ const SCOPE_ACTIVITY_DEFAULTS: Record<string, { activityType: string; activityLa
     { activityType: 'procurement', activityLabel: 'Procurement', isApplicable: true, sortOrder: 3 },
     { activityType: 'production', activityLabel: 'Production', isApplicable: true, sortOrder: 4 },
     { activityType: 'coating', activityLabel: 'Coating', isApplicable: true, sortOrder: 5 },
-    { activityType: 'dispatch', activityLabel: 'Dispatch & Delivery', isApplicable: true, sortOrder: 6 },
+    { activityType: 'delivery', activityLabel: 'Delivery', isApplicable: true, sortOrder: 6 },
     { activityType: 'erection', activityLabel: 'Erection', isApplicable: true, sortOrder: 7 },
   ],
   roof_sheeting: [
@@ -102,7 +102,7 @@ const SCOPE_ACTIVITY_DEFAULTS: Record<string, { activityType: string; activityLa
     { activityType: 'procurement', activityLabel: 'Procurement', isApplicable: true, sortOrder: 3 },
     { activityType: 'production', activityLabel: 'Production', isApplicable: false, sortOrder: 4 },
     { activityType: 'coating', activityLabel: 'Coating', isApplicable: false, sortOrder: 5 },
-    { activityType: 'dispatch', activityLabel: 'Dispatch & Delivery', isApplicable: true, sortOrder: 6 },
+    { activityType: 'delivery', activityLabel: 'Delivery', isApplicable: true, sortOrder: 6 },
     { activityType: 'erection', activityLabel: 'Erection', isApplicable: true, sortOrder: 7 },
   ],
   wall_sheeting: [
@@ -111,7 +111,7 @@ const SCOPE_ACTIVITY_DEFAULTS: Record<string, { activityType: string; activityLa
     { activityType: 'procurement', activityLabel: 'Procurement', isApplicable: true, sortOrder: 3 },
     { activityType: 'production', activityLabel: 'Production', isApplicable: false, sortOrder: 4 },
     { activityType: 'coating', activityLabel: 'Coating', isApplicable: false, sortOrder: 5 },
-    { activityType: 'dispatch', activityLabel: 'Dispatch & Delivery', isApplicable: true, sortOrder: 6 },
+    { activityType: 'delivery', activityLabel: 'Delivery', isApplicable: true, sortOrder: 6 },
     { activityType: 'erection', activityLabel: 'Erection', isApplicable: true, sortOrder: 7 },
   ],
   deck_panel: [
@@ -120,7 +120,7 @@ const SCOPE_ACTIVITY_DEFAULTS: Record<string, { activityType: string; activityLa
     { activityType: 'procurement', activityLabel: 'Procurement', isApplicable: true, sortOrder: 3 },
     { activityType: 'production', activityLabel: 'Production', isApplicable: false, sortOrder: 4 },
     { activityType: 'coating', activityLabel: 'Coating', isApplicable: false, sortOrder: 5 },
-    { activityType: 'dispatch', activityLabel: 'Dispatch & Delivery', isApplicable: true, sortOrder: 6 },
+    { activityType: 'delivery', activityLabel: 'Delivery', isApplicable: true, sortOrder: 6 },
     { activityType: 'erection', activityLabel: 'Erection', isApplicable: true, sortOrder: 7 },
   ],
   metal_work: [
@@ -129,7 +129,7 @@ const SCOPE_ACTIVITY_DEFAULTS: Record<string, { activityType: string; activityLa
     { activityType: 'procurement', activityLabel: 'Procurement', isApplicable: true, sortOrder: 3 },
     { activityType: 'production', activityLabel: 'Production', isApplicable: true, sortOrder: 4 },
     { activityType: 'coating', activityLabel: 'Coating', isApplicable: true, sortOrder: 5 },
-    { activityType: 'dispatch', activityLabel: 'Dispatch & Delivery', isApplicable: true, sortOrder: 6 },
+    { activityType: 'delivery', activityLabel: 'Delivery', isApplicable: true, sortOrder: 6 },
     { activityType: 'erection', activityLabel: 'Erection', isApplicable: true, sortOrder: 7 },
   ],
   other: [
@@ -138,7 +138,7 @@ const SCOPE_ACTIVITY_DEFAULTS: Record<string, { activityType: string; activityLa
     { activityType: 'procurement', activityLabel: 'Procurement', isApplicable: true, sortOrder: 3 },
     { activityType: 'production', activityLabel: 'Production', isApplicable: false, sortOrder: 4 },
     { activityType: 'coating', activityLabel: 'Coating', isApplicable: false, sortOrder: 5 },
-    { activityType: 'dispatch', activityLabel: 'Dispatch & Delivery', isApplicable: true, sortOrder: 6 },
+    { activityType: 'delivery', activityLabel: 'Delivery', isApplicable: true, sortOrder: 6 },
     { activityType: 'erection', activityLabel: 'Erection', isApplicable: false, sortOrder: 7 },
   ],
 };

--- a/src/app/subcontractor-contracts/page.tsx
+++ b/src/app/subcontractor-contracts/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function SubcontractorContractsRedirect() {
+  redirect('/supply-chain/subcontractors');
+}

--- a/src/components/tasks-client.tsx
+++ b/src/components/tasks-client.tsx
@@ -53,6 +53,7 @@ type Task = {
   releaseDate: string | null;
   project: { id: string; projectNumber: string; name: string } | null;
   building: { id: string; designation: string; name: string } | null;
+  scopeOfWork: { id: string; scopeType: string; scopeLabel: string } | null;
   department: { id: string; name: string } | null;
   mainActivity: string | null;
   subActivity: string | null;
@@ -1708,6 +1709,7 @@ export function TasksClient({ initialTasks, userId, allUsers, allProjects, allBu
                     <TableHead className="cursor-pointer select-none" onClick={() => handleSort('building')}>
                       <div className="flex items-center">Building {getSortIcon('building')}</div>
                     </TableHead>
+                    <TableHead>Scope</TableHead>
                     <TableHead className="cursor-pointer select-none" onClick={() => handleSort('mainActivity')}>
                       Main Activity{getSortIcon('mainActivity')}
                     </TableHead>
@@ -1843,6 +1845,7 @@ export function TasksClient({ initialTasks, userId, allUsers, allProjects, allBu
                             ))}
                         </select>
                       </TableCell>
+                      <TableCell></TableCell>
                       <TableCell>
                         <select
                           value={quickAddData.mainActivity}
@@ -2217,6 +2220,14 @@ export function TasksClient({ initialTasks, userId, allUsers, allProjects, allBu
                           ) : (
                             <span className="text-muted-foreground">-</span>
                           )
+                        )}
+                      </TableCell>
+                      {/* Scope of Work */}
+                      <TableCell>
+                        {task.scopeOfWork ? (
+                          <span className="text-sm">{task.scopeOfWork.scopeLabel}</span>
+                        ) : (
+                          <span className="text-muted-foreground text-sm">-</span>
                         )}
                       </TableCell>
                       <TableCell>

--- a/src/lib/activity-constants.ts
+++ b/src/lib/activity-constants.ts
@@ -5,7 +5,7 @@ export const MAIN_ACTIVITIES = [
   { key: 'procurement', label: 'Procurement' },
   { key: 'production', label: 'Production' },
   { key: 'coating', label: 'Coating' },
-  { key: 'delivery_logistics', label: 'Delivery & Logistics' },
+  { key: 'delivery', label: 'Delivery' },
   { key: 'erection', label: 'Erection' },
 ] as const;
 
@@ -42,7 +42,7 @@ export const SUB_ACTIVITIES: Record<string, { key: string; label: string }[]> = 
     { key: 'painting', label: 'Painting' },
     { key: 'galvanization', label: 'Galvanization' },
   ],
-  delivery_logistics: [
+  delivery: [
     { key: 'dispatch_sand_blasting', label: 'Dispatch to Sand Blasting' },
     { key: 'dispatch_customer', label: 'Dispatch to Customer' },
   ],
@@ -71,7 +71,7 @@ export const SUB_ACTIVITY_DEPENDENCIES: Record<string, string> = {
   fabrication: 'preparation',
   // Coating
   painting: 'sand_blasting',
-  // Delivery & Logistics
+  // Delivery
   dispatch_customer: 'dispatch_sand_blasting',
   // Erection
   erection_steel: 'erection_anchor_bolts',

--- a/src/lib/navigation-permissions.ts
+++ b/src/lib/navigation-permissions.ts
@@ -39,6 +39,7 @@ export const NAVIGATION_PERMISSIONS: NavigationPermissionMap = {
   
   // Projects
   '/projects-dashboard': ['projects.view', 'projects.view_all'],
+  '/project-card': ['projects.view', 'projects.view_all'],
   '/projects': ['projects.view', 'projects.view_all'],
   '/projects/kickoff': ['projects.view', 'projects.view_all'],
   '/buildings': ['buildings.view'],

--- a/src/lib/services/early-warning-engine.service.ts
+++ b/src/lib/services/early-warning-engine.service.ts
@@ -26,7 +26,7 @@ import crypto from 'crypto';
 import { getProjectActivitySummaries, ACTIVITY_LABELS, type ProjectActivitySummary } from '@/lib/services/project-tracker.service';
 
 // Maps WorkUnit.type values to the tracker activity columns they correspond to.
-// Sequence starts from DESIGN: DESIGN → DETAILING → PROCUREMENT → PRODUCTION → COATING → DISPATCH → ERECTION
+// Sequence starts from DESIGN: DESIGN → DETAILING → PROCUREMENT → PRODUCTION → COATING → DELIVERY → ERECTION
 // Used to cross-check plan-based alerts against real execution progress in the tracker.
 const WORK_UNIT_TYPE_TO_TRACKER_ACTIVITIES: Record<string, string[]> = {
   DOCUMENTATION: [], // arch approval removed from tracker — no tracker column to cross-check
@@ -35,7 +35,7 @@ const WORK_UNIT_TYPE_TO_TRACKER_ACTIVITIES: Record<string, string[]> = {
   PROCUREMENT:   ['procurement'],
   PRODUCTION:    ['production'],
   COATING:       ['coating'],
-  DISPATCH:      ['dispatch'],
+  DISPATCH:      ['delivery'],
   ERECTION:      ['erection'],
   QC:            [], // cross-cutting, no dedicated tracker column
 };

--- a/src/lib/services/google-sheets-sync.service.ts
+++ b/src/lib/services/google-sheets-sync.service.ts
@@ -114,7 +114,8 @@ const PROCESS_TYPE_MAP: Record<string, string> = {
   'sandblasting': 'Sandblasting',
   'painting': 'Painting',
   'galvanization': 'Galvanization',
-  'dispatch': 'Dispatch',
+  'delivery': 'Delivery',
+  'dispatch': 'Delivery',
   'erection': 'Erection',
 };
 

--- a/src/lib/services/project-tracker.service.ts
+++ b/src/lib/services/project-tracker.service.ts
@@ -23,7 +23,7 @@ export const TRACKER_COLUMNS = [
   { type: 'procurement', label: 'Procurement' },
   { type: 'production', label: 'Production' },
   { type: 'coating', label: 'Coating' },
-  { type: 'dispatch', label: 'Dispatch' },
+  { type: 'delivery', label: 'Delivery' },
   { type: 'erection', label: 'Erection' },
 ] as const;
 
@@ -43,7 +43,7 @@ const DESIGN_REVISION_ACTIVITIES = new Set(['design', 'detailing']);
 const PRODUCTION_PROCESS_TYPES: Record<string, string[]> = {
   production: ['Fit-up', 'Welding', 'Visualization'],
   coating: ['Sandblasting', 'Painting', 'Galvanization'],
-  dispatch: ['Dispatched to Customer'],
+  delivery: ['Dispatched to Customer'],
   erection: ['Erection'],
 };
 
@@ -322,7 +322,7 @@ async function computeProductionProgress(
     : 0;
 
   const shipmentCount =
-    activityType === 'dispatch'
+    activityType === 'delivery'
       ? (() => {
           const dispatchLogs = logs.filter((l) => l.processType === 'Dispatched to Customer');
           const reportNums = new Set(dispatchLogs.map((l) => l.reportNumber).filter(Boolean));

--- a/src/lib/startup-migrations.ts
+++ b/src/lib/startup-migrations.ts
@@ -153,6 +153,9 @@ const STARTUP_MIGRATIONS = [
 
   // ── v23.0.0 — Subcontractor Contracts Module ──────────────────────────────
   'v23_0_subcontractor_contracts.sql',  // SubcontractorContract + SubcontractorPaymentCertificate tables
+
+  // ── v23.0.1 — Activity name unification ───────────────────────────────────
+  'v23_0_1_unify_activity_names.sql',   // Rename dispatch→delivery in BuildingActivity; delivery_logistics→delivery in Task
 ];
 
 /**

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -10,7 +10,7 @@ const { version: pkgVersion } = require('../../package.json') as { version: stri
 export const APP_VERSION = {
   version: pkgVersion,
   date: 'May 7, 2026',
-  type: 'major' as const,
+  type: 'patch' as const,
   name: 'Hexa Steel Operation Tracking System',
 };
 


### PR DESCRIPTION
- Add /subcontractor-contracts redirect to /supply-chain/subcontractors
- Add /project-card to NAVIGATION_PERMISSIONS; fix admin navPermissions to use
  resolved permissions so new modules (SC Contracts, Project Card) are always
  visible to CEO/Admin without DB role re-sync
- Unify activity names: dispatch→delivery across TRACKER_COLUMNS, wizard
  defaults, building-activities API, EWS engine, planning, google-sheets-sync;
  delivery_logistics→delivery in activity-constants.ts
- Add DB migration v23.0.1 renaming BuildingActivity.activityType dispatch→delivery
  and Task.mainActivity delivery_logistics→delivery
- Add Scope of Work column to tasks flat-list table between Building and Main Activity
- Sync changelog page with missing v22.15.0 (Project Card) and v22.14.0 (Bug Fixes)
- Version bumped to 23.0.1

https://claude.ai/code/session_01Admf4GRyvGzFRkmU3vb3Kt