### PR TITLE
feat(workflow): add approval tracking central page and dashboard widget

### DIFF
--- a/src/app/api/dashboard/approvals/summary/route.ts
+++ b/src/app/api/dashboard/approvals/summary/route.ts
@@ -1,0 +1,98 @@
+import { NextResponse } from 'next/server';
+import { withApiContext } from '@/lib/api-utils';
+import { logger } from '@/lib/logger';
+import { checkPermission } from '@/lib/permission-checker';
+import { workflowService } from '@/lib/services/workflow.service';
+import prisma from '@/lib/db';
+
+export const GET = withApiContext(async (_req, session) => {
+  const canView = await checkPermission('workflow.my-approvals.view');
+  if (!canView) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  const userId = session!.userId;
+
+  try {
+    // Pending action: ACTIVE steps where user is listed approver and hasn't decided
+    const pendingSteps = await workflowService.getPendingApprovalsForUser(userId);
+    const pendingAction = pendingSteps.length;
+
+    // My submissions by status
+    const submissionGroups = await prisma.workflowInstance.groupBy({
+      by: ['status'],
+      _count: { _all: true },
+      where: { initiatedById: userId },
+    });
+    const mySubmissions = {
+      inProgress: 0,
+      approved: 0,
+      rejected: 0,
+    };
+    for (const g of submissionGroups) {
+      if (g.status === 'IN_PROGRESS' || g.status === 'PENDING') mySubmissions.inProgress += g._count._all;
+      else if (g.status === 'APPROVED') mySubmissions.approved += g._count._all;
+      else if (g.status === 'REJECTED') mySubmissions.rejected += g._count._all;
+    }
+
+    // Recent items: instances user is involved in (initiated OR decided on OR pending action)
+    const decidedRows = await prisma.workflowApproval.findMany({
+      where: { userId },
+      select: { stepInstance: { select: { instanceId: true } } },
+    });
+    const decidedIds = decidedRows.map(a => a.stepInstance.instanceId);
+    const pendingInstanceIds = pendingSteps
+      .filter(s => s.instance !== null)
+      .map(s => s.instanceId);
+
+    const initiatedRows = await prisma.workflowInstance.findMany({
+      where: { initiatedById: userId },
+      select: { id: true },
+    });
+    const initiatedIds = initiatedRows.map(r => r.id);
+
+    const allIds = [...new Set([...initiatedIds, ...decidedIds, ...pendingInstanceIds])].slice(0, 500);
+
+    const recentInstances = allIds.length > 0
+      ? await prisma.workflowInstance.findMany({
+          where: { id: { in: allIds } },
+          include: {
+            definition: { select: { name: true } },
+            initiatedBy: { select: { name: true } },
+            stepInstances: {
+              where: { status: 'ACTIVE' },
+              select: {
+                resolvedApprovers: true,
+                step: { select: { name: true } },
+              },
+              take: 1,
+            },
+          },
+          orderBy: { createdAt: 'desc' },
+          take: 5,
+        })
+      : [];
+
+    const recentItems = recentInstances.map(inst => {
+      const activeStep = inst.stepInstances[0] ?? null;
+      const approvers = activeStep
+        ? ((activeStep.resolvedApprovers ?? []) as { name: string }[]).map(a => a.name).slice(0, 2)
+        : [];
+
+      return {
+        id: inst.id,
+        entityType: inst.entityType,
+        entityId: inst.entityId,
+        workflowName: inst.definition.name,
+        status: inst.status,
+        initiatedByName: inst.initiatedBy.name,
+        createdAt: inst.createdAt,
+        currentStepName: activeStep?.step?.name ?? null,
+        currentApprovers: approvers,
+      };
+    });
+
+    return NextResponse.json({ pendingAction, mySubmissions, recentItems });
+  } catch (error) {
+    logger.error({ error }, 'Failed to fetch approvals summary');
+    return NextResponse.json({ error: 'Failed to fetch approvals summary' }, { status: 500 });
+  }
+});

