### PR TITLE
feat(hr): add employee turnover rate KPI to HR dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [23.1.0] - 2026-05-08
+
+### HR Turnover Rate KPI
+
+#### Added
+- **Employee Turnover Rate KPI** — New KPI section on the HR Dashboard displaying:
+  - **At Start**: headcount at the beginning of the selected period
+  - **At End**: headcount at the end of the selected period
+  - **New Hires**: employees who joined during the period
+  - **Leavers**: employees whose `dateOfLeaving` falls within the period
+  - **Turnover Rate** (auto-calculated): `(Leavers ÷ Average Headcount) × 100`, where Average Headcount = `(At Start + At End) ÷ 2`
+- **Stability indicator** — The turnover rate card is colour-coded and labelled by threshold:
+  - < 10%: Good Stability (emerald)
+  - 10 – 20%: Normal (amber)
+  - > 20%: Requires Further Analysis (rose)
+- All turnover figures respect the existing occupation / section / department filters and refresh automatically when the date range or any filter changes.
+- Version bumped to **23.1.0**
+
+---
+
 ## [23.0.2] - 2026-05-07
 
 ### Building Details, Subcontractor Form, Project Card & Tracker Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexa-steel-ots",
-  "version": "23.0.2",
+  "version": "23.1.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/components/hr/hr-dashboard-client.tsx
+++ b/src/components/hr/hr-dashboard-client.tsx
@@ -46,9 +46,11 @@ import {
   Smartphone,
   Wrench,
   DollarSign,
-  HandCoins,
   ShieldAlert,
   UserCheck,
+  UserPlus,
+  UserMinus,
+  Activity,
 } from 'lucide-react';
 import type { HrDashboardResult, HrDashboardGroupBy } from '@/lib/services/hr/hr-dashboard-stats';
 
@@ -702,6 +704,99 @@ export function HrDashboardClient({
           </CardContent>
         </Card>
       )}
