### PR TITLE
feat(hr): automated monthly HR report — v23.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexa-steel-ots",
-  "version": "23.1.0",
+  "version": "23.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/prisma/manual_migrations/v23_2_hr_monthly_reports.sql
+++ b/prisma/manual_migrations/v23_2_hr_monthly_reports.sql
@@ -1,0 +1,50 @@
+-- v23.2.0 — HR Monthly Report table
+-- Creates the HrMonthlyReport table for storing auto-generated monthly HR PDF reports.
+
+DROP PROCEDURE IF EXISTS add_hr_monthly_report_table;
+
+DELIMITER //
+CREATE PROCEDURE add_hr_monthly_report_table()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_name = 'HrMonthlyReport'
+  ) THEN
+    CREATE TABLE `HrMonthlyReport` (
+      `id`                    CHAR(36)       NOT NULL,
+      `year`                  INT            NOT NULL,
+      `month`                 INT            NOT NULL,
+      `status`                ENUM('GENERATING','READY','FAILED') NOT NULL DEFAULT 'GENERATING',
+      `newHires`              INT            NOT NULL DEFAULT 0,
+      `resignations`          INT            NOT NULL DEFAULT 0,
+      `terminations`          INT            NOT NULL DEFAULT 0,
+      `headcountAtEnd`        INT            NOT NULL DEFAULT 0,
+      `turnoverRate`          DECIMAL(5,2)   NOT NULL DEFAULT 0.00,
+      `burnoutScore`          DECIMAL(5,2)   NOT NULL DEFAULT 0.00,
+      `totalPayroll`          DECIMAL(15,2)  NOT NULL DEFAULT 0.00,
+      `leaveRequestsTotal`    INT            NOT NULL DEFAULT 0,
+      `leaveRequestsApproved` INT            NOT NULL DEFAULT 0,
+      `iqamaExpiredCount`     INT            NOT NULL DEFAULT 0,
+      `iqamaDueSoonCount`     INT            NOT NULL DEFAULT 0,
+      `docRenewalsDueSoon`    INT            NOT NULL DEFAULT 0,
+      `reportData`            JSON,
+      `errorMessage`          TEXT,
+      `filePath`              VARCHAR(500),
+      `generatedAt`           DATETIME(3),
+      `createdById`           CHAR(36)       NOT NULL,
+      `createdAt`             DATETIME(3)    NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+      `updatedAt`             DATETIME(3)    NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+      PRIMARY KEY (`id`),
+      UNIQUE KEY `HrMonthlyReport_year_month_key` (`year`, `month`),
+      INDEX `HrMonthlyReport_status_idx` (`status`),
+      INDEX `HrMonthlyReport_createdAt_idx` (`createdAt`),
+      CONSTRAINT `HrMonthlyReport_createdBy_fkey`
+        FOREIGN KEY (`createdById`) REFERENCES `User` (`id`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+  END IF;
+END //
+DELIMITER ;
+
+CALL add_hr_monthly_report_table();
+DROP PROCEDURE IF EXISTS add_hr_monthly_report_table;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7151,3 +7151,48 @@ model SubcontractorPaymentCertificate {
   @@index([certificateDate])
   @@index([deletedAt])
 }
+
+// ─── HR Monthly Report ───────────────────────────────────────────────────────
+
+enum HrReportStatus {
+  GENERATING
+  READY
+  FAILED
+}
+
+model HrMonthlyReport {
+  id     String         @id @default(uuid()) @db.Char(36)
+  year   Int
+  month  Int
+  status HrReportStatus @default(GENERATING)
+
+  // Key metric snapshots (stored for quick listing without reading JSON)
+  newHires               Int     @default(0)
+  resignations           Int     @default(0)
+  terminations           Int     @default(0)
+  headcountAtEnd         Int     @default(0)
+  turnoverRate           Decimal @default(0) @db.Decimal(5, 2)
+  burnoutScore           Decimal @default(0) @db.Decimal(5, 2)
+  totalPayroll           Decimal @default(0) @db.Decimal(15, 2)
+  leaveRequestsTotal     Int     @default(0)
+  leaveRequestsApproved  Int     @default(0)
+  iqamaExpiredCount      Int     @default(0)
+  iqamaDueSoonCount      Int     @default(0)
+  docRenewalsDueSoon     Int     @default(0)
+
+  // Full JSON payload for PDF re-render
+  reportData   Json?
+  errorMessage String?   @db.Text
+  filePath     String?   @db.VarChar(500)
+  generatedAt  DateTime?
+
+  createdById String   @db.Char(36)
+  createdBy   User     @relation("HrReportCreatedBy", fields: [createdById], references: [id])
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@unique([year, month])
+  @@index([status])
+  @@index([createdAt])
+  @@map("HrMonthlyReport")
+}

--- a/src/app/api/cron/hr-monthly-report/route.ts
+++ b/src/app/api/cron/hr-monthly-report/route.ts
@@ -1,0 +1,120 @@
+/**
+ * POST /api/cron/hr-monthly-report
+ *
+ * Generates the HR Monthly Report for the previous calendar month.
+ * Triggered by HrMonthlyReportScheduler on the 2nd of each month at 06:00 Riyadh time
+ * (giving payroll a day to be finalised after month-end).
+ *
+ * Auth: Bearer <CRON_SECRET>
+ * Optional body: { year?: number; month?: number }  — override for manual runs
+ *
+ * v23.2.0
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '@/lib/db';
+import { logger } from '@/lib/logger';
+import { buildMonthlyReportData } from '@/lib/services/hr/hr-monthly-report-service';
+import { generateMonthlyReportPdf } from '@/lib/services/hr/hr-monthly-report-pdf';
+
+const log = logger.child({ module: 'cron.hr-monthly-report' });
+
+export async function POST(req: NextRequest) {
+  const authHeader = req.headers.get('authorization');
+  const cronSecret = process.env.CRON_SECRET;
+
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  // Default: previous calendar month
+  const now   = new Date();
+  let year    = now.getUTCMonth() === 0 ? now.getUTCFullYear() - 1 : now.getUTCFullYear();
+  let month   = now.getUTCMonth() === 0 ? 12 : now.getUTCMonth();
+
+  // Allow manual override via request body
+  try {
+    const body = await req.json().catch(() => ({})) as Record<string, unknown>;
+    if (typeof body.year  === 'number' && body.year  > 2020) year  = body.year;
+    if (typeof body.month === 'number' && body.month >= 1 && body.month <= 12) month = body.month;
+  } catch { /* no body */ }
+
+  log.info({ year, month }, '[HrMonthlyReport] Cron triggered');
+
+  // Find the system user (first admin) to record as createdById
+  const systemUser = await prisma.user.findFirst({
+    where: { status: 'active' },
+    select: { id: true },
+    orderBy: { createdAt: 'asc' },
+  });
+
+  if (!systemUser) {
+    log.error({}, '[HrMonthlyReport] No active user found for createdById');
+    return NextResponse.json({ error: 'No active user found' }, { status: 500 });
+  }
+
+  // Upsert a GENERATING record (idempotent — rerunning regenerates)
+  let reportId: string;
+  const existing = await prisma.hrMonthlyReport.findUnique({ where: { year_month: { year, month } } });
+
+  if (existing) {
+    reportId = existing.id;
+    await prisma.hrMonthlyReport.update({
+      where: { id: reportId },
+      data: { status: 'GENERATING', errorMessage: null, filePath: null, generatedAt: null },
+    });
+  } else {
+    const created = await prisma.hrMonthlyReport.create({
+      data: { year, month, status: 'GENERATING', createdById: systemUser.id },
+    });
+    reportId = created.id;
+  }
+
+  try {
+    // Build data
+    const data = await buildMonthlyReportData(year, month);
+
+    // Generate PDF
+    const filePath = await generateMonthlyReportPdf(data);
+
+    // Persist results
+    await prisma.hrMonthlyReport.update({
+      where: { id: reportId },
+      data: {
+        status:                'READY',
+        filePath,
+        generatedAt:           new Date(),
+        reportData:            data as object,
+        newHires:              data.headcount.newHires.length,
+        resignations:          data.headcount.resignations.length,
+        terminations:          data.headcount.terminations.length,
+        headcountAtEnd:        data.headcount.atEnd,
+        turnoverRate:          data.turnover.rate,
+        burnoutScore:          data.burnout.score,
+        totalPayroll:          data.payroll.totalGross,
+        leaveRequestsTotal:    data.leave.totalRequests,
+        leaveRequestsApproved: data.leave.approved,
+        iqamaExpiredCount:     data.documents.iqamaExpired.length,
+        iqamaDueSoonCount:     data.documents.iqamaDueSoon.length,
+        docRenewalsDueSoon:    data.documents.workPermitsDueSoon.length
+                             + data.documents.insuranceDueSoon.length
+                             + data.documents.otherDueSoon.length,
+      },
+    });
+
+    log.info({ reportId, year, month }, '[HrMonthlyReport] Generated successfully');
+    return NextResponse.json({ ok: true, reportId, filePath });
+  } catch (error) {
+    log.error({ error, reportId }, '[HrMonthlyReport] Generation failed');
+
+    await prisma.hrMonthlyReport.update({
+      where: { id: reportId },
+      data: {
+        status:       'FAILED',
+        errorMessage: error instanceof Error ? error.message : String(error),
+      },
+    });
+
+    return NextResponse.json({ error: 'Report generation failed' }, { status: 500 });
+  }
+}

