### PR TITLE
fix: register v23.1 migrations in startup runner to fix N/A tracker display

### DIFF
--- a/src/lib/startup-migrations.ts
+++ b/src/lib/startup-migrations.ts
@@ -156,6 +156,10 @@ const STARTUP_MIGRATIONS = [
 
   // ── v23.0.1 — Activity name unification ───────────────────────────────────
   'v23_0_1_unify_activity_names.sql',   // Rename dispatch→delivery in BuildingActivity; delivery_logistics→delivery in Task
+
+  // ── v23.1.0 — Fix steel-scope BuildingActivity records ────────────────────
+  'v23_1_fix_steel_scope_activities.sql', // Set all steel-scope activities to isApplicable=1; insert missing rows
+  'v23_2_seed_assembly_part_steel_scope.sql', // Backfill AssemblyPart.scopeOfWorkId to steel scope
 ];
 
 /**


### PR DESCRIPTION
v23_1_fix_steel_scope_activities and v23_2_seed_assembly_part_steel_scope
were added to prisma/manual_migrations/ in the v23.1.0 commit but were
never registered in STARTUP_MIGRATIONS, so the DB fixes never ran on
server start. Buildings showed N/A because their steel-scope
BuildingActivity rows were missing or had isApplicable=false, and the
old ?? false default in the tracker API made every un-seeded column N/A.

https://claude.ai/code/session_01WnYe7Dhf2JPAFcXojt4yiB