--- a/src/app/api/workflow/all-approvals/route.ts
+++ b/src/app/api/workflow/all-approvals/route.ts
@@ -1,0 +1,152 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withApiContext } from '@/lib/api-utils';
+import { logger } from '@/lib/logger';
+import { checkPermission } from '@/lib/permission-checker';
+import prisma from '@/lib/db';
+
+const querySchema = z.object({
+  status: z.enum(['PENDING', 'IN_PROGRESS', 'APPROVED', 'REJECTED', 'CANCELLED']).optional(),
+  entityType: z.string().optional(),
+  page: z.coerce.number().int().positive().default(1),
+  limit: z.coerce.number().int().positive().max(100).default(20),
+});
+
+const instanceInclude = {
+  definition: { select: { key: true, name: true, entityType: true } },
+  initiatedBy: { select: { id: true, name: true } },
+  cancelledBy: { select: { id: true, name: true } },
+  stepInstances: {
+    orderBy: { sequence: 'asc' as const },
+    include: {
+      step: { select: { name: true, sequence: true, slaHours: true } },
+      approvals: {
+        include: { user: { select: { id: true, name: true } } },
+        orderBy: { createdAt: 'asc' as const },
+      },
+    },
+  },
+} as const;
+
+export const GET = withApiContext(async (req, session) => {
+  const canViewAll = await checkPermission('workflow.instances.view');
+  const canViewOwn = await checkPermission('workflow.my-approvals.view');
+
+  if (!canViewAll && !canViewOwn) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const parsed = querySchema.safeParse({
+    status: searchParams.get('status') ?? undefined,
+    entityType: searchParams.get('entityType') ?? undefined,
+    page: searchParams.get('page') ?? 1,
+    limit: searchParams.get('limit') ?? 20,
+  });
+
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid query parameters', issues: parsed.error.flatten() }, { status: 422 });
+  }
+
+  const { status, entityType, page, limit } = parsed.data;
+  const skip = (page - 1) * limit;
+
+  try {
+    if (canViewAll) {
+      // Admin / CEO path — return all instances
+      const baseWhere = {
+        ...(status ? { status } : {}),
+        ...(entityType ? { entityType } : {}),
+      };
+
+      const [items, total] = await Promise.all([
+        prisma.workflowInstance.findMany({
+          where: baseWhere,
+          include: instanceInclude,
+          orderBy: { createdAt: 'desc' },
+          skip,
+          take: limit,
+        }),
+        prisma.workflowInstance.count({ where: baseWhere }),
+      ]);
+
+      const statusCounts = await prisma.workflowInstance.groupBy({
+        by: ['status'],
+        _count: { _all: true },
+        where: entityType ? { entityType } : {},
+      });
+
+      const counts = Object.fromEntries(
+        statusCounts.map((r: { status: string; _count: { _all: number } }) => [r.status, r._count._all])
+      );
+
+      return NextResponse.json({ items, total, page, limit, statusCounts: counts });
+    }
+
+    // Non-admin path — find instances the user is involved in
+    const userId = session!.userId;
+
+    // 1. Instances user initiated
+    const initiatedRows = await prisma.workflowInstance.findMany({
+      where: { initiatedById: userId },
+      select: { id: true },
+    });
+    const initiatedIds = initiatedRows.map(r => r.id);
+
+    // 2. Instances user made a decision on
+    const approvalRows = await prisma.workflowApproval.findMany({
+      where: { userId },
+      select: { stepInstance: { select: { instanceId: true } } },
+    });
+    const decidedIds = approvalRows.map(a => a.stepInstance.instanceId);
+
+    // 3. Instances with an ACTIVE step where user is a listed approver
+    const activeStepRows = await prisma.workflowStepInstance.findMany({
+      where: { status: 'ACTIVE' },
+      select: { instanceId: true, resolvedApprovers: true },
+    });
+    const pendingIds = activeStepRows
+      .filter(s => {
+        const approvers = (s.resolvedApprovers ?? []) as { userId: string }[];
+        return approvers.some(a => a.userId === userId);
+      })
+      .map(s => s.instanceId);
+
+    const allIds = [...new Set([...initiatedIds, ...decidedIds, ...pendingIds])].slice(0, 1000);
+
+    if (allIds.length === 0) {
+      return NextResponse.json({ items: [], total: 0, page, limit, statusCounts: {} });
+    }
+
+    const involvedWhere = {
+      id: { in: allIds },
+      ...(status ? { status } : {}),
+      ...(entityType ? { entityType } : {}),
+    };
+
+    const [items, total] = await Promise.all([
+      prisma.workflowInstance.findMany({
+        where: involvedWhere,
+        include: instanceInclude,
+        orderBy: { createdAt: 'desc' },
+        skip,
+        take: limit,
+      }),
+      prisma.workflowInstance.count({ where: involvedWhere }),
+    ]);
+
+    const statusCountRows = await prisma.workflowInstance.groupBy({
+      by: ['status'],
+      _count: { _all: true },
+      where: { id: { in: allIds }, ...(entityType ? { entityType } : {}) },
+    });
+    const counts = Object.fromEntries(
+      statusCountRows.map((r: { status: string; _count: { _all: number } }) => [r.status, r._count._all])
+    );
+
+    return NextResponse.json({ items, total, page, limit, statusCounts: counts });
+  } catch (error) {
+    logger.error({ error }, 'Failed to fetch all approvals');
+    return NextResponse.json({ error: 'Failed to fetch approvals' }, { status: 500 });
+  }
+});

