### PR TITLE
fix(23.1.0): tracker scope display, subcontractor wizard, project card UI

### DIFF
--- a/prisma/manual_migrations/v23_1_fix_steel_scope_activities.sql
+++ b/prisma/manual_migrations/v23_1_fix_steel_scope_activities.sql
@@ -1,0 +1,50 @@
+-- v23.1.0: Fix steel scope BuildingActivity records
+-- 1. All activities on a steel ScopeOfWork should be isApplicable = true.
+--    Previously some were saved as false due to a tracker default bug.
+-- 2. Insert the 7 standard tracker activity records for any steel scope that
+--    has a ScopeOfWork but is missing one or more BuildingActivity rows.
+
+-- Step 1: Ensure all existing steel-scope activities are marked applicable
+UPDATE BuildingActivity ba
+JOIN ScopeOfWork sow ON sow.id = ba.scopeOfWorkId
+SET ba.isApplicable = 1
+WHERE sow.scopeType = 'steel'
+  AND ba.isApplicable = 0;
+
+-- Step 2: Insert missing activity rows for steel scopes
+-- Using a temporary reference table for the 7 standard types
+CREATE TEMPORARY TABLE _steel_activity_defs (
+  activityType VARCHAR(50) NOT NULL,
+  activityLabel VARCHAR(100) NOT NULL,
+  sortOrder INT NOT NULL
+);
+
+INSERT INTO _steel_activity_defs VALUES
+  ('design',       'Design',       1),
+  ('detailing',    'Detailing',    2),
+  ('procurement',  'Procurement',  3),
+  ('production',   'Production',   4),
+  ('coating',      'Coating',      5),
+  ('delivery',     'Delivery',     6),
+  ('erection',     'Erection',     7);
+
+INSERT INTO BuildingActivity (id, projectId, buildingId, scopeOfWorkId, activityType, activityLabel, isApplicable, sortOrder, createdAt, updatedAt)
+SELECT
+  UUID(),
+  sow.projectId,
+  sow.buildingId,
+  sow.id,
+  def.activityType,
+  def.activityLabel,
+  1,
+  def.sortOrder,
+  NOW(3),
+  NOW(3)
+FROM ScopeOfWork sow
+CROSS JOIN _steel_activity_defs def
+LEFT JOIN BuildingActivity ba
+  ON ba.scopeOfWorkId = sow.id AND ba.activityType = def.activityType
+WHERE sow.scopeType = 'steel'
+  AND ba.id IS NULL;
+
+DROP TEMPORARY TABLE _steel_activity_defs;

--- a/prisma/manual_migrations/v23_2_seed_assembly_part_steel_scope.sql
+++ b/prisma/manual_migrations/v23_2_seed_assembly_part_steel_scope.sql
@@ -1,0 +1,26 @@
+-- v23.2.0: Seed steel scopeOfWorkId for all unlinked AssemblyPart records
+-- "Steel" is the default scope for all production log entries and PTS-synced parts.
+-- This backfills any parts (including newly PTS-synced ones) that lack a scopeOfWorkId.
+
+UPDATE AssemblyPart ap
+JOIN ScopeOfWork sow
+  ON sow.buildingId = ap.buildingId
+  AND sow.scopeType = 'steel'
+SET ap.scopeOfWorkId = sow.id
+WHERE ap.scopeOfWorkId IS NULL
+  AND ap.buildingId IS NOT NULL
+  AND ap.deletedAt IS NULL;
+
+-- Also cover project-level parts (buildingId IS NULL): link to ANY steel scope
+-- in the same project as a best-effort default (rare scenario).
+UPDATE AssemblyPart ap
+JOIN (
+  SELECT projectId, MIN(id) AS steelScopeId
+  FROM ScopeOfWork
+  WHERE scopeType = 'steel'
+  GROUP BY projectId
+) best ON best.projectId = ap.projectId
+SET ap.scopeOfWorkId = best.steelScopeId
+WHERE ap.scopeOfWorkId IS NULL
+  AND ap.buildingId IS NULL
+  AND ap.deletedAt IS NULL;

--- a/src/app/api/production/assembly-parts/route.ts
+++ b/src/app/api/production/assembly-parts/route.ts
@@ -30,6 +30,18 @@ const assemblyPartSchema = z.object({
   netWeightTotal: z.number().optional().nullable(),
 });
 
