### PR TITLE
fix: HR reports sidebar visibility, backlog dashboard link, and WhatsApp share button

### DIFF
--- a/src/app/backlog/[id]/_page-client.tsx
+++ b/src/app/backlog/[id]/_page-client.tsx
@@ -670,20 +670,36 @@ export default function BacklogItemDetail() {
             <Card>
               <CardHeader className="flex flex-row items-center justify-between">
                 <CardTitle>Description</CardTitle>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="gap-1.5 h-8 text-muted-foreground hover:text-foreground"
-                  onClick={() => {
-                    navigator.clipboard.writeText(item.description);
-                    setCopiedDesc(true);
-                    setTimeout(() => setCopiedDesc(false), 2000);
-                  }}
-                  title="Copy description"
-                >
-                  {copiedDesc ? <Check className="size-3.5 text-emerald-500" /> : <Copy className="size-3.5" />}
-                  <span className="text-xs">{copiedDesc ? 'Copied!' : 'Copy'}</span>
-                </Button>
+                <div className="flex items-center gap-1">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="gap-1.5 h-8 border-green-300 text-green-700 hover:bg-green-50 hover:text-green-800"
+                    onClick={() => {
+                      const url = typeof window !== 'undefined' ? window.location.href : '';
+                      const text = `*${item.code}* — ${item.title}\n\nStatus: ${item.status.replace(/_/g, ' ')}\nPriority: ${item.priority}\nType: ${item.type.replace(/_/g, ' ')}\n\nSubmitted by: ${item.createdBy.name}\n\n🔗 ${url}`;
+                      window.open(`https://api.whatsapp.com/send?text=${encodeURIComponent(text)}`, '_blank');
+                    }}
+                    title="Share on WhatsApp"
+                  >
+                    <Share2 className="size-3.5" />
+                    <span className="text-xs">WhatsApp</span>
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="gap-1.5 h-8 text-muted-foreground hover:text-foreground"
+                    onClick={() => {
+                      navigator.clipboard.writeText(item.description);
+                      setCopiedDesc(true);
+                      setTimeout(() => setCopiedDesc(false), 2000);
+                    }}
+                    title="Copy description"
+                  >
+                    {copiedDesc ? <Check className="size-3.5 text-emerald-500" /> : <Copy className="size-3.5" />}
+                    <span className="text-xs">{copiedDesc ? 'Copied!' : 'Copy'}</span>
+                  </Button>
+                </div>
               </CardHeader>
               <CardContent>
                 <p className="whitespace-pre-wrap">{item.description}</p>

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -320,7 +320,7 @@ const navigationSections: NavigationSection[] = [
     name: 'Product Backlog',
     icon: Layers,
     items: [
-      { name: 'Backlog Dashboard', href: '/backlog', icon: LayoutDashboard },
+      { name: 'Backlog Dashboard', href: '/backlog/dashboard', icon: LayoutDashboard },
       { name: 'Create Backlog', href: '/backlog/new', icon: Plus },
       { name: 'CEO Control Center', href: '/ceo-control-center', icon: Crown },
     ],

--- a/src/lib/navigation-permissions.ts
+++ b/src/lib/navigation-permissions.ts
@@ -110,6 +110,7 @@ export const NAVIGATION_PERMISSIONS: NavigationPermissionMap = {
   
   // Product Backlog
   '/backlog/new': ['backlog.create'],
+  '/backlog/dashboard': ['backlog.view'],
   '/backlog': ['backlog.view'],
   '/ceo-control-center': ['backlog.ceo_center'],
   

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -441,6 +441,9 @@ export const PERMISSIONS: PermissionCategory[] = [
       { id: 'hr.letters.approveCeo', name: 'CEO-Approve Letters', description: 'Final CEO sign-off on HR letters — approve or reject letters pending approval', category: 'hr' },
       // 19.4.0 — HR Absence Analytics
       { id: 'hr.analytics.view', name: 'View HR Analytics', description: 'Access the absence and leave behavioral analytics dashboard', category: 'hr' },
+      // 23.2.0 — HR Monthly Reports
+      { id: 'hr.reports.view', name: 'View HR Monthly Reports', description: 'View generated HR monthly reports and download PDFs', category: 'hr' },
+      { id: 'hr.reports.manage', name: 'Manage HR Monthly Reports', description: 'Generate, regenerate, and manage HR monthly reports', category: 'hr' },
     ],
   },
   {


### PR DESCRIPTION
- Add hr.reports.view and hr.reports.manage to permissions.ts so Admin/CEO
  roles inherit them via ALL_PERMISSIONS; fixes access denied on /hr/reports
  and missing sidebar item
- Fix Backlog Dashboard sidebar href from /backlog to /backlog/dashboard;
  add /backlog/dashboard to navigation-permissions.ts so the item renders
- Add WhatsApp share button next to Description card header on backlog detail
  page, alongside the existing Copy button

https://claude.ai/code/session_01JMuMRcssFWeGFRTxJPSwYz