--- a/src/app/workflow/approvals/ApprovalsTrackingClient.tsx
+++ b/src/app/workflow/approvals/ApprovalsTrackingClient.tsx
@@ -1,0 +1,395 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { LayoutList, ChevronDown, ChevronUp, Clock, Loader2, RefreshCw, AlertTriangle } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Input } from '@/components/ui/input';
+import { HorizontalStepsTimeline } from '@/components/workflow/HorizontalStepsTimeline';
+import { WorkflowTimeline } from '@/components/workflow/WorkflowTimeline';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface Approval {
+  id: string;
+  decision: string;
+  comment: string | null;
+  user: { id: string; name: string; email: string };
+  createdAt: string;
+}
+
+interface StepInstance {
+  id: string;
+  instanceId: string;
+  sequence: number;
+  status: string;
+  resolvedApprovers: { userId: string; name: string; email: string }[] | null;
+  requiredApprovals: number;
+  receivedApprovals: number;
+  skipReason: string | null;
+  activatedAt: string | null;
+  completedAt: string | null;
+  step: { name: string; sequence: number; slaHours: number | null; onRejectBehavior: string };
+  approvals: Approval[];
+}
+
+interface WorkflowInstance {
+  id: string;
+  status: string;
+  entityType: string;
+  entityId: string;
+  createdAt: string;
+  completedAt: string | null;
+  cancelledAt: string | null;
+  cancelReason: string | null;
+  definition: { key: string; name: string; entityType: string };
+  initiatedBy: { id: string; name: string };
+  cancelledBy: { id: string; name: string } | null;
+  stepInstances: StepInstance[];
+}
+
+interface AllApprovalsResponse {
+  items: WorkflowInstance[];
+  total: number;
+  page: number;
+  limit: number;
+  statusCounts: Record<string, number>;
+}
+
+interface ApprovalsTrackingClientProps {
+  isAdmin: boolean;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function idleLabel(stepInstances: StepInstance[]): { label: string; urgent: boolean } | null {
+  const active = stepInstances.find(s => s.status === 'ACTIVE');
+  if (!active?.activatedAt) return null;
+  const hours = (Date.now() - new Date(active.activatedAt).getTime()) / 3_600_000;
+  const urgent = hours > 48;
+  if (hours < 1) return { label: '< 1h idle', urgent };
+  if (hours < 24) return { label: `${Math.floor(hours)}h idle`, urgent };
+  return { label: `${Math.floor(hours / 24)}d idle`, urgent };
+}
+
+function currentStepInfo(stepInstances: StepInstance[]): { name: string; approvers: string } | null {
+  const active = stepInstances.find(s => s.status === 'ACTIVE');
+  if (!active) return null;
+  const approvers = (active.resolvedApprovers ?? []).map(a => a.name);
+  const display = approvers.length > 2
+    ? `${approvers.slice(0, 2).join(', ')} +${approvers.length - 2}`
+    : approvers.join(', ') || '—';
+  return { name: active.step.name, approvers: display };
+}
+
+function statusBadge(status: string) {
+  switch (status) {
+    case 'APPROVED':    return <Badge className="bg-emerald-100 text-emerald-700 border border-emerald-200 hover:bg-emerald-100">Approved</Badge>;
+    case 'REJECTED':    return <Badge className="bg-rose-100 text-rose-700 border border-rose-200 hover:bg-rose-100">Rejected</Badge>;
+    case 'IN_PROGRESS': return <Badge className="bg-amber-100 text-amber-700 border border-amber-200 hover:bg-amber-100">In Progress</Badge>;
+    case 'CANCELLED':   return <Badge className="bg-slate-100 text-slate-600 border border-slate-200 hover:bg-slate-100">Cancelled</Badge>;
+    default:            return <Badge className="bg-slate-100 text-slate-500 border border-slate-200 hover:bg-slate-100">{status}</Badge>;
+  }
+}
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString('en-SA-u-ca-gregory', {
+    day: '2-digit', month: 'short', year: 'numeric',
+  });
+}
+
+// ─── KPI Card ─────────────────────────────────────────────────────────────────
+
+function KpiCard({ label, value, color }: { label: string; value: number; color: string }) {
+  return (
+    <div className={`rounded-xl border bg-white p-4 shadow-sm`}>
+      <p className={`text-xs font-semibold uppercase tracking-wide ${color} mb-1`}>{label}</p>
+      <p className="text-2xl font-bold text-slate-800">{value}</p>
+    </div>
+  );
+}
+
+// ─── Instance Row ─────────────────────────────────────────────────────────────
+
+function InstanceRow({ instance }: { instance: WorkflowInstance }) {
+  const [expanded, setExpanded] = useState(false);
+  const idle = idleLabel(instance.stepInstances);
+  const stepInfo = currentStepInfo(instance.stepInstances);
+
+  const timelineSteps = instance.stepInstances.map(s => ({
+    id: s.id,
+    sequence: s.sequence,
+    status: s.status as 'PENDING' | 'ACTIVE' | 'APPROVED' | 'REJECTED' | 'SKIPPED',
+    name: s.step.name,
+    completedAt: s.completedAt,
+    activatedAt: s.activatedAt,
+  }));
+
+  return (
+    <Card className="overflow-hidden">
+      <CardContent className="p-0">
+        {/* Main row */}
+        <button
+          className="w-full text-left p-4 hover:bg-slate-50 transition-colors"
+          onClick={() => setExpanded(e => !e)}
+        >
+          <div className="flex flex-col sm:flex-row sm:items-start gap-3">
+            {/* Left: workflow + entity */}
+            <div className="flex-1 min-w-0">
+              <div className="flex flex-wrap items-center gap-2 mb-1">
+                <span className="font-semibold text-slate-800 text-sm">{instance.definition.name}</span>
+                <span className="text-xs px-2 py-0.5 rounded-full bg-violet-50 text-violet-700 border border-violet-200 font-mono">
+                  {instance.entityType} #{instance.entityId.slice(0, 8)}
+                </span>
+              </div>
+              <p className="text-xs text-slate-500">
+                Submitted by <span className="font-medium text-slate-700">{instance.initiatedBy.name}</span>
+                {' · '}{formatDate(instance.createdAt)}
+              </p>
+
+              {/* Mini horizontal timeline */}
+              {timelineSteps.length > 0 && (
+                <div className="mt-3">
+                  <HorizontalStepsTimeline steps={timelineSteps} compact />
+                </div>
+              )}
+            </div>
+
+            {/* Right: status + step info */}
+            <div className="flex flex-col items-start sm:items-end gap-2 shrink-0">
+              {statusBadge(instance.status)}
+
+              {idle && (
+                <span className={`flex items-center gap-1 text-xs font-medium ${idle.urgent ? 'text-red-600' : 'text-slate-500'}`}>
+                  <Clock className="w-3.5 h-3.5" />
+                  {idle.label}
+                </span>
+              )}
+
+              {stepInfo && (
+                <div className="text-right">
+                  <p className="text-xs font-medium text-slate-700">{stepInfo.name}</p>
+                  <p className="text-xs text-slate-400">{stepInfo.approvers}</p>
+                </div>
+              )}
+
+              {expanded
+                ? <ChevronUp className="w-4 h-4 text-slate-400 mt-1" />
+                : <ChevronDown className="w-4 h-4 text-slate-400 mt-1" />
+              }
+            </div>
+          </div>
+        </button>
+
+        {/* Expanded full timeline */}
+        {expanded && (
+          <div className="border-t px-4 py-4 bg-slate-50">
+            <WorkflowTimeline instance={instance} />
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Main Component ───────────────────────────────────────────────────────────
+
+const ENTITY_TYPES = ['Loan', 'NCRReport', 'ImsRevision', 'ImsChangeRequest', 'Document'];
+
+export function ApprovalsTrackingClient({ isAdmin }: ApprovalsTrackingClientProps) {
+  const [data, setData] = useState<AllApprovalsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [statusFilter, setStatusFilter] = useState<string>('all');
+  const [entityTypeFilter, setEntityTypeFilter] = useState<string>('all');
+  const [search, setSearch] = useState('');
+  const [page, setPage] = useState(1);
+
+  const load = useCallback(async (pg = page) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams({ page: String(pg), limit: '20' });
+      if (statusFilter !== 'all') params.set('status', statusFilter);
+      if (entityTypeFilter !== 'all') params.set('entityType', entityTypeFilter);
+
+      const res = await fetch(`/api/workflow/all-approvals?${params}`);
+      if (!res.ok) throw new Error('Failed to fetch');
+      setData(await res.json());
+    } catch {
+      setError('Failed to load approval data.');
+    } finally {
+      setLoading(false);
+    }
+  }, [statusFilter, entityTypeFilter, page]);
+
+  useEffect(() => {
+    setPage(1);
+    load(1);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [statusFilter, entityTypeFilter]);
+
+  useEffect(() => {
+    load(page);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [page]);
+
+  // Client-side search filter
+  const filteredItems = (data?.items ?? []).filter(inst => {
+    if (!search) return true;
+    const q = search.toLowerCase();
+    return (
+      inst.definition.name.toLowerCase().includes(q) ||
+      inst.entityType.toLowerCase().includes(q) ||
+      inst.entityId.toLowerCase().includes(q) ||
+      inst.initiatedBy.name.toLowerCase().includes(q)
+    );
+  });
+
+  const counts = data?.statusCounts ?? {};
+  const total = data?.total ?? 0;
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-slate-50 to-white">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
+
+        {/* Hero */}
+        <div className="rounded-2xl border bg-gradient-to-br from-violet-600 via-violet-500 to-indigo-600 p-6 md:p-8 text-white shadow-lg relative overflow-hidden">
+          <div className="absolute -top-4 -right-4 w-32 h-32 bg-white/10 rounded-full blur-2xl" />
+          <div className="absolute -bottom-8 -left-8 w-48 h-48 bg-white/5 rounded-full blur-3xl" />
+          <div className="relative z-10 flex items-start justify-between gap-4">
+            <div>
+              <div className="flex items-center gap-3 mb-2">
+                <div className="p-2 bg-white/20 rounded-lg backdrop-blur-sm">
+                  <LayoutList className="h-5 w-5" />
+                </div>
+                <h1 className="text-2xl font-bold">Approval Tracking</h1>
+                {isAdmin && (
+                  <span className="text-xs px-2 py-0.5 rounded-full bg-white/20 border border-white/30 font-medium">
+                    Admin View
+                  </span>
+                )}
+              </div>
+              <p className="text-violet-100 text-sm">
+                {isAdmin
+                  ? 'Central unit for all workflow approval requests across every module.'
+                  : 'Approval requests you submitted or are responsible for approving.'}
+              </p>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              className="bg-white/20 border-white/30 text-white hover:bg-white/30 shrink-0"
+              onClick={() => load(page)}
+            >
+              <RefreshCw className="w-3.5 h-3.5 mr-1.5" />
+              Refresh
+            </Button>
+          </div>
+        </div>
+
+        {/* KPI strip */}
+        <div className="grid grid-cols-2 sm:grid-cols-5 gap-3">
+          <KpiCard label="Total" value={total} color="text-blue-600" />
+          <KpiCard label="In Progress" value={(counts.IN_PROGRESS ?? 0) + (counts.PENDING ?? 0)} color="text-amber-600" />
+          <KpiCard label="Approved" value={counts.APPROVED ?? 0} color="text-emerald-600" />
+          <KpiCard label="Rejected" value={counts.REJECTED ?? 0} color="text-rose-600" />
+          <KpiCard label="Cancelled" value={counts.CANCELLED ?? 0} color="text-slate-500" />
+        </div>
+
+        {/* Filters */}
+        <div className="flex flex-col sm:flex-row gap-3">
+          <Input
+            placeholder="Search by workflow, entity type, ID, or submitter…"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            className="flex-1"
+          />
+          <Select value={statusFilter} onValueChange={setStatusFilter}>
+            <SelectTrigger className="w-full sm:w-44">
+              <SelectValue placeholder="Status" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Statuses</SelectItem>
+              <SelectItem value="IN_PROGRESS">In Progress</SelectItem>
+              <SelectItem value="APPROVED">Approved</SelectItem>
+              <SelectItem value="REJECTED">Rejected</SelectItem>
+              <SelectItem value="CANCELLED">Cancelled</SelectItem>
+              <SelectItem value="PENDING">Pending</SelectItem>
+            </SelectContent>
+          </Select>
+          <Select value={entityTypeFilter} onValueChange={setEntityTypeFilter}>
+            <SelectTrigger className="w-full sm:w-48">
+              <SelectValue placeholder="Entity Type" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Modules</SelectItem>
+              {ENTITY_TYPES.map(t => (
+                <SelectItem key={t} value={t}>{t}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {/* Content */}
+        {loading ? (
+          <div className="flex items-center justify-center h-48">
+            <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : error ? (
+          <div className="flex items-center gap-2 text-destructive text-sm p-4 rounded-lg border border-destructive/20 bg-destructive/5">
+            <AlertTriangle className="w-4 h-4 shrink-0" />
+            {error}
+          </div>
+        ) : filteredItems.length === 0 ? (
+          <div className="text-center py-16 text-slate-400">
+            <LayoutList className="w-10 h-10 mx-auto mb-3 opacity-30" />
+            <p className="text-sm">No approval requests found.</p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {filteredItems.map(inst => (
+              <InstanceRow key={inst.id} instance={inst} />
+            ))}
+          </div>
+        )}
+
+        {/* Pagination */}
+        {!loading && !error && data && data.total > data.limit && (
+          <div className="flex items-center justify-between pt-2">
+            <p className="text-sm text-slate-500">
+              Showing {Math.min((page - 1) * data.limit + 1, data.total)}–{Math.min(page * data.limit, data.total)} of {data.total}
+            </p>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page === 1}
+                onClick={() => setPage(p => p - 1)}
+              >
+                Previous
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page * data.limit >= data.total}
+                onClick={() => setPage(p => p + 1)}
+              >
+                Next
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/workflow/approvals/page.tsx
+++ b/src/app/workflow/approvals/page.tsx
@@ -1,0 +1,22 @@
+import { redirect } from 'next/navigation';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import { checkPermission } from '@/lib/permission-checker';
+import { ApprovalsTrackingClient } from './ApprovalsTrackingClient';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = { title: 'Approval Tracking — OTS' };
+
+export default async function ApprovalsPage() {
+  const store = await cookies();
+  const token = store.get(process.env.COOKIE_NAME ?? 'ots_session')?.value;
+  const session = token ? await verifySession(token) : null;
+  if (!session) redirect('/login');
+
+  const canViewAll = await checkPermission('workflow.instances.view');
+  const canViewOwn = await checkPermission('workflow.my-approvals.view');
+
+  if (!canViewAll && !canViewOwn) redirect('/unauthorized?from=/workflow/approvals');
+
+  return <ApprovalsTrackingClient isAdmin={canViewAll} />;
+}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -94,6 +94,7 @@ import {
   Award,
   PieChart,
   IdCard,
+  LayoutList,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useState, useEffect, useLayoutEffect } from 'react';
@@ -412,6 +413,7 @@ const navigationSections: NavigationSection[] = [
     items: [
       { name: 'Definitions', href: '/workflow/definitions', icon: GitBranch, newSince: '2026-04-26' },
       { name: 'My Approvals', href: '/workflow/my-approvals', icon: CheckCircle, newSince: '2026-04-26' },
+      { name: 'Approval Tracking', href: '/workflow/approvals', icon: LayoutList, newSince: '2026-05-08' },
       { name: 'Integration Guide', href: '/workflow/guide', icon: BookOpen, newSince: '2026-04-26' },
     ],
   },

--- a/src/components/dashboard/WidgetContainer.tsx
+++ b/src/components/dashboard/WidgetContainer.tsx
@@ -12,6 +12,7 @@ import BacklogWidget from './widgets/BacklogWidget';
 import WeeklyIssuesWidget from './widgets/WeeklyIssuesWidget';
 import PointsWidget from './widgets/PointsWidget';
 import PaymentScheduleWidget from './widgets/PaymentScheduleWidget';
+import ApprovalStatusWidget from './widgets/ApprovalStatusWidget';
 import { Button } from '@/components/ui/button';
 import { Plus, Loader2, X, GripVertical } from 'lucide-react';
 import {
@@ -59,6 +60,7 @@ const WIDGET_COMPONENTS: { [key: string]: React.ComponentType } = {
   WEEKLY_ISSUES: WeeklyIssuesWidget,
   POINTS_REWARDS: PointsWidget,
   PAYMENT_SCHEDULE: PaymentScheduleWidget,
+  APPROVAL_STATUS: ApprovalStatusWidget,
 };
 
 const WIDGET_DEFINITIONS = [
@@ -73,6 +75,7 @@ const WIDGET_DEFINITIONS = [
   { type: 'WEEKLY_ISSUES', name: 'Weekly Issues', description: 'Open issues from weekly meetings', size: 'medium' },
   { type: 'POINTS_REWARDS', name: 'Points & Rewards', description: 'Your points, badges, and leaderboard ranking', size: 'medium' },
   { type: 'PAYMENT_SCHEDULE', name: 'Payment Schedule', description: 'Forecasted collections, pending and overdue payments', size: 'medium' },
+  { type: 'APPROVAL_STATUS', name: 'My Approvals', description: 'Pending approvals and your submission status across all modules', size: 'medium' },
 ];
 
 // Sortable Widget Wrapper

--- a/src/components/dashboard/widgets/ApprovalStatusWidget.tsx
+++ b/src/components/dashboard/widgets/ApprovalStatusWidget.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { ClipboardCheck, Loader2, AlertCircle, Clock } from 'lucide-react';
+
+interface RecentItem {
+  id: string;
+  entityType: string;
+  entityId: string;
+  workflowName: string;
+  status: string;
+  initiatedByName: string;
+  createdAt: string;
+  currentStepName: string | null;
+  currentApprovers: string[];
+}
+
+interface SummaryData {
+  pendingAction: number;
+  mySubmissions: { inProgress: number; approved: number; rejected: number };
+  recentItems: RecentItem[];
+}
+
+function statusBadge(status: string) {
+  switch (status) {
+    case 'APPROVED':    return <Badge className="text-xs bg-emerald-100 text-emerald-700 border-emerald-200 hover:bg-emerald-100">Approved</Badge>;
+    case 'REJECTED':    return <Badge className="text-xs bg-rose-100 text-rose-700 border-rose-200 hover:bg-rose-100">Rejected</Badge>;
+    case 'IN_PROGRESS': return <Badge className="text-xs bg-amber-100 text-amber-700 border-amber-200 hover:bg-amber-100">In Progress</Badge>;
+    case 'CANCELLED':   return <Badge className="text-xs bg-slate-100 text-slate-600 border-slate-200 hover:bg-slate-100">Cancelled</Badge>;
+    default:            return <Badge className="text-xs bg-slate-100 text-slate-500 border-slate-200 hover:bg-slate-100">{status}</Badge>;
+  }
+}
+
+function relativeDate(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const days = Math.floor(diff / 86_400_000);
+  if (days === 0) return 'Today';
+  if (days === 1) return 'Yesterday';
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  return `${months}mo ago`;
+}
+
+export default function ApprovalStatusWidget() {
+  const [data, setData] = useState<SummaryData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        setLoading(true);
+        const res = await fetch('/api/dashboard/approvals/summary');
+        if (!res.ok) throw new Error('Failed');
+        setData(await res.json());
+        setError(null);
+      } catch {
+        setError('Failed to load approval data');
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+    const interval = setInterval(load, 60_000);
+    return () => clearInterval(interval);
+  }, []);
+
+  if (loading) {
+    return (
+      <Card className="h-full">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <ClipboardCheck className="size-4 text-violet-600" />
+            My Approvals
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="flex items-center justify-center h-32">
+          <Loader2 className="size-5 animate-spin text-muted-foreground" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <Card className="h-full">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <ClipboardCheck className="size-4 text-violet-600" />
+            My Approvals
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-destructive">{error ?? 'No data'}</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="h-full hover:shadow-lg transition-all border-l-4 border-l-violet-500">
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <ClipboardCheck className="size-4 text-violet-600" />
+          My Approvals
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+
+        {/* Pending action */}
+        <Link href="/workflow/my-approvals">
+          <div className={`rounded-lg p-3 transition-colors cursor-pointer ${
+            data.pendingAction > 0
+              ? 'bg-amber-50 dark:bg-amber-950/30 border border-amber-200 hover:bg-amber-100'
+              : 'bg-slate-50 dark:bg-slate-900/30 border border-slate-200 hover:bg-slate-100'
+          }`}>
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                {data.pendingAction > 0
+                  ? <AlertCircle className="size-4 text-amber-600 shrink-0" />
+                  : <Clock className="size-4 text-slate-400 shrink-0" />
+                }
+                <p className="text-xs text-muted-foreground">Pending your action</p>
+              </div>
+              <p className={`text-2xl font-bold ${data.pendingAction > 0 ? 'text-amber-700 dark:text-amber-400' : 'text-slate-600'}`}>
+                {data.pendingAction}
+              </p>
+            </div>
+          </div>
+        </Link>
+
+        {/* My submissions summary */}
+        <div className="grid grid-cols-3 gap-2">
+          <div className="rounded-md bg-amber-50 dark:bg-amber-950/20 p-2 text-center">
+            <p className="text-xs text-muted-foreground mb-0.5">In Progress</p>
+            <p className="text-sm font-bold text-amber-700 dark:text-amber-400">{data.mySubmissions.inProgress}</p>
+          </div>
+          <div className="rounded-md bg-emerald-50 dark:bg-emerald-950/20 p-2 text-center">
+            <p className="text-xs text-muted-foreground mb-0.5">Approved</p>
+            <p className="text-sm font-bold text-emerald-700 dark:text-emerald-400">{data.mySubmissions.approved}</p>
+          </div>
+          <div className="rounded-md bg-rose-50 dark:bg-rose-950/20 p-2 text-center">
+            <p className="text-xs text-muted-foreground mb-0.5">Rejected</p>
+            <p className="text-sm font-bold text-rose-700 dark:text-rose-400">{data.mySubmissions.rejected}</p>
+          </div>
+        </div>
+
+        {/* Recent items */}
+        {data.recentItems.length > 0 && (
+          <div className="space-y-2">
+            <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide">Recent</p>
+            {data.recentItems.map(item => (
+              <Link key={item.id} href="/workflow/approvals">
+                <div className="flex items-center justify-between gap-2 p-2 rounded-md hover:bg-slate-50 transition-colors cursor-pointer">
+                  <div className="min-w-0">
+                    <p className="text-xs font-medium text-slate-700 truncate">{item.workflowName}</p>
+                    <p className="text-xs text-slate-400">{item.entityType} · {relativeDate(item.createdAt)}</p>
+                  </div>
+                  {statusBadge(item.status)}
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+
+        <Link href="/workflow/approvals" className="block">
+          <p className="text-xs text-violet-600 hover:underline text-right">View all approvals →</p>
+        </Link>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/workflow/HorizontalStepsTimeline.tsx
+++ b/src/components/workflow/HorizontalStepsTimeline.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { CheckCircle, XCircle, AlertCircle, SkipForward, Circle } from 'lucide-react';
+
+interface Step {
+  id: string;
+  sequence: number;
+  status: 'PENDING' | 'ACTIVE' | 'APPROVED' | 'REJECTED' | 'SKIPPED';
+  name: string;
+  completedAt?: string | null;
+  activatedAt?: string | null;
+}
+
+interface HorizontalStepsTimelineProps {
+  steps: Step[];
+  compact?: boolean;
+}
+
+function formatStepDate(iso: string | null | undefined): string | null {
+  if (!iso) return null;
+  return new Date(iso).toLocaleDateString('en-SA-u-ca-gregory', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
+}
+
+function stepConfig(status: Step['status']) {
+  switch (status) {
+    case 'APPROVED':
+      return {
+        circle: 'bg-emerald-500 border-emerald-500',
+        icon: CheckCircle,
+        iconClass: 'text-white',
+        label: 'Approved',
+        ring: '',
+      };
+    case 'ACTIVE':
+      return {
+        circle: 'bg-red-500 border-red-500 ring-2 ring-red-300 ring-offset-1',
+        icon: AlertCircle,
+        iconClass: 'text-white',
+        label: 'In Review',
+        ring: 'ring-2 ring-red-300 ring-offset-1',
+      };
+    case 'REJECTED':
+      return {
+        circle: 'bg-red-600 border-red-600',
+        icon: XCircle,
+        iconClass: 'text-white',
+        label: 'Rejected',
+        ring: '',
+      };
+    case 'SKIPPED':
+      return {
+        circle: 'bg-slate-300 border-slate-300',
+        icon: SkipForward,
+        iconClass: 'text-white',
+        label: 'Skipped',
+        ring: '',
+      };
+    default:
+      return {
+        circle: 'bg-white border-2 border-dashed border-slate-300',
+        icon: Circle,
+        iconClass: 'text-slate-300',
+        label: 'Pending',
+        ring: '',
+      };
+  }
+}
+
+function lineColor(left: Step, right: Step): string {
+  if (left.status === 'APPROVED' && right.status === 'APPROVED') return 'bg-emerald-400';
+  if (left.status === 'APPROVED' && (right.status === 'ACTIVE' || right.status === 'REJECTED')) return 'bg-red-400';
+  return 'bg-slate-200';
+}
+
+// Deduplicate steps by sequence (keep ACTIVE or latest status over PENDING duplicates from RESTART)
+function deduplicateSteps(steps: Step[]): Step[] {
+  const map = new Map<number, Step>();
+  for (const s of steps) {
+    const existing = map.get(s.sequence);
+    if (!existing) {
+      map.set(s.sequence, s);
+    } else if (
+      s.status === 'ACTIVE' ||
+      (s.status !== 'PENDING' && existing.status === 'PENDING')
+    ) {
+      map.set(s.sequence, s);
+    }
+  }
+  return Array.from(map.values()).sort((a, b) => a.sequence - b.sequence);
+}
+
+export function HorizontalStepsTimeline({ steps, compact = false }: HorizontalStepsTimelineProps) {
+  const dedupedSteps = deduplicateSteps(steps);
+
+  if (dedupedSteps.length === 0) return null;
+
+  return (
+    <div className="w-full overflow-x-auto">
+      <div className="flex items-start min-w-0" style={{ minWidth: `${dedupedSteps.length * 80}px` }}>
+        {dedupedSteps.map((step, idx) => {
+          const cfg = stepConfig(step.status);
+          const Icon = cfg.icon;
+          const isLast = idx === dedupedSteps.length - 1;
+          const dateLabel = step.status === 'APPROVED'
+            ? formatStepDate(step.completedAt)
+            : step.status === 'ACTIVE'
+            ? formatStepDate(step.activatedAt)
+            : null;
+
+          return (
+            <div key={step.id} className="flex items-start flex-1 min-w-0">
+              {/* Step node */}
+              <div className="flex flex-col items-center flex-shrink-0">
+                {/* Circle */}
+                <div
+                  className={`flex items-center justify-center w-10 h-10 rounded-full border ${cfg.circle} shadow-sm`}
+                >
+                  <Icon className={`w-5 h-5 ${cfg.iconClass}`} />
+                </div>
+
+                {!compact && (
+                  <>
+                    {/* Step name */}
+                    <p
+                      className="mt-1.5 text-xs font-medium text-slate-700 text-center leading-tight"
+                      style={{ maxWidth: '80px', wordBreak: 'break-word' }}
+                      title={step.name}
+                    >
+                      {step.name.length > 18 ? step.name.slice(0, 16) + '…' : step.name}
+                    </p>
+                    {/* Date */}
+                    <p className="mt-0.5 text-xs text-slate-400 text-center" style={{ maxWidth: '80px' }}>
+                      {dateLabel ?? '—'}
+                    </p>
+                  </>
+                )}
+              </div>
+
+              {/* Connecting line */}
+              {!isLast && (
+                <div className="flex-1 flex items-center" style={{ paddingTop: '19px' }}>
+                  <div className={`h-0.5 w-full ${lineColor(step, dedupedSteps[idx + 1])}`} />
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/navigation-permissions.ts
+++ b/src/lib/navigation-permissions.ts
@@ -250,6 +250,7 @@ export const NAVIGATION_PERMISSIONS: NavigationPermissionMap = {
   // Workflow Engine (21.0.0)
   '/workflow/definitions': ['workflow.definitions.view', 'workflow.definitions.manage'],
   '/workflow/my-approvals': ['workflow.my-approvals.view'],
+  '/workflow/approvals': ['workflow.instances.view', 'workflow.my-approvals.view'],
   '/workflow/guide': null, // Public — anyone logged in can read the guide
 
   // IMS


### PR DESCRIPTION
- New /workflow/approvals page: central unit for all workflow approval requests
  - Admins/CEO see all instances across every module (workflow.instances.view)
  - Regular users see only their own submitted or involved approvals
  - Hero + KPI strip (total, in-progress, approved, rejected, cancelled)
  - Filter by status, entity type, and text search
  - Each row shows workflow name, submitter, idle time since activation,
    current step and responsible approver names, and a horizontal step
    progress timeline matching the design reference
  - Expandable rows reveal the full WorkflowTimeline inline
  - Pagination for large result sets

- New HorizontalStepsTimeline component: horizontal circles-and-lines
  timeline visualizing each step's status (approved=green, active=red,
  rejected=red-dark, skipped=gray, pending=dashed) with connecting
  colored lines and optional name/date labels

- New /api/workflow/all-approvals endpoint (GET) with admin vs. non-admin
  paths, status/entityType filters, pagination, and per-status counts

- New /api/dashboard/approvals/summary endpoint: returns pendingAction count,
  mySubmissions breakdown, and 5 recent involved instances for the widget

- New ApprovalStatusWidget dashboard widget (APPROVAL_STATUS): shows
  pending-action count, in-progress/approved/rejected submission counts,
  and a recent-items list linked to the tracking page

- Sidebar: "Approval Tracking" added to Workflow section (newSince 2026-05-08)
- WidgetContainer: APPROVAL_STATUS registered in registry and definitions
- navigation-permissions: /workflow/approvals mapped to workflow.instances.view
  OR workflow.my-approvals.view

https://claude.ai/code/session_01UoTTRAoCFqsN4QU2Qm4vWr