+async function resolveSteelScopeId(projectId: string, buildingId: string | null | undefined): Promise<string | null> {
+  const scope = await prisma.scopeOfWork.findFirst({
+    where: {
+      projectId,
+      ...(buildingId ? { buildingId } : {}),
+      scopeType: 'steel',
+    },
+    select: { id: true },
+  });
+  return scope?.id ?? null;
+}
+
 async function generatePartDesignation(
   projectId: string,
   buildingId: string | null,
@@ -318,11 +330,15 @@ export async function POST(req: Request) {
             itemData.assemblyMark
           );
 
+          const resolvedScopeId = itemData.scopeOfWorkId
+            ?? await resolveSteelScopeId(itemData.projectId, itemData.buildingId);
+
           const assemblyPart = await prisma.assemblyPart.create({
             data: {
               ...itemData,
               partMark: itemData.partMark ?? '',
               partDesignation,
+              scopeOfWorkId: resolvedScopeId,
               source: 'Upload',
               createdById: session.sub,
             },
@@ -405,11 +421,15 @@ export async function POST(req: Request) {
       parsed.data.assemblyMark
     );
 
+    const resolvedScopeId = parsed.data.scopeOfWorkId
+      ?? await resolveSteelScopeId(parsed.data.projectId, parsed.data.buildingId);
+
     const assemblyPart = await prisma.assemblyPart.create({
       data: {
         ...parsed.data,
         partMark: parsed.data.partMark ?? '',
         partDesignation,
+        scopeOfWorkId: resolvedScopeId,
         source: 'Upload',
         createdById: session.sub,
       },

--- a/src/app/api/project-tracker/route.ts
+++ b/src/app/api/project-tracker/route.ts
@@ -119,8 +119,10 @@ export const GET = withApiContext(async (req, session) => {
                   const hasActivityConfig = scope.activities.length > 0;
                   const scopeActivities = activities.map((act) => ({
                     ...act,
+                    // If an activity type has no explicit config entry, default to applicable
+                    // (true). Only an explicit isApplicable=false record hides the column.
                     isApplicable: hasActivityConfig
-                      ? (applicableMap.get(act.activityType) ?? false)
+                      ? (applicableMap.get(act.activityType) ?? true)
                       : true,
                   }));
                   const applicable = scopeActivities.filter((a) => a.isApplicable);

--- a/src/app/api/subcontractor-contracts/route.ts
+++ b/src/app/api/subcontractor-contracts/route.ts
@@ -122,7 +122,7 @@ export const POST = withApiContext(async (req: NextRequest, session) => {
       buildingDesignation = building?.designation ?? null;
     }
 
-    const contractNumber = generateContractNumber(
+    const contractNumber = await generateContractNumber(
       project.projectNumber,
       buildingDesignation,
       data.scopeTypes

--- a/src/app/projects/[id]/buildings/_page-client.tsx
+++ b/src/app/projects/[id]/buildings/_page-client.tsx
@@ -750,6 +750,17 @@ export function ProjectCardClient({
   return (
     <div className="p-4 md:p-6 space-y-5 max-w-5xl mx-auto">
 
+      {/* ── Page Title ── */}
+      <div className="flex items-center gap-3">
+        <div className="flex items-center justify-center w-9 h-9 rounded-lg bg-gradient-to-br from-blue-500 to-indigo-600 shadow-md">
+          <LayoutGrid className="w-5 h-5 text-white" />
+        </div>
+        <div>
+          <h1 className="text-xl font-bold tracking-tight">Project Card</h1>
+          <p className="text-xs text-muted-foreground">Buildings, scope &amp; technical specifications</p>
+        </div>
+      </div>
+
       {/* ── Project Header ── */}
       <Card className="overflow-hidden">
         <CardContent className="p-4 space-y-3">
@@ -841,10 +852,10 @@ export function ProjectCardClient({
         <div className="flex-1 flex items-center gap-1.5 overflow-x-auto [&::-webkit-scrollbar]:hidden [scrollbar-width:none]">
           <button
             onClick={() => setSelectedBuildingId(null)}
-            className={`flex-shrink-0 px-3 py-1.5 rounded-md text-sm font-medium transition-colors border ${
+            className={`flex-shrink-0 px-3 py-1.5 rounded-md text-sm font-medium transition-all border shadow-sm ${
               selectedBuildingId === null
-                ? 'bg-primary text-primary-foreground border-primary'
-                : 'bg-background text-muted-foreground border-border hover:bg-accent'
+                ? 'bg-slate-700 text-white border-slate-700 shadow-md scale-105'
+                : 'bg-background text-muted-foreground border-border hover:bg-accent hover:scale-105'
             }`}
           >
             <span className="flex items-center gap-1.5">
@@ -852,20 +863,34 @@ export function ProjectCardClient({
               All
             </span>
           </button>
-          {buildings.map((b) => (
-            <button
-              key={b.id}
-              onClick={() => setSelectedBuildingId(b.id)}
-              className={`flex-shrink-0 px-3 py-1.5 rounded-md text-sm font-medium transition-colors border ${
-                selectedBuildingId === b.id
-                  ? 'bg-primary text-primary-foreground border-primary'
-                  : 'bg-background text-muted-foreground border-border hover:bg-accent'
-              }`}
-              title={b.name ?? undefined}
-            >
-              {b.designation || b.name || '?'}
-            </button>
-          ))}
+          {buildings.map((b, idx) => {
+            const palette = [
+              { active: 'bg-blue-600 text-white border-blue-600', idle: 'border-blue-300 text-blue-700 hover:bg-blue-50 dark:border-blue-700 dark:text-blue-300 dark:hover:bg-blue-950' },
+              { active: 'bg-emerald-600 text-white border-emerald-600', idle: 'border-emerald-300 text-emerald-700 hover:bg-emerald-50 dark:border-emerald-700 dark:text-emerald-300 dark:hover:bg-emerald-950' },
+              { active: 'bg-violet-600 text-white border-violet-600', idle: 'border-violet-300 text-violet-700 hover:bg-violet-50 dark:border-violet-700 dark:text-violet-300 dark:hover:bg-violet-950' },
+              { active: 'bg-amber-600 text-white border-amber-600', idle: 'border-amber-300 text-amber-700 hover:bg-amber-50 dark:border-amber-700 dark:text-amber-300 dark:hover:bg-amber-950' },
+              { active: 'bg-rose-600 text-white border-rose-600', idle: 'border-rose-300 text-rose-700 hover:bg-rose-50 dark:border-rose-700 dark:text-rose-300 dark:hover:bg-rose-950' },
+              { active: 'bg-cyan-600 text-white border-cyan-600', idle: 'border-cyan-300 text-cyan-700 hover:bg-cyan-50 dark:border-cyan-700 dark:text-cyan-300 dark:hover:bg-cyan-950' },
+              { active: 'bg-orange-600 text-white border-orange-600', idle: 'border-orange-300 text-orange-700 hover:bg-orange-50 dark:border-orange-700 dark:text-orange-300 dark:hover:bg-orange-950' },
+              { active: 'bg-teal-600 text-white border-teal-600', idle: 'border-teal-300 text-teal-700 hover:bg-teal-50 dark:border-teal-700 dark:text-teal-300 dark:hover:bg-teal-950' },
+              { active: 'bg-pink-600 text-white border-pink-600', idle: 'border-pink-300 text-pink-700 hover:bg-pink-50 dark:border-pink-700 dark:text-pink-300 dark:hover:bg-pink-950' },
+              { active: 'bg-indigo-600 text-white border-indigo-600', idle: 'border-indigo-300 text-indigo-700 hover:bg-indigo-50 dark:border-indigo-700 dark:text-indigo-300 dark:hover:bg-indigo-950' },
+            ];
+            const color = palette[idx % palette.length];
+            const isActive = selectedBuildingId === b.id;
+            return (
+              <button
+                key={b.id}
+                onClick={() => setSelectedBuildingId(b.id)}
+                className={`flex-shrink-0 px-3 py-1.5 rounded-md text-sm font-medium transition-all border shadow-sm ${
+                  isActive ? `${color.active} shadow-md scale-105` : `bg-background ${color.idle}`
+                }`}
+                title={b.name ?? undefined}
+              >
+                {b.designation || b.name || '?'}
+              </button>
+            );
+          })}
         </div>
 
         <Button
@@ -882,62 +907,94 @@ export function ProjectCardClient({
 
       {/* ── KPI strip ── */}
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-        <Card className="p-4">
-          <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1 flex items-center gap-1">
-            <Building2 className="w-3 h-3" />
-            {selectedBuilding ? 'Building' : 'Buildings'}
-          </div>
-          {selectedBuilding ? (
-            <>
-              <div className="text-xl font-bold">{selectedBuilding.designation || '—'}</div>
-              {selectedBuilding.name && selectedBuilding.name !== selectedBuilding.designation && (
-                <div className="text-xs text-muted-foreground mt-0.5">{selectedBuilding.name}</div>
-              )}
-              {selectedBuilding.location && (
-                <div className="text-xs text-muted-foreground mt-0.5 flex items-center gap-0.5">
-                  <MapPin className="w-2.5 h-2.5" />{selectedBuilding.location}
-                </div>
-              )}
-            </>
-          ) : (
-            <div className="text-2xl font-bold">{buildings.length}</div>
-          )}
-        </Card>
-
-        <Card className="p-4">
-          <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1 flex items-center gap-1">
-            <Weight className="w-3 h-3" /> Tonnage
-          </div>
-          <div className="text-2xl font-bold">{fmt(totalTonnage, 2)} t</div>
-          {project.contractualTonnage && !selectedBuilding && (
-            <div className="text-xs text-muted-foreground mt-0.5">
-              Contract: {fmt(project.contractualTonnage, 2)} t
+        {/* Buildings tile — blue */}
+        <Card className="relative overflow-hidden border-0 shadow-md">
+          <div className="absolute inset-0 bg-gradient-to-br from-blue-500 to-blue-700" />
+          <div className="relative p-4 text-white">
+            <div className="flex items-center justify-between mb-2">
+              <div className="text-xs font-semibold uppercase tracking-wider opacity-80">
+                {selectedBuilding ? 'Building' : 'Buildings'}
+              </div>
+              <div className="flex items-center justify-center w-7 h-7 rounded-lg bg-white/20">
+                <Building2 className="w-4 h-4" />
+              </div>
             </div>
-          )}
-          {selectedBuilding?.weight !== null && selectedBuilding && (
-            <div className="text-xs text-muted-foreground mt-0.5">
-              Manual: {fmt(selectedBuilding.weight ?? 0, 2)} t
+            {selectedBuilding ? (
+              <>
+                <div className="text-xl font-bold">{selectedBuilding.designation || '—'}</div>
+                {selectedBuilding.name && selectedBuilding.name !== selectedBuilding.designation && (
+                  <div className="text-xs opacity-75 mt-0.5">{selectedBuilding.name}</div>
+                )}
+                {selectedBuilding.location && (
+                  <div className="text-xs opacity-75 mt-0.5 flex items-center gap-0.5">
+                    <MapPin className="w-2.5 h-2.5" />{selectedBuilding.location}
+                  </div>
+                )}
+              </>
+            ) : (
+              <>
+                <div className="text-3xl font-bold">{buildings.length}</div>
+                <div className="text-xs opacity-75 mt-0.5">total buildings</div>
+              </>
+            )}
+          </div>
+        </Card>
+
+        {/* Tonnage tile — amber */}
+        <Card className="relative overflow-hidden border-0 shadow-md">
+          <div className="absolute inset-0 bg-gradient-to-br from-amber-500 to-orange-600" />
+          <div className="relative p-4 text-white">
+            <div className="flex items-center justify-between mb-2">
+              <div className="text-xs font-semibold uppercase tracking-wider opacity-80">Tonnage</div>
+              <div className="flex items-center justify-center w-7 h-7 rounded-lg bg-white/20">
+                <Weight className="w-4 h-4" />
+              </div>
             </div>
-          )}
+            <div className="text-2xl font-bold">{fmt(totalTonnage, 2)} <span className="text-base font-medium opacity-80">t</span></div>
+            {project.contractualTonnage && !selectedBuilding && (
+              <div className="text-xs opacity-75 mt-0.5">
+                Contract: {fmt(project.contractualTonnage, 2)} t
+              </div>
+            )}
+            {selectedBuilding?.weight !== null && selectedBuilding && (
+              <div className="text-xs opacity-75 mt-0.5">
+                Manual: {fmt(selectedBuilding.weight ?? 0, 2)} t
+              </div>
+            )}
+          </div>
         </Card>
 
-        <Card className="p-4">
-          <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1 flex items-center gap-1">
-            <Ruler className="w-3 h-3" /> Total Area
-          </div>
-          <div className="text-2xl font-bold">{fmt(totalArea)} m²</div>
-          <div className="text-xs text-muted-foreground mt-0.5">
-            Purlin: {fmt(kpiBuildings.reduce((s, b) => s + b.purlinArea, 0))} m²
+        {/* Total Area tile — emerald */}
+        <Card className="relative overflow-hidden border-0 shadow-md">
+          <div className="absolute inset-0 bg-gradient-to-br from-emerald-500 to-teal-600" />
+          <div className="relative p-4 text-white">
+            <div className="flex items-center justify-between mb-2">
+              <div className="text-xs font-semibold uppercase tracking-wider opacity-80">Total Area</div>
+              <div className="flex items-center justify-center w-7 h-7 rounded-lg bg-white/20">
+                <Ruler className="w-4 h-4" />
+              </div>
+            </div>
+            <div className="text-2xl font-bold">{fmt(totalArea)} <span className="text-base font-medium opacity-80">m²</span></div>
+            <div className="text-xs opacity-75 mt-0.5">
+              Purlin: {fmt(kpiBuildings.reduce((s, b) => s + b.purlinArea, 0))} m²
+            </div>
           </div>
         </Card>
 
-        <Card className="p-4">
-          <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1 flex items-center gap-1">
-            <Paintbrush className="w-3 h-3" /> Paintable Area
-          </div>
-          <div className="text-2xl font-bold">{fmt(totalPaintable)} m²</div>
-          <div className="text-xs text-muted-foreground mt-0.5">
-            {coatCount > 0 ? `${coatCount} coat${coatCount !== 1 ? 's' : ''}` : 'Coating not set'}
+        {/* Paintable Area tile — violet */}
+        <Card className="relative overflow-hidden border-0 shadow-md">
+          <div className="absolute inset-0 bg-gradient-to-br from-violet-500 to-purple-700" />
+          <div className="relative p-4 text-white">
+            <div className="flex items-center justify-between mb-2">
+              <div className="text-xs font-semibold uppercase tracking-wider opacity-80">Paintable Area</div>
+              <div className="flex items-center justify-center w-7 h-7 rounded-lg bg-white/20">
+                <Paintbrush className="w-4 h-4" />
+              </div>
+            </div>
+            <div className="text-2xl font-bold">{fmt(totalPaintable)} <span className="text-base font-medium opacity-80">m²</span></div>
+            <div className="text-xs opacity-75 mt-0.5">
+              {coatCount > 0 ? `${coatCount} coat${coatCount !== 1 ? 's' : ''}` : 'Coating not set'}
+            </div>
           </div>
         </Card>
       </div>

--- a/src/app/projects/wizard/_page-client.tsx
+++ b/src/app/projects/wizard/_page-client.tsx
@@ -262,13 +262,14 @@ export default function ProjectSetupWizard() {
         if (project.downPaymentDate) setDownPaymentDate(project.downPaymentDate.split('T')[0]);
         if (project.contractValue) setContractValue(String(project.contractValue));
 
-        // Restore wizard state from remarks
+        // Restore wizard state from remarks (draft saves)
+        let sowRestoredFromRemarks = false;
         if (project.remarks) {
           try {
             const parsed = JSON.parse(project.remarks);
             if (parsed?.__wizardDraft && parsed.data) {
               const d = parsed.data;
-              if (d.scopeOfWork) setScopeOfWork(d.scopeOfWork);
+              if (d.scopeOfWork) { setScopeOfWork(d.scopeOfWork); sowRestoredFromRemarks = true; }
               if (d.stageDurations) setStageDurations(d.stageDurations);
               if (d.paymentTerms) setPaymentTerms(d.paymentTerms);
               if (d.coatingCoats) setCoatingCoats(d.coatingCoats);
@@ -282,6 +283,33 @@ export default function ProjectSetupWizard() {
               if (parsed.step) setCurrentStep(parsed.step);
             }
           } catch {}
+        }
+
+        // Restore SoW checkboxes from project's scopeOfWork text when not available in draft.
+        // The text field stores the selected scope labels line-by-line.
+        if (!sowRestoredFromRemarks && project.scopeOfWork) {
+          const text = project.scopeOfWork as string;
+          setScopeOfWork(
+            SCOPE_OPTIONS.map(opt => ({
+              ...opt,
+              checked: text.includes(opt.label),
+            }))
+          );
+        }
+
+        // Restore technical specs from project fields when not in draft
+        if (!project.remarks || !JSON.parse(project.remarks || 'null')?.__wizardDraft) {
+          if (project.cranesIncluded !== undefined) setCranesIncluded(!!project.cranesIncluded);
+          if (project.surveyorOurScope !== undefined) setSurveyorIncluded(!!project.surveyorOurScope);
+          if (project.thirdPartyRequired !== undefined) setThirdPartyRequired(!!project.thirdPartyRequired);
+          if (project.thirdPartyResponsibility) setThirdPartyResponsibility(project.thirdPartyResponsibility as 'our' | 'customer');
+          if (project.engineeringWeeksMin || project.engineeringWeeksMax || project.operationsWeeksMin || project.operationsWeeksMax || project.siteWeeksMin || project.siteWeeksMax) {
+            setStageDurations([
+              { stage: 'engineering', label: 'Engineering', durationWeeksMin: project.engineeringWeeksMin ?? 0, durationWeeksMax: project.engineeringWeeksMax ?? 0 },
+              { stage: 'operations', label: 'Operations', durationWeeksMin: project.operationsWeeksMin ?? 0, durationWeeksMax: project.operationsWeeksMax ?? 0 },
+              { stage: 'site', label: 'Site', durationWeeksMin: project.siteWeeksMin ?? 0, durationWeeksMax: project.siteWeeksMax ?? 0 },
+            ]);
+          }
         }
 
         // Also load buildings from API if wizard data didn't have them

--- a/src/app/supply-chain/subcontractors/new/_page-client.tsx
+++ b/src/app/supply-chain/subcontractors/new/_page-client.tsx
@@ -58,10 +58,10 @@ export default function NewSubcontractorContractPage() {
   const [submitAction, setSubmitAction] = useState<'draft' | 'submit'>('draft');
 
   const fetchProjects = useCallback(async () => {
-    const res = await fetch('/api/projects');
+    const res = await fetch('/api/projects?status=Active');
     if (res.ok) {
       const data = await res.json() as Project[];
-      setProjects(data);
+      setProjects(Array.isArray(data) ? data : []);
     }
   }, []);
 
@@ -152,8 +152,8 @@ export default function NewSubcontractorContractPage() {
 
   const milestoneTotal = paymentTerms.reduce((s, m) => s + m.percentage, 0);
 
-  const canProceed = () => {
-    if (step === 0) return selectedProject && selectedSupplier;
+  const canProceed = (): boolean => {
+    if (step === 0) return !!(selectedProject && selectedSupplier);
     if (step === 1) return selectedScopeTypes.length > 0;
     return true;
   };

--- a/src/lib/services/subcontractor-contract.service.ts
+++ b/src/lib/services/subcontractor-contract.service.ts
@@ -30,7 +30,7 @@ export const VALID_TRANSITIONS: Record<string, string[]> = {
 
 // ─── Contract number generation ───────────────────────────────────────────────
 
-export function generateContractNumber(
+function buildContractBase(
   projectNumber: string,
   buildingDesignation: string | null,
   scopeTypes: string[]
@@ -41,6 +41,19 @@ export function generateContractNumber(
     return `${projectNumber}-${buildingDesignation.toUpperCase()}-${scopePart}`;
   }
   return `${projectNumber}-${scopePart}`;
+}
+
+export async function generateContractNumber(
+  projectNumber: string,
+  buildingDesignation: string | null,
+  scopeTypes: string[]
+): Promise<string> {
+  const base = buildContractBase(projectNumber, buildingDesignation, scopeTypes);
+  const existing = await prisma.subcontractorContract.count({
+    where: { contractNumber: { startsWith: base } },
+  });
+  if (existing === 0) return base;
+  return `${base}-${existing + 1}`;
 }
 
 export function generateCertificateNumber(contractNumber: string, sequence: number): string {


### PR DESCRIPTION
- Tracker: fix `?? false` → `?? true` so scopes with partial BuildingActivity
  config default to applicable rather than N/A
- Migration v23_1: backfill steel-scope BuildingActivity rows with isApplicable=1
- Migration v23_2: seed AssemblyPart.scopeOfWorkId to steel scope for all
  legacy parts; assembly-parts API now auto-resolves steel scope on creation
- Subcontractor wizard: generateContractNumber now async, queries DB to avoid
  duplicate contract numbers; canProceed() returns explicit boolean so next-step
  works correctly
- Project edit wizard: restore SoW checkboxes from project.scopeOfWork text
  when wizard draft is not available in remarks
- Project Card: add page title header, gradient KPI tiles (blue/amber/emerald/
  violet), per-building color-coded pill buttons (10-color rotating palette)

https://claude.ai/code/session_01LG5fuPyibWmwJF4DgiRxU6