+
+      {/* Turnover Rate KPI */}
+      {(() => {
+        const t = stats.turnover;
+        const stabilityConfig = {
+          good:   { label: 'Good Stability',        bg: 'from-emerald-50 to-white', border: 'border-emerald-200', text: 'text-emerald-700', badge: 'bg-emerald-100 text-emerald-700' },
+          normal: { label: 'Normal',                bg: 'from-amber-50 to-white',   border: 'border-amber-200',   text: 'text-amber-700',   badge: 'bg-amber-100 text-amber-700'   },
+          review: { label: 'Requires Further Analysis', bg: 'from-rose-50 to-white', border: 'border-rose-200', text: 'text-rose-700', badge: 'bg-rose-100 text-rose-700' },
+        }[t.stability];
+        return (
+          <Card>
+            <CardHeader className="pb-3">
+              <div className="flex items-center justify-between flex-wrap gap-2">
+                <CardTitle className="text-base flex items-center gap-2">
+                  <Activity className="h-4 w-4 text-violet-600" />
+                  Employee Turnover Rate
+                </CardTitle>
+                <span className={`text-xs font-medium px-2.5 py-1 rounded-full ${stabilityConfig.badge}`}>
+                  {stabilityConfig.label}
+                </span>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4">
+                <div className="rounded-xl border bg-gradient-to-b from-slate-50 to-white border-slate-200 p-4 shadow-sm">
+                  <div className="flex items-center gap-2 mb-2">
+                    <div className="flex h-7 w-7 items-center justify-center rounded-md bg-slate-100 text-slate-600">
+                      <Users className="h-3.5 w-3.5" />
+                    </div>
+                    <p className="text-xs text-slate-500 font-medium uppercase tracking-wide">At Start</p>
+                  </div>
+                  <p className="text-2xl font-bold text-slate-700">{t.atStart}</p>
+                  <p className="text-xs text-slate-400 mt-0.5">beginning of period</p>
+                </div>
+
+                <div className="rounded-xl border bg-gradient-to-b from-slate-50 to-white border-slate-200 p-4 shadow-sm">
+                  <div className="flex items-center gap-2 mb-2">
+                    <div className="flex h-7 w-7 items-center justify-center rounded-md bg-slate-100 text-slate-600">
+                      <Users className="h-3.5 w-3.5" />
+                    </div>
+                    <p className="text-xs text-slate-500 font-medium uppercase tracking-wide">At End</p>
+                  </div>
+                  <p className="text-2xl font-bold text-slate-700">{t.atEnd}</p>
+                  <p className="text-xs text-slate-400 mt-0.5">end of period</p>
+                </div>
+
+                <div className="rounded-xl border bg-gradient-to-b from-sky-50 to-white border-sky-200 p-4 shadow-sm">
+                  <div className="flex items-center gap-2 mb-2">
+                    <div className="flex h-7 w-7 items-center justify-center rounded-md bg-sky-100 text-sky-600">
+                      <UserPlus className="h-3.5 w-3.5" />
+                    </div>
+                    <p className="text-xs text-sky-600 font-medium uppercase tracking-wide">New Hires</p>
+                  </div>
+                  <p className="text-2xl font-bold text-sky-700">{t.newHires}</p>
+                  <p className="text-xs text-sky-400 mt-0.5">joined this period</p>
+                </div>
+
+                <div className="rounded-xl border bg-gradient-to-b from-rose-50 to-white border-rose-200 p-4 shadow-sm">
+                  <div className="flex items-center gap-2 mb-2">
+                    <div className="flex h-7 w-7 items-center justify-center rounded-md bg-rose-100 text-rose-600">
+                      <UserMinus className="h-3.5 w-3.5" />
+                    </div>
+                    <p className="text-xs text-rose-600 font-medium uppercase tracking-wide">Leavers</p>
+                  </div>
+                  <p className="text-2xl font-bold text-rose-700">{t.leavers}</p>
+                  <p className="text-xs text-rose-400 mt-0.5">left this period</p>
+                </div>
+
+                <div className={`rounded-xl border bg-gradient-to-b ${stabilityConfig.bg} ${stabilityConfig.border} p-4 shadow-sm sm:col-span-3 lg:col-span-1`}>
+                  <div className="flex items-center gap-2 mb-2">
+                    <div className="flex h-7 w-7 items-center justify-center rounded-md bg-white/80 border border-current/20">
+                      <TrendingUp className={`h-3.5 w-3.5 ${stabilityConfig.text}`} />
+                    </div>
+                    <p className={`text-xs font-medium uppercase tracking-wide ${stabilityConfig.text}`}>Turnover Rate</p>
+                  </div>
+                  <p className={`text-3xl font-bold tabular-nums ${stabilityConfig.text}`}>
+                    {t.turnoverRate.toFixed(1)}
+                    <span className="text-lg font-medium ml-0.5">%</span>
+                  </p>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    avg. {t.averageHeadcount} employees
+                  </p>
+                  <div className="mt-2 text-[10px] text-muted-foreground space-y-0.5 border-t pt-2">
+                    <div className="flex justify-between"><span>{"< 10%"}</span><span className="text-emerald-600 font-medium">Good</span></div>
+                    <div className="flex justify-between"><span>10 – 20%</span><span className="text-amber-600 font-medium">Normal</span></div>
+                    <div className="flex justify-between"><span>{"> 20%"}</span><span className="text-rose-600 font-medium">Review</span></div>
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        );
+      })()}
 
       {/* Contracts & Documents widget */}
       {contractStats && (

--- a/src/lib/services/hr/hr-dashboard-stats.ts
+++ b/src/lib/services/hr/hr-dashboard-stats.ts
@@ -56,6 +56,16 @@ export interface HrDashboardTrendPoint {
   overtimeHours: number;
 }
 
+export interface TurnoverStats {
+  atStart: number;
+  atEnd: number;
+  newHires: number;
+  leavers: number;
+  averageHeadcount: number;
+  turnoverRate: number;
+  stability: 'good' | 'normal' | 'review';
+}
+
 export interface HrDashboardResult {
   filters: {
     startDate: string;
@@ -79,6 +89,7 @@ export interface HrDashboardResult {
     publicHoliday: number;
     unknown: number;
   };
+  turnover: TurnoverStats;
 }
 
 // ----------------------------------------------------------------------------
@@ -127,7 +138,15 @@ export async function getHrDashboardStats(
     ...(filters.departmentId ? { departmentId: filters.departmentId } : {}),
   };
 
-  const [records, departmentName] = await Promise.all([
+  // Exact period boundaries for turnover (date-only comparison against @db.Date fields).
+  const periodStart = startDate; // midnight UTC of first day
+  const periodEnd = new Date(Date.UTC(
+    filters.endDate.getUTCFullYear(),
+    filters.endDate.getUTCMonth(),
+    filters.endDate.getUTCDate(),
+  ));
+
+  const [records, departmentName, turnoverAtStart, turnoverAtEnd, turnoverNewHires, turnoverLeavers] = await Promise.all([
     prisma.attendanceRecord.findMany({
       where: {
         workerType: 'EMPLOYEE',
@@ -158,6 +177,36 @@ export async function getHrDashboardStats(
           select: { name: true },
         })
       : Promise.resolve(null),
+    // Employees active at the start of the period
+    prisma.employee.count({
+      where: {
+        ...employeeWhere,
+        dateOfJoining: { lte: periodStart },
+        OR: [{ dateOfLeaving: null }, { dateOfLeaving: { gte: periodStart } }],
+      },
+    }),
+    // Employees active at the end of the period
+    prisma.employee.count({
+      where: {
+        ...employeeWhere,
+        dateOfJoining: { lte: periodEnd },
+        OR: [{ dateOfLeaving: null }, { dateOfLeaving: { gt: periodEnd } }],
+      },
+    }),
+    // New hires during the period
+    prisma.employee.count({
+      where: {
+        ...employeeWhere,
+        dateOfJoining: { gte: periodStart, lte: periodEnd },
+      },
+    }),
+    // Employees who left during the period
+    prisma.employee.count({
+      where: {
+        ...employeeWhere,
+        dateOfLeaving: { gte: periodStart, lte: periodEnd },
+      },
+    }),
   ]);
 
   // ----------------------------------------------------------------
@@ -303,6 +352,22 @@ export async function getHrDashboardStats(
     a.date.localeCompare(b.date),
   );
 
+  const avgHeadcount = (turnoverAtStart + turnoverAtEnd) / 2;
+  const rawRate = avgHeadcount > 0 ? (turnoverLeavers / avgHeadcount) * 100 : 0;
+  const turnoverRate = Math.round(rawRate * 10) / 10;
+  const stability: TurnoverStats['stability'] =
+    turnoverRate < 10 ? 'good' : turnoverRate <= 20 ? 'normal' : 'review';
+
+  const turnover: TurnoverStats = {
+    atStart: turnoverAtStart,
+    atEnd: turnoverAtEnd,
+    newHires: turnoverNewHires,
+    leavers: turnoverLeavers,
+    averageHeadcount: Math.round(avgHeadcount * 10) / 10,
+    turnoverRate,
+    stability,
+  };
+
   return {
     filters: {
       startDate: isoDate(filters.startDate),
@@ -317,5 +382,6 @@ export async function getHrDashboardStats(
     groups,
     trend,
     absenceMix,
+    turnover,
   };
 }


### PR DESCRIPTION
Adds a new Turnover Rate KPI section to the HR Dashboard showing:
- Headcount at start and end of the selected period
- New hires and leavers during the period
- Auto-calculated turnover rate: (leavers ÷ avg headcount) × 100
- Stability label colour-coded by threshold (< 10% good, 10–20% normal, > 20% review)

Turnover figures respect all existing filters (occupation, section, department)
and refresh automatically when the date range or any filter changes.

Bumps version to 23.1.0.

https://claude.ai/code/session_01R4VPPwJi6AFUWGWswr97An