--- a/src/app/api/hr/reports/monthly/route.ts
+++ b/src/app/api/hr/reports/monthly/route.ts
@@ -1,0 +1,111 @@
+/**
+ * GET  /api/hr/reports/monthly          — list all generated reports
+ * POST /api/hr/reports/monthly          — trigger generation for a specific month
+ *
+ * Permission: hr.reports.view (GET) / hr.reports.manage (POST)
+ * v23.2.0
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import { checkPermission } from '@/lib/permission-checker';
+import { logger } from '@/lib/logger';
+import prisma from '@/lib/db';
+import { env } from '@/lib/env';
+import { z } from 'zod';
+
+function getBaseUrl(): string {
+  return process.env.NEXTAUTH_URL || process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
+}
+
+const log = logger.child({ module: 'api.hr.reports.monthly' });
+
+export async function GET() {
+  const store = await cookies();
+  const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+  const session = token ? await verifySession(token) : null;
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const canView = await checkPermission('hr.reports.view');
+  if (!canView) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  const reports = await prisma.hrMonthlyReport.findMany({
+    orderBy: [{ year: 'desc' }, { month: 'desc' }],
+    select: {
+      id: true,
+      year: true,
+      month: true,
+      status: true,
+      newHires: true,
+      resignations: true,
+      terminations: true,
+      headcountAtEnd: true,
+      turnoverRate: true,
+      burnoutScore: true,
+      totalPayroll: true,
+      leaveRequestsTotal: true,
+      leaveRequestsApproved: true,
+      iqamaExpiredCount: true,
+      iqamaDueSoonCount: true,
+      docRenewalsDueSoon: true,
+      filePath: true,
+      generatedAt: true,
+      errorMessage: true,
+      createdAt: true,
+      createdBy: { select: { name: true } },
+    },
+  });
+
+  return NextResponse.json(reports);
+}
+
+const GenerateSchema = z.object({
+  year:  z.number().int().min(2020).max(2100),
+  month: z.number().int().min(1).max(12),
+});
+
+export async function POST(req: NextRequest) {
+  const store = await cookies();
+  const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+  const session = token ? await verifySession(token) : null;
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const canManage = await checkPermission('hr.reports.manage');
+  if (!canManage) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  const body = await req.json().catch(() => ({}));
+  const parsed = GenerateSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input', details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const { year, month } = parsed.data;
+
+  log.info({ year, month, userId: session.sub }, '[HR Reports] Manual generation triggered');
+
+  // Delegate to the cron endpoint (reuses the same logic)
+  const cronSecret = env.CRON_SECRET;
+  const baseUrl    = getBaseUrl();
+  const basePath   = env.NEXT_PUBLIC_BASE_PATH || '';
+
+  try {
+    const res = await fetch(`${baseUrl}${basePath}/api/cron/hr-monthly-report`, {
+      method:  'POST',
+      headers: {
+        'Content-Type':  'application/json',
+        'Authorization': `Bearer ${cronSecret}`,
+      },
+      body: JSON.stringify({ year, month }),
+    });
+
+    const result = await res.json() as Record<string, unknown>;
+    if (!res.ok) {
+      return NextResponse.json({ error: result.error ?? 'Generation failed' }, { status: res.status });
+    }
+    return NextResponse.json(result);
+  } catch (error) {
+    log.error({ error }, '[HR Reports] Failed to call cron endpoint');
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
+}

--- a/src/app/hr/reports/page.tsx
+++ b/src/app/hr/reports/page.tsx
@@ -1,0 +1,66 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { verifySession } from '@/lib/jwt';
+import { checkPermission } from '@/lib/permission-checker';
+import prisma from '@/lib/db';
+import { HrMonthlyReportsClient } from '@/components/hr/hr-monthly-reports-client';
+
+export const dynamic = 'force-dynamic';
+
+export default async function HrReportsPage() {
+  const cookieName = process.env.COOKIE_NAME || 'ots_session';
+  const store      = await cookies();
+  const token      = store.get(cookieName)?.value;
+  const session    = token ? verifySession(token) : null;
+  if (!session) redirect('/login');
+
+  const [canView, canManage] = await Promise.all([
+    checkPermission('hr.reports.view'),
+    checkPermission('hr.reports.manage'),
+  ]);
+  if (!canView && !canManage) redirect('/unauthorized?from=/hr/reports');
+
+  const reports = await prisma.hrMonthlyReport.findMany({
+    orderBy: [{ year: 'desc' }, { month: 'desc' }],
+    select: {
+      id:                    true,
+      year:                  true,
+      month:                 true,
+      status:                true,
+      newHires:              true,
+      resignations:          true,
+      terminations:          true,
+      headcountAtEnd:        true,
+      turnoverRate:          true,
+      burnoutScore:          true,
+      totalPayroll:          true,
+      leaveRequestsTotal:    true,
+      leaveRequestsApproved: true,
+      iqamaExpiredCount:     true,
+      iqamaDueSoonCount:     true,
+      docRenewalsDueSoon:    true,
+      filePath:              true,
+      generatedAt:           true,
+      errorMessage:          true,
+      createdAt:             true,
+      createdBy:             { select: { name: true } },
+    },
+  });
+
+  // Prisma Decimal fields must be serialised to plain numbers before passing to client
+  const serialised = reports.map((r) => ({
+    ...r,
+    turnoverRate: Number(r.turnoverRate),
+    burnoutScore: Number(r.burnoutScore),
+    totalPayroll: Number(r.totalPayroll),
+    generatedAt:  r.generatedAt?.toISOString() ?? null,
+    createdAt:    r.createdAt.toISOString(),
+  }));
+
+  return (
+    <HrMonthlyReportsClient
+      initialReports={serialised}
+      canManage={canManage}
+    />
+  );
+}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -331,6 +331,7 @@ const navigationSections: NavigationSection[] = [
     items: [
       { name: 'My Profile', href: '/hr/employees/me', icon: UserCircle2, newSince: '2026-04-21' },
       { name: 'HR Dashboard', href: '/hr/dashboard', icon: BarChart3, newSince: '2026-04-12' },
+      { name: 'HR Monthly Reports', href: '/hr/reports', icon: FileBarChart2, newSince: '2026-05-08' },
       { name: 'Absence Analytics', href: '/hr/analytics', icon: TrendingUp, newSince: '2026-04-18' },
       { name: 'Employees', href: '/hr/employees', icon: Users, newSince: '2026-04-12' },
       { name: 'Attendance', href: '/hr/attendance', icon: Calendar, newSince: '2026-04-12' },

--- a/src/components/hr/hr-monthly-reports-client.tsx
+++ b/src/components/hr/hr-monthly-reports-client.tsx
@@ -1,0 +1,386 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { FileText, RefreshCw, Download, AlertTriangle, CheckCircle2, Clock, TrendingDown, TrendingUp, Users, DollarSign, Calendar, Shield, ChevronDown, ChevronUp } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface ReportRow {
+  id: string;
+  year: number;
+  month: number;
+  status: 'GENERATING' | 'READY' | 'FAILED';
+  newHires: number;
+  resignations: number;
+  terminations: number;
+  headcountAtEnd: number;
+  turnoverRate: string | number;
+  burnoutScore: string | number;
+  totalPayroll: string | number;
+  leaveRequestsTotal: number;
+  leaveRequestsApproved: number;
+  iqamaExpiredCount: number;
+  iqamaDueSoonCount: number;
+  docRenewalsDueSoon: number;
+  filePath: string | null;
+  generatedAt: string | null;
+  errorMessage: string | null;
+  createdAt: string;
+  createdBy: { name: string } | null;
+}
+
+const MONTH_NAMES = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+
+function toNum(v: string | number | null | undefined): number {
+  if (v === null || v === undefined) return 0;
+  return Number(v);
+}
+
+function formatSar(n: number): string {
+  return `SAR ${n.toLocaleString('en-SA-u-ca-gregory', { minimumFractionDigits: 0 })}`;
+}
+
+// ─── Status badge ─────────────────────────────────────────────────────────────
+
+function StatusBadge({ status }: { status: ReportRow['status'] }) {
+  if (status === 'READY')      return <Badge className="bg-emerald-100 text-emerald-700 border-emerald-200">Ready</Badge>;
+  if (status === 'GENERATING') return <Badge className="bg-amber-100 text-amber-700 border-amber-200"><Clock className="h-3 w-3 mr-1" />Generating…</Badge>;
+  return <Badge className="bg-red-100 text-red-700 border-red-200"><AlertTriangle className="h-3 w-3 mr-1" />Failed</Badge>;
+}
+
+// ─── Burnout badge ────────────────────────────────────────────────────────────
+
+function BurnoutBadge({ score }: { score: number }) {
+  if (score <= 25) return <span className="text-emerald-600 font-bold">{score.toFixed(0)} <span className="text-xs font-normal text-slate-500">Low</span></span>;
+  if (score <= 50) return <span className="text-amber-600 font-bold">{score.toFixed(0)} <span className="text-xs font-normal text-slate-500">Moderate</span></span>;
+  if (score <= 75) return <span className="text-orange-600 font-bold">{score.toFixed(0)} <span className="text-xs font-normal text-slate-500">High</span></span>;
+  return <span className="text-red-600 font-bold">{score.toFixed(0)} <span className="text-xs font-normal text-slate-500">Critical</span></span>;
+}
+
+// ─── Turnover badge ───────────────────────────────────────────────────────────
+
+function TurnoverBadge({ rate }: { rate: number }) {
+  if (rate < 5)  return <span className="text-emerald-600 font-bold">{rate.toFixed(1)}%</span>;
+  if (rate <= 15) return <span className="text-amber-600 font-bold">{rate.toFixed(1)}%</span>;
+  return <span className="text-red-600 font-bold">{rate.toFixed(1)}%</span>;
+}
+
+// ─── Report card ─────────────────────────────────────────────────────────────
+
+function ReportCard({ report }: { report: ReportRow }) {
+  const [expanded, setExpanded] = useState(false);
+
+  const turnoverRate = toNum(report.turnoverRate);
+  const burnoutScore = toNum(report.burnoutScore);
+  const totalPayroll = toNum(report.totalPayroll);
+  const leavers      = report.resignations + report.terminations;
+
+  return (
+    <Card className="border border-slate-200 shadow-sm hover:shadow-md transition-shadow">
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <div className="rounded-lg bg-blue-50 p-2">
+              <FileText className="h-5 w-5 text-blue-600" />
+            </div>
+            <div>
+              <CardTitle className="text-base">
+                {MONTH_NAMES[report.month - 1]} {report.year}
+              </CardTitle>
+              <p className="text-xs text-slate-500 mt-0.5">
+                {report.generatedAt
+                  ? `Generated ${new Date(report.generatedAt).toLocaleDateString('en-SA-u-ca-gregory')}`
+                  : `Created ${new Date(report.createdAt).toLocaleDateString('en-SA-u-ca-gregory')}`}
+                {report.createdBy ? ` · ${report.createdBy.name}` : ''}
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <StatusBadge status={report.status} />
+            {report.status === 'READY' && report.filePath && (
+              <a
+                href={report.filePath}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700 transition-colors"
+              >
+                <Download className="h-3.5 w-3.5" />
+                PDF
+              </a>
+            )}
+          </div>
+        </div>
+      </CardHeader>
+
+      {report.status === 'READY' && (
+        <CardContent className="pt-0">
+          {/* KPI Strip */}
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 mb-3">
+            <div className="rounded-lg bg-slate-50 p-3 text-center">
+              <Users className="h-4 w-4 text-slate-400 mx-auto mb-1" />
+              <p className="text-lg font-bold text-slate-800">{report.headcountAtEnd}</p>
+              <p className="text-[10px] text-slate-500">Headcount</p>
+            </div>
+            <div className="rounded-lg bg-slate-50 p-3 text-center">
+              <TrendingDown className="h-4 w-4 text-slate-400 mx-auto mb-1" />
+              <TurnoverBadge rate={turnoverRate} />
+              <p className="text-[10px] text-slate-500 mt-0.5">Turnover Rate</p>
+            </div>
+            <div className="rounded-lg bg-slate-50 p-3 text-center">
+              <TrendingUp className="h-4 w-4 text-slate-400 mx-auto mb-1" />
+              <BurnoutBadge score={burnoutScore} />
+              <p className="text-[10px] text-slate-500 mt-0.5">Burnout Index</p>
+            </div>
+            <div className="rounded-lg bg-slate-50 p-3 text-center">
+              <DollarSign className="h-4 w-4 text-slate-400 mx-auto mb-1" />
+              <p className="text-sm font-bold text-slate-800">{formatSar(totalPayroll)}</p>
+              <p className="text-[10px] text-slate-500">Gross Payroll</p>
+            </div>
+          </div>
+
+          {/* Expandable detail row */}
+          <button
+            onClick={() => setExpanded((v) => !v)}
+            className="flex w-full items-center justify-between rounded-md bg-slate-50 px-3 py-2 text-xs text-slate-600 hover:bg-slate-100 transition-colors"
+          >
+            <span>Details</span>
+            {expanded ? <ChevronUp className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
+          </button>
+
+          {expanded && (
+            <div className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2 text-xs text-slate-600">
+              {/* Headcount */}
+              <div className="rounded-lg border border-slate-100 p-3">
+                <p className="font-semibold text-slate-700 mb-1.5 flex items-center gap-1"><Users className="h-3.5 w-3.5" /> Headcount Movement</p>
+                <div className="space-y-0.5">
+                  <div className="flex justify-between"><span>New Hires</span><span className="text-emerald-600 font-medium">+{report.newHires}</span></div>
+                  <div className="flex justify-between"><span>Resignations</span><span className="text-amber-600 font-medium">-{report.resignations}</span></div>
+                  <div className="flex justify-between"><span>Terminations</span><span className="text-red-600 font-medium">-{report.terminations}</span></div>
+                  <div className="flex justify-between border-t border-slate-100 pt-1 mt-1"><span>Net Change</span><span className={`font-bold ${report.newHires - leavers >= 0 ? 'text-emerald-600' : 'text-red-600'}`}>{report.newHires - leavers >= 0 ? '+' : ''}{report.newHires - leavers}</span></div>
+                </div>
+              </div>
+
+              {/* Leave */}
+              <div className="rounded-lg border border-slate-100 p-3">
+                <p className="font-semibold text-slate-700 mb-1.5 flex items-center gap-1"><Calendar className="h-3.5 w-3.5" /> Leave Requests</p>
+                <div className="space-y-0.5">
+                  <div className="flex justify-between"><span>Total Submitted</span><span className="font-medium">{report.leaveRequestsTotal}</span></div>
+                  <div className="flex justify-between"><span>Approved</span><span className="text-emerald-600 font-medium">{report.leaveRequestsApproved}</span></div>
+                </div>
+              </div>
+
+              {/* Documents */}
+              <div className="rounded-lg border border-slate-100 p-3 sm:col-span-2">
+                <p className="font-semibold text-slate-700 mb-1.5 flex items-center gap-1"><Shield className="h-3.5 w-3.5" /> Document Renewals</p>
+                <div className="flex flex-wrap gap-3">
+                  {report.iqamaExpiredCount > 0 && (
+                    <span className="rounded-full bg-red-50 border border-red-200 px-2 py-0.5 text-red-700">
+                      {report.iqamaExpiredCount} Iqama expired
+                    </span>
+                  )}
+                  {report.iqamaDueSoonCount > 0 && (
+                    <span className="rounded-full bg-amber-50 border border-amber-200 px-2 py-0.5 text-amber-700">
+                      {report.iqamaDueSoonCount} Iqama due soon
+                    </span>
+                  )}
+                  {report.docRenewalsDueSoon > 0 && (
+                    <span className="rounded-full bg-orange-50 border border-orange-200 px-2 py-0.5 text-orange-700">
+                      {report.docRenewalsDueSoon} other docs due soon
+                    </span>
+                  )}
+                  {report.iqamaExpiredCount === 0 && report.iqamaDueSoonCount === 0 && report.docRenewalsDueSoon === 0 && (
+                    <span className="flex items-center gap-1 text-emerald-600"><CheckCircle2 className="h-3.5 w-3.5" /> All documents current</span>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      )}
+
+      {report.status === 'FAILED' && report.errorMessage && (
+        <CardContent className="pt-0">
+          <div className="rounded-lg bg-red-50 border border-red-200 px-3 py-2 text-xs text-red-700">
+            <span className="font-semibold">Error:</span> {report.errorMessage}
+          </div>
+        </CardContent>
+      )}
+    </Card>
+  );
+}
+
+// ─── Main client component ────────────────────────────────────────────────────
+
+interface Props {
+  initialReports: ReportRow[];
+  canManage: boolean;
+}
+
+export function HrMonthlyReportsClient({ initialReports, canManage }: Props) {
+  const [reports, setReports]     = useState<ReportRow[]>(initialReports);
+  const [loading, setLoading]     = useState(false);
+  const [generating, setGenerating] = useState(false);
+  const [error, setError]         = useState<string | null>(null);
+  const [genYear, setGenYear]     = useState<string>(String(new Date().getFullYear()));
+  const [genMonth, setGenMonth]   = useState<string>(String(new Date().getMonth() === 0 ? 12 : new Date().getMonth()));
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res  = await fetch('/api/hr/reports/monthly');
+      const data = await res.json() as ReportRow[];
+      setReports(Array.isArray(data) ? data : []);
+    } catch {
+      setError('Failed to load reports');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const generate = useCallback(async () => {
+    setGenerating(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/hr/reports/monthly', {
+        method:  'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body:    JSON.stringify({ year: Number(genYear), month: Number(genMonth) }),
+      });
+      const result = await res.json() as Record<string, unknown>;
+      if (!res.ok) {
+        setError(String(result.error ?? 'Generation failed'));
+      } else {
+        await refresh();
+      }
+    } catch {
+      setError('Failed to trigger report generation');
+    } finally {
+      setGenerating(false);
+    }
+  }, [genYear, genMonth, refresh]);
+
+  // Year options: current year ± 3
+  const currentYear = new Date().getFullYear();
+  const yearOptions = Array.from({ length: 5 }, (_, i) => currentYear - 2 + i);
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-6 p-4 sm:p-6">
+      {/* Hero */}
+      <div className="rounded-2xl bg-gradient-to-br from-[#0f3460] to-[#1e64aa] p-6 text-white shadow-lg">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight">HR Monthly Reports</h1>
+            <p className="mt-1 text-sm text-blue-200">
+              Auto-generated on the 2nd of each month · PDF download
+            </p>
+          </div>
+          <FileText className="h-10 w-10 text-blue-300 shrink-0" />
+        </div>
+
+        {/* KPI summary strip */}
+        {reports.length > 0 && reports[0].status === 'READY' && (
+          <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
+            {[
+              { label: 'Latest Report',    value: `${MONTH_NAMES[reports[0].month - 1]} ${reports[0].year}` },
+              { label: 'Total Reports',    value: String(reports.filter((r) => r.status === 'READY').length) },
+              { label: 'Latest Turnover',  value: `${toNum(reports[0].turnoverRate).toFixed(1)}%` },
+              { label: 'Latest Burnout',   value: `${toNum(reports[0].burnoutScore).toFixed(0)}/100` },
+            ].map((kpi) => (
+              <div key={kpi.label} className="rounded-xl bg-white/10 p-3 text-center">
+                <p className="text-lg font-bold">{kpi.value}</p>
+                <p className="text-[10px] text-blue-200">{kpi.label}</p>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Generate panel */}
+      {canManage && (
+        <Card className="border border-slate-200">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-semibold text-slate-700">Generate Report</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="flex flex-wrap items-end gap-3">
+              <div>
+                <label className="mb-1 block text-xs font-medium text-slate-600">Year</label>
+                <Select value={genYear} onValueChange={setGenYear}>
+                  <SelectTrigger className="w-28">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {yearOptions.map((y) => (
+                      <SelectItem key={y} value={String(y)}>{y}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <label className="mb-1 block text-xs font-medium text-slate-600">Month</label>
+                <Select value={genMonth} onValueChange={setGenMonth}>
+                  <SelectTrigger className="w-36">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {MONTH_NAMES.map((name, i) => (
+                      <SelectItem key={i + 1} value={String(i + 1)}>{name}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <Button
+                onClick={generate}
+                disabled={generating || loading}
+                className="bg-blue-600 hover:bg-blue-700 text-white"
+              >
+                {generating ? (
+                  <><RefreshCw className="mr-2 h-4 w-4 animate-spin" /> Generating…</>
+                ) : (
+                  <><FileText className="mr-2 h-4 w-4" /> Generate</>
+                )}
+              </Button>
+              <Button
+                variant="outline"
+                onClick={refresh}
+                disabled={loading || generating}
+                className="ml-auto"
+              >
+                <RefreshCw className={`mr-2 h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+                Refresh
+              </Button>
+            </div>
+            {error && (
+              <p className="mt-2 text-xs text-red-600">{error}</p>
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Report list */}
+      {reports.length === 0 ? (
+        <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-slate-200 bg-slate-50 py-16">
+          <FileText className="h-10 w-10 text-slate-300 mb-3" />
+          <p className="text-sm font-medium text-slate-500">No reports generated yet</p>
+          {canManage && (
+            <p className="text-xs text-slate-400 mt-1">Use the Generate panel above to create the first report</p>
+          )}
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {reports.map((r) => (
+            <ReportCard key={r.id} report={r} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -18,6 +18,7 @@ export async function register() {
     const { OpsAgentScheduler } = await import('@/lib/scheduler/ops-agent.scheduler');
     const { AttendanceSyncScheduler } = await import('@/lib/scheduler/attendance-sync.scheduler');
     const { CalibrationReminderScheduler } = await import('@/lib/scheduler/calibration-reminder.scheduler');
+    const { HrMonthlyReportScheduler } = await import('@/lib/scheduler/hr-monthly-report.scheduler');
     const { ensureOpsAgentConfig } = await import('@/lib/ops-agent/seeder');
     const { registerIntegrationListeners } = await import('@/lib/events/integration-listeners');
     const { runStartupMigrations } = await import('@/lib/startup-migrations');
@@ -48,6 +49,9 @@ export async function register() {
 
     // Initialize the daily Calibration Due Reminder scheduler (IMS module, 22.2.0)
     CalibrationReminderScheduler.initialize();
+
+    // Initialize the monthly HR Report scheduler (HR module, 23.2.0)
+    HrMonthlyReportScheduler.initialize();
 
     // Register integration event listeners (open-audit, Libre MES, …)
     registerIntegrationListeners();

--- a/src/lib/navigation-permissions.ts
+++ b/src/lib/navigation-permissions.ts
@@ -212,6 +212,9 @@ export const NAVIGATION_PERMISSIONS: NavigationPermissionMap = {
   '/hr/loans': ['hr.loans.view', 'hr.loans.manage', 'hr.loans.viewOwn'],
   '/hr/custodies': ['hr.custodies.view', 'hr.custodies.manage', 'hr.custodies.viewOwn'],
 
+  // HR Monthly Reports (23.2.0)
+  '/hr/reports': ['hr.reports.view', 'hr.reports.manage'],
+
   // HR Absence Analytics (19.4.0)
   '/hr/analytics': ['hr.analytics.view'],
 

--- a/src/lib/scheduler/hr-monthly-report.scheduler.ts
+++ b/src/lib/scheduler/hr-monthly-report.scheduler.ts
@@ -1,0 +1,126 @@
+/**
+ * HR Monthly Report Scheduler — v23.2.0
+ *
+ * Fires on the 2nd of each month at 06:00 Asia/Riyadh, generating
+ * the previous month's HR report. Running on the 2nd (not the 1st)
+ * gives payroll one extra day to be approved/locked after month-end.
+ */
+
+import * as cron from 'node-cron';
+import { logger } from '@/lib/logger';
+
+const log = logger.child({ module: 'HrMonthlyReportScheduler' });
+
+const SCHEDULER_CONFIG = {
+  JOB_NAME:        'HrMonthlyReport',
+  // 06:00 Riyadh on the 2nd of each month
+  CRON_EXPRESSION: '0 6 2 * *',
+  TIMEZONE:        'Asia/Riyadh',
+};
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __hrMonthlyReportSchedulerInitialized: boolean | undefined;
+  // eslint-disable-next-line no-var
+  var __hrMonthlyReportSchedulerTask: cron.ScheduledTask | undefined;
+}
+
+export class HrMonthlyReportScheduler {
+  private static isRunning = false;
+
+  static isEnabled(): boolean {
+    const envValue = process.env.ENABLE_HR_MONTHLY_REPORT_SCHEDULER;
+    if (envValue === undefined) {
+      return process.env.NODE_ENV === 'production';
+    }
+    return envValue === 'true' || envValue === '1';
+  }
+
+  static initialize(): void {
+    if (global.__hrMonthlyReportSchedulerInitialized) {
+      log.info({}, 'Scheduler already initialized, skipping');
+      return;
+    }
+
+    if (!this.isEnabled()) {
+      log.info(
+        { enabled: process.env.ENABLE_HR_MONTHLY_REPORT_SCHEDULER },
+        'HR Monthly Report scheduler disabled',
+      );
+      return;
+    }
+
+    if (!cron.validate(SCHEDULER_CONFIG.CRON_EXPRESSION)) {
+      log.error({ cronExpression: SCHEDULER_CONFIG.CRON_EXPRESSION }, 'Invalid cron expression');
+      return;
+    }
+
+    const task = cron.schedule(
+      SCHEDULER_CONFIG.CRON_EXPRESSION,
+      async () => { await this.executeJob(); },
+      { timezone: SCHEDULER_CONFIG.TIMEZONE },
+    );
+
+    global.__hrMonthlyReportSchedulerTask = task;
+    global.__hrMonthlyReportSchedulerInitialized = true;
+
+    log.info(
+      { cronExpression: SCHEDULER_CONFIG.CRON_EXPRESSION, timezone: SCHEDULER_CONFIG.TIMEZONE },
+      'HR Monthly Report scheduler initialized',
+    );
+  }
+
+  private static async executeJob(): Promise<void> {
+    if (this.isRunning) {
+      log.info({}, 'Job already running, skipping');
+      return;
+    }
+
+    this.isRunning = true;
+    try {
+      const cronSecret = process.env.CRON_SECRET;
+      if (!cronSecret) {
+        log.error({}, 'CRON_SECRET not set — skipping HR monthly report run');
+        return;
+      }
+
+      const baseUrl  = process.env.NEXTAUTH_URL || process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
+      const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+
+      const res = await fetch(`${baseUrl}${basePath}/api/cron/hr-monthly-report`, {
+        method:  'POST',
+        headers: { Authorization: `Bearer ${cronSecret}` },
+      });
+
+      const result = await res.json();
+      log.info({ result }, 'HR Monthly Report cron completed');
+    } catch (error) {
+      log.error({ error }, 'HR Monthly Report cron failed');
+    } finally {
+      this.isRunning = false;
+    }
+  }
+
+  static async runNow(): Promise<void> {
+    log.info({}, 'Manual execution triggered');
+    await this.executeJob();
+  }
+
+  static stop(): void {
+    if (global.__hrMonthlyReportSchedulerTask) {
+      global.__hrMonthlyReportSchedulerTask.stop();
+      global.__hrMonthlyReportSchedulerInitialized = false;
+      log.info({}, 'Scheduler stopped');
+    }
+  }
+
+  static getStatus(): { enabled: boolean; initialized: boolean; isRunning: boolean } {
+    return {
+      enabled:     this.isEnabled(),
+      initialized: global.__hrMonthlyReportSchedulerInitialized || false,
+      isRunning:   this.isRunning,
+    };
+  }
+}
+
+export default HrMonthlyReportScheduler;

--- a/src/lib/services/hr/hr-monthly-report-pdf.ts
+++ b/src/lib/services/hr/hr-monthly-report-pdf.ts
@@ -1,0 +1,517 @@
+/**
+ * HR Monthly Report PDF Generator — v23.2.0
+ *
+ * Renders an A4 multi-page PDF report using jsPDF + jspdf-autotable.
+ * Output: public/outputs/hr-reports/<YYYY-MM>.pdf
+ */
+
+import { promises as fs } from 'fs';
+import path from 'path';
+import jsPDF from 'jspdf';
+import autoTable from 'jspdf-autotable';
+import { logger } from '@/lib/logger';
+import type { HrMonthlyReportData } from './hr-monthly-report-service';
+
+const REPORT_DIR = path.join(process.cwd(), 'public', 'outputs', 'hr-reports');
+const LOGO_DIR   = path.join(process.cwd(), 'public', 'uploads', 'company-logo');
+
+// Brand palette
+const BRAND_DARK:  [number, number, number] = [15, 52, 96];
+const BRAND_MID:   [number, number, number] = [30, 100, 170];
+const BRAND_LIGHT: [number, number, number] = [224, 237, 251];
+const GREEN:       [number, number, number] = [22, 163, 74];
+const AMBER:       [number, number, number] = [217, 119, 6];
+const RED:         [number, number, number] = [185, 28, 28];
+const GREY_TEXT:   [number, number, number] = [80, 80, 80];
+const WHITE:       [number, number, number] = [255, 255, 255];
+
+const A4_W   = 595.28;
+const A4_H   = 841.89;
+const MARGIN = 36;
+const CW     = A4_W - MARGIN * 2;
+
+// ─── Logo loader (same as payslip generator) ──────────────────────────────
+
+type LogoInfo = { base64: string; width: number; height: number };
+
+async function loadLogo(): Promise<LogoInfo | null> {
+  try {
+    const files = await fs.readdir(LOGO_DIR);
+    const pngs  = files.filter((f) => f.toLowerCase().endsWith('.png')).sort().reverse();
+    if (!pngs.length) return null;
+    const buf    = await fs.readFile(path.join(LOGO_DIR, pngs[0]));
+    const width  = buf.readUInt32BE(16);
+    const height = buf.readUInt32BE(20);
+    return { base64: buf.toString('base64'), width, height };
+  } catch {
+    return null;
+  }
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+function sar(n: number): string {
+  return `SAR ${n.toLocaleString('en-SA-u-ca-gregory', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+function pct(n: number, decimals = 1): string {
+  return `${n.toFixed(decimals)}%`;
+}
+
+interface DocAT extends jsPDF { lastAutoTable?: { finalY: number } }
+
+function lastY(doc: jsPDF): number {
+  return ((doc as DocAT).lastAutoTable?.finalY ?? 0);
+}
+
+// ─── Page header / footer ─────────────────────────────────────────────────
+
+function drawPageHeader(doc: jsPDF, logo: LogoInfo | null, data: HrMonthlyReportData, pageNum: number, totalPages: number) {
+  // Top band
+  doc.setFillColor(...(logo ? WHITE : BRAND_DARK));
+  doc.rect(0, 0, A4_W, 60, 'F');
+  if (logo) {
+    doc.setDrawColor(...BRAND_MID);
+    doc.setLineWidth(1);
+    doc.line(0, 60, A4_W, 60);
+  }
+
+  let textX = MARGIN;
+  if (logo) {
+    try {
+      const MAX_H = 44, MAX_W = 100;
+      const scale  = Math.min(MAX_W / logo.width, MAX_H / logo.height);
+      const logoW  = logo.width * scale;
+      const logoH  = logo.height * scale;
+      doc.addImage(logo.base64, 'PNG', MARGIN, (60 - logoH) / 2, logoW, logoH);
+      textX = MARGIN + logoW + 10;
+    } catch { /* skip */ }
+  }
+
+  const hdrColor: [number, number, number] = logo ? BRAND_DARK : WHITE;
+  const subColor: [number, number, number] = logo ? BRAND_MID   : [180, 210, 240];
+
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(14);
+  doc.setTextColor(...hdrColor);
+  doc.text('Hexa Steel®', textX, 24);
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(9);
+  doc.setTextColor(...subColor);
+  doc.text('HR MONTHLY REPORT', textX, 38);
+
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(10);
+  doc.setTextColor(...hdrColor);
+  doc.text(data.period.label, A4_W - MARGIN, 22, { align: 'right' });
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(8);
+  doc.setTextColor(...subColor);
+  doc.text(`Generated: ${new Date().toLocaleDateString('en-SA-u-ca-gregory')}`, A4_W - MARGIN, 36, { align: 'right' });
+  doc.text(`Page ${pageNum} of ${totalPages}`, A4_W - MARGIN, 50, { align: 'right' });
+}
+
+function drawPageFooter(doc: jsPDF) {
+  doc.setFillColor(...BRAND_DARK);
+  doc.rect(0, A4_H - 22, A4_W, 22, 'F');
+  doc.setTextColor(180, 200, 230);
+  doc.setFontSize(7);
+  doc.text(
+    'Hexa Steel® — Confidential — For internal use only',
+    A4_W / 2, A4_H - 8, { align: 'center' },
+  );
+}
+
+// ─── Section heading ──────────────────────────────────────────────────────
+
+function sectionTitle(doc: jsPDF, y: number, title: string): number {
+  doc.setFillColor(...BRAND_MID);
+  doc.rect(MARGIN, y, CW, 16, 'F');
+  doc.setTextColor(...WHITE);
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(9);
+  doc.text(title, MARGIN + 6, y + 11);
+  return y + 22;
+}
+
+// ─── KPI strip (4 boxes) ──────────────────────────────────────────────────
+
+function kpiStrip(
+  doc: jsPDF,
+  y: number,
+  items: Array<{ label: string; value: string; color?: [number, number, number] }>,
+): number {
+  const boxW = CW / items.length;
+  items.forEach((item, i) => {
+    const bx = MARGIN + i * boxW;
+    doc.setFillColor(...BRAND_LIGHT);
+    doc.roundedRect(bx + 2, y, boxW - 4, 42, 3, 3, 'F');
+    doc.setTextColor(...(item.color ?? BRAND_MID));
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(14);
+    doc.text(item.value, bx + boxW / 2, y + 24, { align: 'center' });
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(7.5);
+    doc.setTextColor(...GREY_TEXT);
+    doc.text(item.label, bx + boxW / 2, y + 36, { align: 'center' });
+  });
+  return y + 50;
+}
+
+// ─── Burnout gauge bar ────────────────────────────────────────────────────
+
+function burnoutBar(doc: jsPDF, y: number, score: number, level: string): number {
+  const barW = CW;
+  const barH = 14;
+  // Background gradient zones
+  const zones: Array<{ pct: number; color: [number, number, number] }> = [
+    { pct: 0.25, color: GREEN },
+    { pct: 0.25, color: [132, 204, 22] },
+    { pct: 0.25, color: AMBER },
+    { pct: 0.25, color: RED },
+  ];
+  let cx = MARGIN;
+  for (const z of zones) {
+    const w = barW * z.pct;
+    doc.setFillColor(...z.color);
+    doc.rect(cx, y, w, barH, 'F');
+    cx += w;
+  }
+
+  // Fill up to score
+  const filledW = (score / 100) * barW;
+  doc.setFillColor(...BRAND_DARK);
+  doc.setLineWidth(2);
+  doc.line(MARGIN + filledW, y - 3, MARGIN + filledW, y + barH + 3);
+
+  // Labels
+  doc.setFontSize(7);
+  doc.setTextColor(...GREY_TEXT);
+  ['Low', 'Moderate', 'High', 'Critical'].forEach((lbl, i) => {
+    doc.text(lbl, MARGIN + (i + 0.5) * barW * 0.25, y + barH + 10, { align: 'center' });
+  });
+
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(9);
+  const levelColor: [number, number, number] =
+    level === 'low'      ? GREEN
+    : level === 'moderate' ? AMBER
+    : RED;
+  doc.setTextColor(...levelColor);
+  doc.text(`${score.toFixed(0)}/100 — ${level.charAt(0).toUpperCase() + level.slice(1)}`, A4_W - MARGIN, y + 7, { align: 'right' });
+
+  return y + barH + 16;
+}
+
+// ─── Main PDF generator ───────────────────────────────────────────────────
+
+export async function generateMonthlyReportPdf(
+  data: HrMonthlyReportData,
+): Promise<string> {
+  const logo = await loadLogo();
+  const doc  = new jsPDF({ unit: 'pt', format: 'a4' });
+
+  // We pre-allocate pages:
+  // Page 1: Executive Summary + Headcount KPIs + Turnover + Burnout
+  // Page 2: Leave + Documents
+  // Page 3: Payroll + New Hires / Departures tables
+  const totalPages = 3;
+  let currentPage  = 1;
+
+  // ── PAGE 1 ─────────────────────────────────────────────────────────────────
+  drawPageHeader(doc, logo, data, currentPage, totalPages);
+  drawPageFooter(doc);
+
+  let y = 72;
+
+  // ── Executive Summary ─────────────────────────────────────────────────────
+  y = sectionTitle(doc, y, 'EXECUTIVE SUMMARY');
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(8.5);
+  doc.setTextColor(30, 30, 30);
+  const summaryLines = doc.splitTextToSize(data.executiveSummary, CW - 12);
+  doc.text(summaryLines, MARGIN + 6, y);
+  y += summaryLines.length * 11 + 10;
+
+  // ── Headcount KPIs ────────────────────────────────────────────────────────
+  y = sectionTitle(doc, y, 'WORKFORCE SNAPSHOT');
+  y = kpiStrip(doc, y, [
+    { label: 'Headcount (end of month)', value: String(data.headcount.atEnd) },
+    { label: 'New Hires',                value: String(data.headcount.newHires.length), color: GREEN },
+    { label: 'Departures',               value: String(data.turnover.leavers), color: data.turnover.leavers > 0 ? RED : GREY_TEXT },
+    { label: 'Turnover Rate',            value: pct(data.turnover.rate), color: data.turnover.rating === 'good' ? GREEN : data.turnover.rating === 'normal' ? AMBER : RED },
+  ]);
+
+  // Turnover detail row
+  doc.setFontSize(8);
+  doc.setFont('helvetica', 'normal');
+  doc.setTextColor(...GREY_TEXT);
+  doc.text(
+    `Avg headcount: ${data.turnover.avgHeadcount}  |  Resignations: ${data.headcount.resignations.length}  |  Terminations: ${data.headcount.terminations.length}  |  Rating: ${data.turnover.rating.toUpperCase()}`,
+    MARGIN, y,
+  );
+  y += 14;
+
+  // ── Burnout Indicator ─────────────────────────────────────────────────────
+  y = sectionTitle(doc, y, 'BURNOUT INDICATOR');
+  y = burnoutBar(doc, y, data.burnout.score, data.burnout.level);
+
+  // Component breakdown table
+  autoTable(doc, {
+    startY: y,
+    margin: { left: MARGIN, right: MARGIN },
+    head: [['Component', 'Score (max 25)', 'Value']],
+    body: [
+      ['Overtime Hours',        data.burnout.components.overtimeScore.toFixed(1),    `${data.burnout.avgOvertimeHours.toFixed(1)} hrs/emp`],
+      ['Absenteeism Rate',      data.burnout.components.absenteeismScore.toFixed(1), pct(data.burnout.absenteeismRate)],
+      ['Open Leave Requests',   data.burnout.components.openRequestsScore.toFixed(1),`${data.burnout.avgOpenRequests.toFixed(2)} req/emp`],
+      ['Departmental Turnover', data.burnout.components.turnoverScore.toFixed(1),    pct(data.burnout.departmentalTurnoverRate)],
+    ],
+    headStyles: { fillColor: BRAND_MID, textColor: WHITE, fontSize: 8, fontStyle: 'bold' },
+    bodyStyles: { fontSize: 8, cellPadding: 4 },
+    alternateRowStyles: { fillColor: [245, 248, 252] },
+    columnStyles: {
+      0: { cellWidth: CW * 0.50 },
+      1: { halign: 'center', cellWidth: CW * 0.25, fontStyle: 'bold' },
+      2: { halign: 'right',  cellWidth: CW * 0.25 },
+    },
+  });
+  y = lastY(doc) + 12;
+
+  // ── PAGE 2 ─────────────────────────────────────────────────────────────────
+  doc.addPage();
+  currentPage = 2;
+  drawPageHeader(doc, logo, data, currentPage, totalPages);
+  drawPageFooter(doc);
+  y = 72;
+
+  // ── Leave Statistics ───────────────────────────────────────────────────────
+  y = sectionTitle(doc, y, 'LEAVE REQUESTS');
+  y = kpiStrip(doc, y, [
+    { label: 'Total Submitted', value: String(data.leave.totalRequests) },
+    { label: 'Approved',        value: String(data.leave.approved),  color: GREEN },
+    { label: 'Rejected',        value: String(data.leave.rejected),  color: RED },
+    { label: 'Pending',         value: String(data.leave.pending),   color: AMBER },
+  ]);
+
+  doc.setFontSize(8);
+  doc.setTextColor(...GREY_TEXT);
+  doc.text(
+    `Avg leave days per employee: ${data.leave.avgDaysPerEmployee}  |  Cancelled: ${data.leave.cancelled}`,
+    MARGIN, y,
+  );
+  y += 14;
+
+  if (data.leave.byType.length > 0) {
+    autoTable(doc, {
+      startY: y,
+      margin: { left: MARGIN, right: MARGIN },
+      head: [['Leave Type', 'Requests', 'Total Days']],
+      body: data.leave.byType.map((t) => [t.typeName, String(t.count), String(t.totalDays)]),
+      headStyles: { fillColor: BRAND_MID, textColor: WHITE, fontSize: 8, fontStyle: 'bold' },
+      bodyStyles: { fontSize: 8, cellPadding: 4 },
+      alternateRowStyles: { fillColor: [245, 248, 252] },
+      columnStyles: {
+        0: { cellWidth: CW * 0.60 },
+        1: { halign: 'center', cellWidth: CW * 0.20 },
+        2: { halign: 'center', cellWidth: CW * 0.20 },
+      },
+    });
+    y = lastY(doc) + 12;
+  }
+
+  // ── Document Renewals ─────────────────────────────────────────────────────
+  y = sectionTitle(doc, y, 'IQAMA & DOCUMENT RENEWALS');
+
+  const totalDocAlerts = data.documents.iqamaExpired.length
+    + data.documents.iqamaDueSoon.length
+    + data.documents.workPermitsDueSoon.length
+    + data.documents.insuranceDueSoon.length
+    + data.documents.otherDueSoon.length;
+
+  if (totalDocAlerts === 0) {
+    doc.setFontSize(8.5);
+    doc.setTextColor(...GREEN);
+    doc.setFont('helvetica', 'bold');
+    doc.text('All documents are current — no renewals required.', MARGIN + 6, y + 8);
+    y += 20;
+  } else {
+    const allDocs = [
+      ...data.documents.iqamaExpired.map((d) => ({ ...d, category: 'Iqama — EXPIRED' })),
+      ...data.documents.iqamaDueSoon.map((d) => ({ ...d, category: 'Iqama — Due Soon' })),
+      ...data.documents.workPermitsDueSoon.map((d) => ({ ...d, category: 'Work Permit' })),
+      ...data.documents.insuranceDueSoon.map((d) => ({ ...d, category: 'Insurance' })),
+      ...data.documents.otherDueSoon.map((d) => ({ ...d, category: 'Other' })),
+    ];
+
+    autoTable(doc, {
+      startY: y,
+      margin: { left: MARGIN, right: MARGIN },
+      head: [['Category', 'Document', 'Employee', 'Expiry Date', 'Days']],
+      body: allDocs.map((d) => [
+        d.category,
+        d.title,
+        d.employeeName ?? '—',
+        d.expiryDate,
+        d.daysUntilExpiry <= 0 ? `${Math.abs(d.daysUntilExpiry)}d ago` : `${d.daysUntilExpiry}d`,
+      ]),
+      headStyles: { fillColor: BRAND_MID, textColor: WHITE, fontSize: 8, fontStyle: 'bold' },
+      bodyStyles: { fontSize: 7.5, cellPadding: 3.5 },
+      alternateRowStyles: { fillColor: [245, 248, 252] },
+      columnStyles: {
+        0: { cellWidth: CW * 0.22 },
+        1: { cellWidth: CW * 0.28 },
+        2: { cellWidth: CW * 0.22 },
+        3: { halign: 'center', cellWidth: CW * 0.16 },
+        4: { halign: 'center', cellWidth: CW * 0.12 },
+      },
+      didParseCell: (hookData) => {
+        if (hookData.column.index === 4 && hookData.section === 'body') {
+          const val = String(hookData.cell.raw ?? '');
+          if (val.includes('ago')) hookData.cell.styles.textColor = RED;
+          else if (parseInt(val) <= 30) hookData.cell.styles.textColor = AMBER;
+        }
+      },
+    });
+    y = lastY(doc) + 12;
+  }
+
+  // ── PAGE 3 ─────────────────────────────────────────────────────────────────
+  doc.addPage();
+  currentPage = 3;
+  drawPageHeader(doc, logo, data, currentPage, totalPages);
+  drawPageFooter(doc);
+  y = 72;
+
+  // ── Payroll KPIs ──────────────────────────────────────────────────────────
+  y = sectionTitle(doc, y, 'MONTHLY PAYROLL KPI');
+
+  if (!data.payroll.periodFound) {
+    doc.setFontSize(8.5);
+    doc.setTextColor(...AMBER);
+    doc.setFont('helvetica', 'italic');
+    doc.text('No payroll period found for this month.', MARGIN + 6, y + 8);
+    y += 20;
+  } else {
+    y = kpiStrip(doc, y, [
+      { label: 'Total Gross Payroll',  value: sar(data.payroll.totalGross) },
+      { label: 'Total Net Payroll',    value: sar(data.payroll.totalNet),   color: GREEN },
+      { label: 'Employees Paid',       value: String(data.payroll.employeesPaid) },
+      { label: 'Avg Net Salary',       value: sar(data.payroll.avgNetSalary) },
+    ]);
+
+    autoTable(doc, {
+      startY: y,
+      margin: { left: MARGIN, right: MARGIN },
+      head: [['Payroll Component', 'Amount (SAR)']],
+      body: [
+        ['Total Gross Payroll',        sar(data.payroll.totalGross)],
+        ['Total Deductions',           sar(data.payroll.totalDeductions)],
+        ['Total Net Payroll',          sar(data.payroll.totalNet)],
+        ['GOSI — Employee (10%)',      sar(data.payroll.gosiEmployee)],
+        ['GOSI — Employer (12%)',      sar(data.payroll.gosiEmployer)],
+        ['Average Net Salary',         sar(data.payroll.avgNetSalary)],
+        ['Employees Paid',             String(data.payroll.employeesPaid)],
+        ['Period Status',              data.payroll.periodStatus ?? '—'],
+      ],
+      headStyles: { fillColor: BRAND_MID, textColor: WHITE, fontSize: 8.5, fontStyle: 'bold' },
+      bodyStyles: { fontSize: 8.5, cellPadding: 5 },
+      alternateRowStyles: { fillColor: [245, 248, 252] },
+      columnStyles: {
+        0: { cellWidth: CW * 0.60 },
+        1: { halign: 'right', cellWidth: CW * 0.40, fontStyle: 'bold' },
+      },
+    });
+    y = lastY(doc) + 14;
+  }
+
+  // ── New Hires table ───────────────────────────────────────────────────────
+  y = sectionTitle(doc, y, `NEW HIRES (${data.headcount.newHires.length})`);
+
+  if (data.headcount.newHires.length === 0) {
+    doc.setFontSize(8.5);
+    doc.setTextColor(...GREY_TEXT);
+    doc.text('No new hires this month.', MARGIN + 6, y + 8);
+    y += 20;
+  } else {
+    autoTable(doc, {
+      startY: y,
+      margin: { left: MARGIN, right: MARGIN },
+      head: [['ID', 'Full Name', 'Position', 'Department', 'Joined']],
+      body: data.headcount.newHires.map((h) => [
+        h.employmentId,
+        h.fullNameEn,
+        h.occupation ?? '—',
+        h.department ?? '—',
+        h.dateOfJoining,
+      ]),
+      headStyles: { fillColor: GREEN, textColor: WHITE, fontSize: 8, fontStyle: 'bold' },
+      bodyStyles: { fontSize: 7.5, cellPadding: 3.5 },
+      alternateRowStyles: { fillColor: [240, 253, 244] },
+      columnStyles: {
+        0: { cellWidth: CW * 0.14 },
+        1: { cellWidth: CW * 0.26 },
+        2: { cellWidth: CW * 0.22 },
+        3: { cellWidth: CW * 0.22 },
+        4: { halign: 'center', cellWidth: CW * 0.16 },
+      },
+    });
+    y = lastY(doc) + 12;
+  }
+
+  // ── Departures table ──────────────────────────────────────────────────────
+  const allDepartures = [
+    ...data.headcount.resignations,
+    ...data.headcount.terminations,
+  ];
+  y = sectionTitle(doc, y, `DEPARTURES (${allDepartures.length})`);
+
+  if (allDepartures.length === 0) {
+    doc.setFontSize(8.5);
+    doc.setTextColor(...GREY_TEXT);
+    doc.text('No departures this month.', MARGIN + 6, y + 8);
+    y += 20;
+  } else {
+    autoTable(doc, {
+      startY: y,
+      margin: { left: MARGIN, right: MARGIN },
+      head: [['ID', 'Full Name', 'Position', 'Department', 'Left On', 'Reason']],
+      body: allDepartures.map((d) => [
+        d.employmentId,
+        d.fullNameEn,
+        d.occupation ?? '—',
+        d.department ?? '—',
+        d.dateOfLeaving,
+        d.reason,
+      ]),
+      headStyles: { fillColor: RED, textColor: WHITE, fontSize: 8, fontStyle: 'bold' },
+      bodyStyles: { fontSize: 7.5, cellPadding: 3.5 },
+      alternateRowStyles: { fillColor: [255, 245, 245] },
+      columnStyles: {
+        0: { cellWidth: CW * 0.12 },
+        1: { cellWidth: CW * 0.24 },
+        2: { cellWidth: CW * 0.20 },
+        3: { cellWidth: CW * 0.20 },
+        4: { halign: 'center', cellWidth: CW * 0.14 },
+        5: { halign: 'center', cellWidth: CW * 0.10, fontStyle: 'bold' },
+      },
+      didParseCell: (hookData) => {
+        if (hookData.column.index === 5 && hookData.section === 'body') {
+          hookData.cell.styles.textColor =
+            hookData.cell.raw === 'RESIGNED' ? AMBER : RED;
+        }
+      },
+    });
+  }
+
+  // ── Write to disk ──────────────────────────────────────────────────────────
+  await fs.mkdir(REPORT_DIR, { recursive: true });
+  const filename   = `${data.period.year}-${String(data.period.month).padStart(2, '0')}.pdf`;
+  const diskPath   = path.join(REPORT_DIR, filename);
+  const publicPath = `/outputs/hr-reports/${filename}`;
+  const raw        = doc.output('arraybuffer');
+  await fs.writeFile(diskPath, Buffer.from(raw));
+
+  logger.info({ publicPath }, '[HrMonthlyReport] PDF written');
+  return publicPath;
+}

--- a/src/lib/services/hr/hr-monthly-report-service.ts
+++ b/src/lib/services/hr/hr-monthly-report-service.ts
@@ -1,0 +1,656 @@
+/**
+ * HR Monthly Report Service — v23.2.0
+ *
+ * Extracts and aggregates all HR metrics for a given year/month:
+ *  • New hires & departures (resignations / terminations)
+ *  • Employee Turnover Rate  = (leavers ÷ avg headcount) × 100
+ *  • Burnout Indicator       = composite 0-100 index
+ *  • Leave statistics        = requests, approvals, breakdown by type
+ *  • Iqama & document renewals expiring / recently expired
+ *  • Payroll KPIs            = gross, net, avg salary, GOSI
+ *  • Executive summary       = plain-text narrative
+ */
+
+import prisma from '@/lib/db';
+import { logger } from '@/lib/logger';
+
+const log = logger.child({ module: 'HrMonthlyReportService' });
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface HireRecord {
+  employmentId: string;
+  fullNameEn: string;
+  occupation: string | null;
+  department: string | null;
+  dateOfJoining: string;
+}
+
+export interface DepartureRecord {
+  employmentId: string;
+  fullNameEn: string;
+  occupation: string | null;
+  department: string | null;
+  dateOfLeaving: string;
+  reason: 'RESIGNED' | 'TERMINATED';
+}
+
+export interface LeaveTypeBreakdown {
+  typeId: string;
+  typeName: string;
+  count: number;
+  totalDays: number;
+}
+
+export interface DocumentRecord {
+  id: string;
+  title: string;
+  type: string;
+  employeeName: string | null;
+  expiryDate: string;
+  daysUntilExpiry: number;
+}
+
+export interface BurnoutComponents {
+  overtimeScore: number;       // 0–25
+  absenteeismScore: number;    // 0–25
+  openRequestsScore: number;   // 0–25
+  turnoverScore: number;       // 0–25
+}
+
+export interface HrMonthlyReportData {
+  period: {
+    year: number;
+    month: number;
+    label: string;
+  };
+
+  headcount: {
+    atStart: number;
+    atEnd: number;
+    newHires: HireRecord[];
+    resignations: DepartureRecord[];
+    terminations: DepartureRecord[];
+  };
+
+  turnover: {
+    rate: number;
+    leavers: number;
+    avgHeadcount: number;
+    rating: 'good' | 'normal' | 'review';
+  };
+
+  burnout: {
+    score: number;
+    level: 'low' | 'moderate' | 'high' | 'critical';
+    components: BurnoutComponents;
+    avgOvertimeHours: number;
+    absenteeismRate: number;
+    avgOpenRequests: number;
+    departmentalTurnoverRate: number;
+  };
+
+  leave: {
+    totalRequests: number;
+    approved: number;
+    rejected: number;
+    pending: number;
+    cancelled: number;
+    byType: LeaveTypeBreakdown[];
+    avgDaysPerEmployee: number;
+  };
+
+  documents: {
+    iqamaExpired: DocumentRecord[];
+    iqamaDueSoon: DocumentRecord[];       // expiring within 60 days from month-end
+    workPermitsDueSoon: DocumentRecord[];
+    insuranceDueSoon: DocumentRecord[];
+    otherDueSoon: DocumentRecord[];
+  };
+
+  payroll: {
+    totalGross: number;
+    totalNet: number;
+    totalDeductions: number;
+    gosiEmployer: number;
+    gosiEmployee: number;
+    avgNetSalary: number;
+    employeesPaid: number;
+    periodFound: boolean;
+    periodStatus: string | null;
+  };
+
+  executiveSummary: string;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const MONTH_NAMES = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+
+function isoDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function toNum(v: unknown): number {
+  if (v === null || v === undefined) return 0;
+  if (typeof v === 'number') return v;
+  if (typeof v === 'object' && 'toString' in (v as object)) return Number((v as { toString(): string }).toString());
+  return Number(v);
+}
+
+function clamp(n: number, max: number): number {
+  return Math.min(n, max);
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+export async function buildMonthlyReportData(
+  year: number,
+  month: number,
+): Promise<HrMonthlyReportData> {
+  const periodLabel = `${MONTH_NAMES[month - 1]} ${year}`;
+  log.info({ year, month }, '[HrMonthlyReport] Building report data');
+
+  // Period boundaries (UTC date objects)
+  const periodStart = new Date(Date.UTC(year, month - 1, 1));
+  const periodEnd   = new Date(Date.UTC(year, month, 0));      // last day of month
+  const periodEndExclusive = new Date(Date.UTC(year, month, 1));
+
+  // "Due soon" window = 60 days past month-end
+  const dueSoonCutoff = new Date(Date.UTC(year, month, 0 + 60));
+
+  // ── 1. Headcount & movement ───────────────────────────────────────────────
+
+  const [atStart, atEnd, rawNewHires, rawDepartures] = await Promise.all([
+    // Active at start of month
+    prisma.employee.count({
+      where: {
+        deletedAt: null,
+        dateOfJoining: { lte: periodStart },
+        OR: [{ dateOfLeaving: null }, { dateOfLeaving: { gte: periodStart } }],
+      },
+    }),
+    // Active at end of month
+    prisma.employee.count({
+      where: {
+        deletedAt: null,
+        dateOfJoining: { lte: periodEnd },
+        OR: [{ dateOfLeaving: null }, { dateOfLeaving: { gt: periodEnd } }],
+      },
+    }),
+    // Joined during the month
+    prisma.employee.findMany({
+      where: {
+        deletedAt: null,
+        dateOfJoining: { gte: periodStart, lte: periodEnd },
+      },
+      select: {
+        employmentId: true,
+        fullNameEn: true,
+        occupation: true,
+        department: true,
+        dateOfJoining: true,
+      },
+      orderBy: { dateOfJoining: 'asc' },
+    }),
+    // Left during the month
+    prisma.employee.findMany({
+      where: {
+        deletedAt: null,
+        dateOfLeaving: { gte: periodStart, lte: periodEnd },
+        status: { in: ['RESIGNED', 'TERMINATED'] },
+      },
+      select: {
+        employmentId: true,
+        fullNameEn: true,
+        occupation: true,
+        department: true,
+        dateOfLeaving: true,
+        status: true,
+      },
+      orderBy: { dateOfLeaving: 'asc' },
+    }),
+  ]);
+
+  const newHires: HireRecord[] = rawNewHires.map((e) => ({
+    employmentId: e.employmentId,
+    fullNameEn: e.fullNameEn,
+    occupation: e.occupation,
+    department: e.department,
+    dateOfJoining: isoDate(e.dateOfJoining),
+  }));
+
+  const resignations: DepartureRecord[] = rawDepartures
+    .filter((e) => e.status === 'RESIGNED')
+    .map((e) => ({
+      employmentId: e.employmentId,
+      fullNameEn: e.fullNameEn,
+      occupation: e.occupation,
+      department: e.department,
+      dateOfLeaving: isoDate(e.dateOfLeaving!),
+      reason: 'RESIGNED' as const,
+    }));
+
+  const terminations: DepartureRecord[] = rawDepartures
+    .filter((e) => e.status === 'TERMINATED')
+    .map((e) => ({
+      employmentId: e.employmentId,
+      fullNameEn: e.fullNameEn,
+      occupation: e.occupation,
+      department: e.department,
+      dateOfLeaving: isoDate(e.dateOfLeaving!),
+      reason: 'TERMINATED' as const,
+    }));
+
+  // ── 2. Turnover Rate ──────────────────────────────────────────────────────
+  //  (leavers ÷ avg headcount) × 100
+
+  const totalLeavers = resignations.length + terminations.length;
+  const avgHeadcount = (atStart + atEnd) / 2;
+  const rawTurnover  = avgHeadcount > 0 ? (totalLeavers / avgHeadcount) * 100 : 0;
+  const turnoverRate = round2(rawTurnover);
+  const turnoverRating: 'good' | 'normal' | 'review' =
+    turnoverRate < 5 ? 'good' : turnoverRate <= 15 ? 'normal' : 'review';
+
+  // ── 3. Attendance data (for burnout) ──────────────────────────────────────
+
+  const attendanceRecords = await prisma.attendanceRecord.findMany({
+    where: {
+      workerType: 'EMPLOYEE',
+      date: { gte: periodStart, lt: periodEndExclusive },
+      employee: { deletedAt: null },
+    },
+    select: {
+      employeeId: true,
+      status: true,
+      overtimeHours: true,
+    },
+    take: 200_000,
+  });
+
+  // Per-employee OT and absences
+  const empOtMap    = new Map<string, number>();
+  const empAbsMap   = new Map<string, number>();
+  const empDaysMap  = new Map<string, number>();
+
+  for (const r of attendanceRecords) {
+    if (!r.employeeId) continue;
+    const ot    = toNum(r.overtimeHours);
+    const cur   = empOtMap.get(r.employeeId) ?? 0;
+    empOtMap.set(r.employeeId, cur + ot);
+
+    const days = empDaysMap.get(r.employeeId) ?? 0;
+    empDaysMap.set(r.employeeId, days + 1);
+
+    if (r.status === 'ABSENT_NO_PERMISSION') {
+      const abs = empAbsMap.get(r.employeeId) ?? 0;
+      empAbsMap.set(r.employeeId, abs + 1);
+    }
+  }
+
+  const totalEmployeesWithAttendance = empOtMap.size;
+  const totalOtHours  = [...empOtMap.values()].reduce((s, v) => s + v, 0);
+  const totalAbsDays  = [...empAbsMap.values()].reduce((s, v) => s + v, 0);
+  const totalWorkDays = [...empDaysMap.values()].reduce((s, v) => s + v, 0);
+
+  const avgOvertimeHours   = totalEmployeesWithAttendance > 0
+    ? totalOtHours / totalEmployeesWithAttendance
+    : 0;
+  const absenteeismRate = totalWorkDays > 0
+    ? (totalAbsDays / totalWorkDays) * 100
+    : 0;
+
+  // ── 4. Open leave requests per employee ───────────────────────────────────
+
+  const openRequests = await prisma.leaveRequest.count({
+    where: {
+      deletedAt: null,
+      status: { in: ['PENDING_MANAGER', 'PENDING_HR', 'PENDING_CEO'] },
+    },
+  });
+
+  const activeHeadcount = atEnd > 0 ? atEnd : 1;
+  const avgOpenRequests = openRequests / activeHeadcount;
+
+  // ── 5. Burnout Score (composite 0–100) ───────────────────────────────────
+  //
+  // Component         Max    Threshold
+  // Overtime          25     40 hrs/month saturates at max
+  // Absenteeism       25     10% absence rate saturates at max
+  // Open requests     25     2 open requests/person saturates at max
+  // Departmental OT   25     Uses turnover rate (>20% → saturates)
+
+  const OT_THRESHOLD       = 40;  // hrs / employee / month
+  const ABS_THRESHOLD      = 10;  // % of working days
+  const OPEN_REQ_THRESHOLD = 2;   // requests per employee
+  const TURNOVER_THRESHOLD = 20;  // % monthly turnover
+
+  const overtimeScore    = round2(clamp((avgOvertimeHours  / OT_THRESHOLD)       * 25, 25));
+  const absenteeismScore = round2(clamp((absenteeismRate   / ABS_THRESHOLD)      * 25, 25));
+  const openReqScore     = round2(clamp((avgOpenRequests   / OPEN_REQ_THRESHOLD) * 25, 25));
+  const turnoverScore    = round2(clamp((turnoverRate      / TURNOVER_THRESHOLD) * 25, 25));
+
+  const burnoutScore = round2(overtimeScore + absenteeismScore + openReqScore + turnoverScore);
+  const burnoutLevel: 'low' | 'moderate' | 'high' | 'critical' =
+    burnoutScore <= 25  ? 'low'
+    : burnoutScore <= 50  ? 'moderate'
+    : burnoutScore <= 75  ? 'high'
+    : 'critical';
+
+  // ── 6. Leave requests this month ─────────────────────────────────────────
+
+  const leaveRequests = await prisma.leaveRequest.findMany({
+    where: {
+      deletedAt: null,
+      createdAt: { gte: periodStart, lt: periodEndExclusive },
+    },
+    select: {
+      status: true,
+      startDate: true,
+      endDate: true,
+      leaveType: { select: { id: true, name: true } },
+    },
+  });
+
+  let approved = 0, rejected = 0, pending = 0, cancelled = 0;
+  const typeMap = new Map<string, { typeName: string; count: number; totalDays: number }>();
+
+  for (const r of leaveRequests) {
+    if (r.status === 'APPROVED') approved++;
+    else if (r.status === 'REJECTED') rejected++;
+    else if (r.status === 'CANCELLED') cancelled++;
+    else pending++;
+
+    const typeId   = r.leaveType?.id ?? '__unknown__';
+    const typeName = r.leaveType?.name ?? 'Unknown';
+    const days     = r.startDate && r.endDate
+      ? Math.max(1, Math.round((r.endDate.getTime() - r.startDate.getTime()) / 86400000) + 1)
+      : 1;
+
+    const acc = typeMap.get(typeId) ?? { typeName, count: 0, totalDays: 0 };
+    acc.count++;
+    acc.totalDays += days;
+    typeMap.set(typeId, acc);
+  }
+
+  const byType: LeaveTypeBreakdown[] = [...typeMap.entries()].map(([typeId, v]) => ({
+    typeId,
+    typeName: v.typeName,
+    count: v.count,
+    totalDays: v.totalDays,
+  })).sort((a, b) => b.count - a.count);
+
+  const totalApprovedDays = byType.reduce((s, t) => s + t.totalDays, 0);
+  const avgDaysPerEmployee = activeHeadcount > 0 ? round2(totalApprovedDays / activeHeadcount) : 0;
+
+  // ── 7. Documents (Iqama + others) ────────────────────────────────────────
+
+  // Iqama expired during the month or currently expired
+  const iqamaExpiredRaw = await prisma.contract.findMany({
+    where: {
+      deletedAt: null,
+      type: 'IQAMA',
+      expiryDate: { lte: periodEnd },
+      status: { in: ['EXPIRED', 'ACTIVE'] },
+    },
+    select: {
+      id: true, title: true, type: true, expiryDate: true,
+      employee: { select: { fullNameEn: true } },
+    },
+    orderBy: { expiryDate: 'asc' },
+  });
+
+  // Iqama due soon (expiring within 60 days from end of month)
+  const iqamaDueSoonRaw = await prisma.contract.findMany({
+    where: {
+      deletedAt: null,
+      type: 'IQAMA',
+      expiryDate: { gt: periodEnd, lte: dueSoonCutoff },
+      status: { in: ['ACTIVE', 'PENDING_RENEWAL'] },
+    },
+    select: {
+      id: true, title: true, type: true, expiryDate: true,
+      employee: { select: { fullNameEn: true } },
+    },
+    orderBy: { expiryDate: 'asc' },
+  });
+
+  // Other documents due soon (work permits, insurance, etc.)
+  const otherDocsDueSoonRaw = await prisma.contract.findMany({
+    where: {
+      deletedAt: null,
+      type: { notIn: ['IQAMA'] },
+      expiryDate: { gte: periodStart, lte: dueSoonCutoff },
+      status: { in: ['ACTIVE', 'PENDING_RENEWAL'] },
+    },
+    select: {
+      id: true, title: true, type: true, expiryDate: true,
+      employee: { select: { fullNameEn: true } },
+    },
+    orderBy: { expiryDate: 'asc' },
+  });
+
+  function toDocRecord(r: {
+    id: string; title: string; type: string; expiryDate: Date | null;
+    employee: { fullNameEn: string } | null;
+  }): DocumentRecord {
+    const expDate  = r.expiryDate ? isoDate(r.expiryDate) : '';
+    const diffMs   = r.expiryDate ? r.expiryDate.getTime() - periodEnd.getTime() : 0;
+    const daysLeft = Math.round(diffMs / 86400000);
+    return {
+      id: r.id,
+      title: r.title,
+      type: r.type,
+      employeeName: r.employee?.fullNameEn ?? null,
+      expiryDate: expDate,
+      daysUntilExpiry: daysLeft,
+    };
+  }
+
+  const iqamaExpired    = iqamaExpiredRaw.map(toDocRecord);
+  const iqamaDueSoon    = iqamaDueSoonRaw.map(toDocRecord);
+  const workPermitsDueSoon = otherDocsDueSoonRaw
+    .filter((d) => d.type === 'PROFESSIONAL_LICENSE' || d.type === 'VEHICLE_LICENSE')
+    .map(toDocRecord);
+  const insuranceDueSoon = otherDocsDueSoonRaw
+    .filter((d) => d.type === 'HEALTH_INSURANCE' || d.type === 'MEDICAL_INSURANCE')
+    .map(toDocRecord);
+  const otherDueSoon = otherDocsDueSoonRaw
+    .filter((d) => !['PROFESSIONAL_LICENSE', 'VEHICLE_LICENSE', 'HEALTH_INSURANCE', 'MEDICAL_INSURANCE'].includes(d.type))
+    .map(toDocRecord);
+
+  // ── 8. Payroll KPIs ───────────────────────────────────────────────────────
+
+  const payrollPeriod = await prisma.payrollPeriod.findFirst({
+    where: { year, month, deletedAt: null },
+    select: {
+      id: true,
+      status: true,
+      lines: {
+        select: {
+          grossPay: true,
+          netPay: true,
+          totalDeductions: true,
+          gosiEmployee: true,
+          gosiEmployer: true,
+        },
+      },
+    },
+  });
+
+  let totalGross = 0, totalNet = 0, totalDeductions = 0;
+  let gosiEmployee = 0, gosiEmployer = 0;
+  let employeesPaid = 0;
+
+  if (payrollPeriod) {
+    for (const line of payrollPeriod.lines) {
+      totalGross       += toNum(line.grossPay);
+      totalNet         += toNum(line.netPay);
+      totalDeductions  += toNum(line.totalDeductions);
+      gosiEmployee     += toNum(line.gosiEmployee);
+      gosiEmployer     += toNum(line.gosiEmployer);
+      employeesPaid++;
+    }
+  }
+
+  const avgNetSalary = employeesPaid > 0 ? round2(totalNet / employeesPaid) : 0;
+
+  // ── 9. Executive Summary ─────────────────────────────────────────────────
+
+  const executiveSummary = buildExecutiveSummary({
+    periodLabel,
+    atEnd,
+    newHires: newHires.length,
+    totalLeavers,
+    turnoverRate,
+    turnoverRating,
+    burnoutScore,
+    burnoutLevel,
+    avgOvertimeHours,
+    absenteeismRate,
+    leaveTotal: leaveRequests.length,
+    leaveApproved: approved,
+    iqamaExpired: iqamaExpired.length,
+    iqamaDueSoon: iqamaDueSoon.length,
+    docsDueSoon: workPermitsDueSoon.length + insuranceDueSoon.length + otherDueSoon.length,
+    totalPayroll: round2(totalGross),
+    employeesPaid,
+    periodFound: !!payrollPeriod,
+  });
+
+  const data: HrMonthlyReportData = {
+    period: { year, month, label: periodLabel },
+    headcount: { atStart, atEnd, newHires, resignations, terminations },
+    turnover: { rate: turnoverRate, leavers: totalLeavers, avgHeadcount: round2(avgHeadcount), rating: turnoverRating },
+    burnout: {
+      score: burnoutScore,
+      level: burnoutLevel,
+      components: { overtimeScore, absenteeismScore, openRequestsScore: openReqScore, turnoverScore },
+      avgOvertimeHours: round2(avgOvertimeHours),
+      absenteeismRate: round2(absenteeismRate),
+      avgOpenRequests: round2(avgOpenRequests),
+      departmentalTurnoverRate: turnoverRate,
+    },
+    leave: {
+      totalRequests: leaveRequests.length,
+      approved,
+      rejected,
+      pending,
+      cancelled,
+      byType,
+      avgDaysPerEmployee,
+    },
+    documents: { iqamaExpired, iqamaDueSoon, workPermitsDueSoon, insuranceDueSoon, otherDueSoon },
+    payroll: {
+      totalGross: round2(totalGross),
+      totalNet: round2(totalNet),
+      totalDeductions: round2(totalDeductions),
+      gosiEmployer: round2(gosiEmployer),
+      gosiEmployee: round2(gosiEmployee),
+      avgNetSalary,
+      employeesPaid,
+      periodFound: !!payrollPeriod,
+      periodStatus: payrollPeriod?.status ?? null,
+    },
+    executiveSummary,
+  };
+
+  log.info({ year, month, burnoutScore, turnoverRate }, '[HrMonthlyReport] Data built successfully');
+  return data;
+}
+
+// ─── Executive summary generator ────────────────────────────────────────────
+
+interface SummaryParams {
+  periodLabel: string;
+  atEnd: number;
+  newHires: number;
+  totalLeavers: number;
+  turnoverRate: number;
+  turnoverRating: 'good' | 'normal' | 'review';
+  burnoutScore: number;
+  burnoutLevel: 'low' | 'moderate' | 'high' | 'critical';
+  avgOvertimeHours: number;
+  absenteeismRate: number;
+  leaveTotal: number;
+  leaveApproved: number;
+  iqamaExpired: number;
+  iqamaDueSoon: number;
+  docsDueSoon: number;
+  totalPayroll: number;
+  employeesPaid: number;
+  periodFound: boolean;
+}
+
+function buildExecutiveSummary(p: SummaryParams): string {
+  const lines: string[] = [];
+
+  lines.push(
+    `HR Monthly Report — ${p.periodLabel}`,
+    '',
+    `Workforce: ${p.atEnd} active employees at month-end. ` +
+    `${p.newHires} new hire${p.newHires !== 1 ? 's' : ''} joined, ` +
+    `${p.totalLeavers} employee${p.totalLeavers !== 1 ? 's' : ''} departed.`,
+    '',
+  );
+
+  // Turnover
+  const turnoverVerdict =
+    p.turnoverRating === 'good'   ? 'within a healthy range'
+    : p.turnoverRating === 'normal' ? 'at a normal level'
+    : 'above recommended thresholds and requires attention';
+  lines.push(
+    `Turnover: The monthly turnover rate is ${p.turnoverRate.toFixed(1)}%, ${turnoverVerdict}.`,
+    '',
+  );
+
+  // Burnout
+  const burnoutVerdict =
+    p.burnoutLevel === 'low'      ? 'Low burnout risk — workforce is in good condition.'
+    : p.burnoutLevel === 'moderate' ? 'Moderate burnout indicators — monitor overtime and leave backlogs.'
+    : p.burnoutLevel === 'high'     ? 'High burnout risk — proactive intervention is recommended.'
+    : 'Critical burnout risk — immediate HR action required.';
+  lines.push(
+    `Burnout Index: ${p.burnoutScore.toFixed(0)}/100 — ${burnoutVerdict}`,
+    `  Average overtime: ${p.avgOvertimeHours.toFixed(1)} hrs/employee. ` +
+    `Unauthorised absence rate: ${p.absenteeismRate.toFixed(1)}%.`,
+    '',
+  );
+
+  // Leave
+  lines.push(
+    `Leave: ${p.leaveTotal} request${p.leaveTotal !== 1 ? 's' : ''} submitted ` +
+    `(${p.leaveApproved} approved).`,
+    '',
+  );
+
+  // Documents
+  if (p.iqamaExpired > 0 || p.iqamaDueSoon > 0 || p.docsDueSoon > 0) {
+    const docParts: string[] = [];
+    if (p.iqamaExpired > 0)  docParts.push(`${p.iqamaExpired} expired Iqama${p.iqamaExpired !== 1 ? 's' : ''}`);
+    if (p.iqamaDueSoon > 0)  docParts.push(`${p.iqamaDueSoon} Iqama${p.iqamaDueSoon !== 1 ? 's' : ''} due within 60 days`);
+    if (p.docsDueSoon > 0)   docParts.push(`${p.docsDueSoon} other document${p.docsDueSoon !== 1 ? 's' : ''} due soon`);
+    lines.push(`Documents: ${docParts.join('; ')}.`, '');
+  } else {
+    lines.push('Documents: All documents are current — no urgent renewals required.', '');
+  }
+
+  // Payroll
+  if (p.periodFound) {
+    lines.push(
+      `Payroll: Total gross payroll SAR ${p.totalPayroll.toLocaleString('en-SA-u-ca-gregory', { minimumFractionDigits: 0 })} ` +
+      `covering ${p.employeesPaid} employee${p.employeesPaid !== 1 ? 's' : ''}.`,
+    );
+  } else {
+    lines.push('Payroll: No payroll period found for this month.');
+  }
+
+  return lines.join('\n');
+}


### PR DESCRIPTION
Implements a complete automated monthly HR report system that auto-generates
on the 2nd of each month at 06:00 Riyadh time, covering:

Metrics computed:
- New hires / resignations / terminations with employee details
- Employee Turnover Rate = (leavers ÷ avg headcount) × 100
- Burnout Indicator (0–100 composite): overtime hours, absenteeism rate,
  open leave requests per employee, and departmental turnover — each
  scored 0–25 and classified as Low / Moderate / High / Critical
- Leave statistics: total, approved, rejected, by-type breakdown
- Iqama renewals (expired + due within 60 days) and all other document types
- Monthly payroll KPIs: gross, net, avg salary, GOSI contributions

Deliverables:
- 3-page A4 PDF (executive summary, leave + docs, payroll + movement tables)
- HrMonthlyReport DB model with snapshot columns for quick listing
- Manual SQL migration (v23_2_hr_monthly_reports.sql)
- Cron endpoint POST /api/cron/hr-monthly-report (Bearer auth)
- API route GET/POST /api/hr/reports/monthly
- HrMonthlyReportScheduler (2nd of month, 06:00 Asia/Riyadh)
- Frontend page /hr/reports with KPI cards, expandable details, PDF download
- Sidebar link "HR Monthly Reports" under HR section

https://claude.ai/code/session_01WRARhjCJ3soL9ZjCVS8wE6