### PR TITLE
fix(workflow/customers/suppliers/hr): multi-area fixes

### DIFF
--- a/src/app/api/hr/loans/route.ts
+++ b/src/app/api/hr/loans/route.ts
@@ -75,7 +75,7 @@ export const POST = withApiContext(async (req: NextRequest, session) => {
     );
   }
 
-  const employee = await prisma.employee.findUnique({ where: { id: d.employeeId, deletedAt: null }, select: { id: true } });
+  const employee = await prisma.employee.findUnique({ where: { id: d.employeeId, deletedAt: null }, select: { id: true, fullNameEn: true } });
   if (!employee) return NextResponse.json({ error: 'Employee not found' }, { status: 404 });
 
   try {
@@ -103,7 +103,7 @@ export const POST = withApiContext(async (req: NextRequest, session) => {
         loan.id,
         session!.userId,
         undefined,
-        { principal: d.principal, installmentsTotal: d.installmentsTotal },
+        { principal: d.principal, installmentsTotal: d.installmentsTotal, employeeName: employee.fullNameEn },
       );
     } catch (wfErr) {
       logger.warn({ loanId: loan.id, error: wfErr }, '[Loans] No workflow definition — activating directly');

--- a/src/app/api/workflow/all-approvals/route.ts
+++ b/src/app/api/workflow/all-approvals/route.ts
@@ -16,10 +16,11 @@ const instanceInclude = {
   definition: { select: { key: true, name: true, entityType: true } },
   initiatedBy: { select: { id: true, name: true } },
   cancelledBy: { select: { id: true, name: true } },
+  metadata: true,
   stepInstances: {
     orderBy: { sequence: 'asc' as const },
     include: {
-      step: { select: { name: true, sequence: true, slaHours: true } },
+      step: { select: { name: true, sequence: true, slaHours: true, onRejectBehavior: true } },
       approvals: {
         include: { user: { select: { id: true, name: true } } },
         orderBy: { createdAt: 'asc' as const },

--- a/src/app/hr/organization-setup/_page-client.tsx
+++ b/src/app/hr/organization-setup/_page-client.tsx
@@ -1,0 +1,283 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { GitBranch, Save, CheckCircle2, Loader2, AlertTriangle, Users } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Input } from '@/components/ui/input';
+
+interface EmployeeRow {
+  id: string;
+  fullNameEn: string;
+  employmentId: string;
+  occupation: string | null;
+  reportsToId: string | null;
+  departmentRef: { name: string } | null;
+}
+
+interface OrgSetupClientProps {
+  employees: EmployeeRow[];
+}
+
+type SaveState = 'idle' | 'saving' | 'saved' | 'error';
+
+export function OrgSetupClient({ employees }: OrgSetupClientProps) {
+  // Track pending changes: employeeId → new reportsToId (or null)
+  const [pending, setPending] = useState<Record<string, string | null>>({});
+  const [saveStates, setSaveStates] = useState<Record<string, SaveState>>({});
+  const [search, setSearch] = useState('');
+
+  const getEffectiveManager = (emp: EmployeeRow) =>
+    emp.id in pending ? pending[emp.id] : emp.reportsToId;
+
+  const handleChange = (employeeId: string, managerId: string | null) => {
+    const emp = employees.find(e => e.id === employeeId);
+    const originalValue = emp?.reportsToId ?? null;
+    const isReset = managerId === originalValue;
+
+    setPending(prev => {
+      const next = { ...prev };
+      if (isReset) {
+        delete next[employeeId];
+      } else {
+        next[employeeId] = managerId;
+      }
+      return next;
+    });
+    setSaveStates(prev => ({ ...prev, [employeeId]: 'idle' }));
+  };
+
+  const saveOne = useCallback(async (employeeId: string) => {
+    setSaveStates(prev => ({ ...prev, [employeeId]: 'saving' }));
+    const newManagerId = pending[employeeId] ?? null;
+    try {
+      const res = await fetch(`/api/hr/employees/${employeeId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reportsToId: newManagerId }),
+      });
+      if (!res.ok) throw new Error('Failed to save');
+      setSaveStates(prev => ({ ...prev, [employeeId]: 'saved' }));
+      setPending(prev => {
+        const next = { ...prev };
+        delete next[employeeId];
+        return next;
+      });
+      // Optimistically update the employee's reportsToId in-place won't work since
+      // employees is a prop — the parent will re-render on next navigation.
+    } catch {
+      setSaveStates(prev => ({ ...prev, [employeeId]: 'error' }));
+    }
+  }, [pending]);
+
+  const saveAll = useCallback(async () => {
+    const ids = Object.keys(pending);
+    await Promise.all(ids.map(id => saveOne(id)));
+  }, [pending, saveOne]);
+
+  const pendingCount = Object.keys(pending).length;
+
+  const filtered = employees.filter(e => {
+    if (!search) return true;
+    const q = search.toLowerCase();
+    return (
+      e.fullNameEn.toLowerCase().includes(q) ||
+      e.employmentId.toLowerCase().includes(q) ||
+      (e.occupation ?? '').toLowerCase().includes(q) ||
+      (e.departmentRef?.name ?? '').toLowerCase().includes(q)
+    );
+  });
+
+  const getManagerName = (id: string | null) =>
+    id ? (employees.find(e => e.id === id)?.fullNameEn ?? '—') : '—';
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-slate-50 to-white">
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
+
+        {/* Hero */}
+        <div className="rounded-2xl border bg-gradient-to-br from-sky-600 via-sky-500 to-blue-600 p-6 text-white shadow-lg relative overflow-hidden">
+          <div className="absolute -top-4 -right-4 w-32 h-32 bg-white/10 rounded-full blur-2xl" />
+          <div className="absolute -bottom-8 -left-8 w-48 h-48 bg-white/5 rounded-full blur-3xl" />
+          <div className="relative z-10 flex items-start justify-between gap-4">
+            <div>
+              <div className="flex items-center gap-3 mb-2">
+                <div className="p-2 bg-white/20 rounded-lg backdrop-blur-sm">
+                  <GitBranch className="h-5 w-5" />
+                </div>
+                <div>
+                  <div className="text-xs px-2 py-0.5 rounded-full bg-white/15 border border-white/20 inline-block mb-1">
+                    HR · Organization
+                  </div>
+                  <h1 className="text-2xl font-bold">Organization Setup</h1>
+                </div>
+              </div>
+              <p className="text-sky-100 text-sm">
+                Assign reporting managers in bulk to build the employee hierarchy. Changes here update the organization chart.
+              </p>
+            </div>
+            {pendingCount > 0 && (
+              <Button
+                size="sm"
+                className="bg-white text-sky-700 hover:bg-sky-50 shrink-0 gap-1.5"
+                onClick={saveAll}
+              >
+                <Save className="w-4 h-4" />
+                Save All ({pendingCount})
+              </Button>
+            )}
+          </div>
+        </div>
+
+        {/* KPI strip */}
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+          <div className="rounded-xl border bg-white p-4 shadow-sm">
+            <p className="text-xs font-semibold uppercase tracking-wide text-blue-600 mb-1">Total Employees</p>
+            <p className="text-2xl font-bold text-slate-800">{employees.length}</p>
+          </div>
+          <div className="rounded-xl border bg-white p-4 shadow-sm">
+            <p className="text-xs font-semibold uppercase tracking-wide text-emerald-600 mb-1">With Manager Set</p>
+            <p className="text-2xl font-bold text-slate-800">
+              {employees.filter(e => (e.id in pending ? pending[e.id] : e.reportsToId) !== null).length}
+            </p>
+          </div>
+          <div className="rounded-xl border bg-white p-4 shadow-sm">
+            <p className="text-xs font-semibold uppercase tracking-wide text-amber-600 mb-1">Unsaved Changes</p>
+            <p className="text-2xl font-bold text-slate-800">{pendingCount}</p>
+          </div>
+        </div>
+
+        {/* Search + Save All */}
+        <div className="flex gap-3">
+          <Input
+            placeholder="Search by name, ID, role, or department…"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            className="flex-1"
+          />
+          {pendingCount > 0 && (
+            <Button variant="outline" onClick={saveAll} className="gap-1.5 shrink-0">
+              <Save className="w-4 h-4" />
+              Save All ({pendingCount})
+            </Button>
+          )}
+        </div>
+
+        {/* Table */}
+        <div className="rounded-xl border overflow-hidden bg-white shadow-sm">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b bg-slate-50">
+                <th className="px-4 py-3 text-left font-medium text-slate-600">Employee</th>
+                <th className="px-4 py-3 text-left font-medium text-slate-600 hidden sm:table-cell">Department</th>
+                <th className="px-4 py-3 text-left font-medium text-slate-600">Reports To</th>
+                <th className="px-4 py-3 w-16" />
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.length === 0 ? (
+                <tr>
+                  <td colSpan={4} className="px-4 py-12 text-center text-slate-400">
+                    <Users className="w-8 h-8 mx-auto mb-2 opacity-30" />
+                    <p>No employees found.</p>
+                  </td>
+                </tr>
+              ) : filtered.map(emp => {
+                const effectiveManager = getEffectiveManager(emp);
+                const isDirty = emp.id in pending;
+                const state = saveStates[emp.id] ?? 'idle';
+
+                return (
+                  <tr key={emp.id} className={`border-b last:border-0 transition-colors ${isDirty ? 'bg-amber-50/40' : 'hover:bg-slate-50/50'}`}>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-2.5">
+                        <div className="size-8 rounded-full bg-sky-100 flex items-center justify-center shrink-0">
+                          <Users className="size-4 text-sky-600" />
+                        </div>
+                        <div>
+                          <p className="font-medium text-slate-800">{emp.fullNameEn}</p>
+                          <p className="text-xs text-slate-400">{emp.occupation ?? emp.employmentId}</p>
+                        </div>
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 text-slate-500 hidden sm:table-cell">
+                      {emp.departmentRef?.name ?? <span className="text-slate-300">—</span>}
+                    </td>
+                    <td className="px-4 py-3">
+                      <Select
+                        value={effectiveManager ?? 'none'}
+                        onValueChange={val => handleChange(emp.id, val === 'none' ? null : val)}
+                      >
+                        <SelectTrigger className={`h-8 text-sm max-w-xs ${isDirty ? 'border-amber-400 ring-1 ring-amber-300' : ''}`}>
+                          <SelectValue>
+                            {effectiveManager
+                              ? <span className="font-medium">{getManagerName(effectiveManager)}</span>
+                              : <span className="text-slate-400">No manager</span>
+                            }
+                          </SelectValue>
+                        </SelectTrigger>
+                        <SelectContent className="max-h-64">
+                          <SelectItem value="none">
+                            <span className="text-slate-400 italic">No manager (top-level)</span>
+                          </SelectItem>
+                          {employees
+                            .filter(m => m.id !== emp.id)
+                            .map(m => (
+                              <SelectItem key={m.id} value={m.id}>
+                                {m.fullNameEn}
+                                {m.occupation && (
+                                  <span className="text-xs text-slate-400 ml-1.5">· {m.occupation}</span>
+                                )}
+                              </SelectItem>
+                            ))
+                          }
+                        </SelectContent>
+                      </Select>
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      {state === 'saving' && (
+                        <Loader2 className="w-4 h-4 animate-spin text-slate-400 inline-block" />
+                      )}
+                      {state === 'saved' && (
+                        <CheckCircle2 className="w-4 h-4 text-emerald-500 inline-block" />
+                      )}
+                      {state === 'error' && (
+                        <AlertTriangle className="w-4 h-4 text-rose-500 inline-block" />
+                      )}
+                      {isDirty && state === 'idle' && (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="h-7 text-xs gap-1 border-sky-300 text-sky-700 hover:bg-sky-50"
+                          onClick={() => saveOne(emp.id)}
+                        >
+                          <Save className="w-3 h-3" /> Save
+                        </Button>
+                      )}
+                      {!isDirty && emp.reportsToId && (
+                        <Badge variant="secondary" className="text-xs font-normal">
+                          Set
+                        </Badge>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        <p className="text-xs text-slate-400 text-center">
+          Changes are saved individually per row or all at once via "Save All". The Organization Chart will reflect changes immediately after saving.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/hr/organization-setup/page.tsx
+++ b/src/app/hr/organization-setup/page.tsx
@@ -1,0 +1,36 @@
+import type { Metadata } from 'next';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { verifySession } from '@/lib/jwt';
+import { checkPermission } from '@/lib/permission-checker';
+import { OrgSetupClient } from './_page-client';
+import prisma from '@/lib/db';
+
+export const metadata: Metadata = { title: 'Organization Setup | HR | OTS' };
+export const dynamic = 'force-dynamic';
+
+export default async function OrgSetupPage() {
+  const store = await cookies();
+  const cookieName = process.env.COOKIE_NAME || 'ots_session';
+  const token = store.get(cookieName)?.value;
+  const session = token ? verifySession(token) : null;
+  if (!session) redirect('/login');
+
+  const canEdit = await checkPermission('hr.employee.edit');
+  if (!canEdit) redirect('/unauthorized?from=/hr/organization-setup');
+
+  const employees = await prisma.employee.findMany({
+    where: { deletedAt: null, status: { not: 'TERMINATED' } },
+    select: {
+      id: true,
+      fullNameEn: true,
+      employmentId: true,
+      occupation: true,
+      reportsToId: true,
+      departmentRef: { select: { name: true } },
+    },
+    orderBy: { fullNameEn: 'asc' },
+  });
+
+  return <OrgSetupClient employees={employees} />;
+}

--- a/src/app/workflow/approvals/ApprovalsTrackingClient.tsx
+++ b/src/app/workflow/approvals/ApprovalsTrackingClient.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { LayoutList, ChevronDown, ChevronUp, Clock, Loader2, RefreshCw, AlertTriangle } from 'lucide-react';
+import { LayoutList, ChevronDown, ChevronUp, Clock, Loader2, RefreshCw, AlertTriangle, CheckCircle2, XCircle, Banknote, User } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -13,6 +13,9 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
 import { HorizontalStepsTimeline } from '@/components/workflow/HorizontalStepsTimeline';
 import { WorkflowTimeline } from '@/components/workflow/WorkflowTimeline';
 
@@ -50,6 +53,7 @@ interface WorkflowInstance {
   completedAt: string | null;
   cancelledAt: string | null;
   cancelReason: string | null;
+  metadata: Record<string, unknown> | null;
   definition: { key: string; name: string; entityType: string };
   initiatedBy: { id: string; name: string };
   cancelledBy: { id: string; name: string } | null;
@@ -66,6 +70,7 @@ interface AllApprovalsResponse {
 
 interface ApprovalsTrackingClientProps {
   isAdmin: boolean;
+  currentUserId: string;
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -90,6 +95,20 @@ function currentStepInfo(stepInstances: StepInstance[]): { name: string; approve
   return { name: active.step.name, approvers: display };
 }
 
+function getPendingActionStep(
+  stepInstances: StepInstance[],
+  currentUserId: string,
+): StepInstance | null {
+  const active = stepInstances.find(s => s.status === 'ACTIVE');
+  if (!active) return null;
+  const isApprover = (active.resolvedApprovers ?? []).some(a => a.userId === currentUserId);
+  if (!isApprover) return null;
+  const hasDecided = active.approvals.some(
+    a => a.user.id === currentUserId && ['APPROVE', 'REJECT'].includes(a.decision),
+  );
+  return hasDecided ? null : active;
+}
+
 function statusBadge(status: string) {
   switch (status) {
     case 'APPROVED':    return <Badge className="bg-emerald-100 text-emerald-700 border border-emerald-200 hover:bg-emerald-100">Approved</Badge>;
@@ -106,23 +125,135 @@ function formatDate(iso: string) {
   });
 }
 
+function fmtSAR(v: unknown) {
+  if (typeof v !== 'number' && typeof v !== 'string') return null;
+  const n = Number(v);
+  if (isNaN(n)) return null;
+  return new Intl.NumberFormat('en-SA', { style: 'currency', currency: 'SAR', maximumFractionDigits: 0 }).format(n);
+}
+
+// ─── Entity context badge strip ───────────────────────────────────────────────
+
+function EntityContext({ entityType, metadata }: { entityType: string; metadata: Record<string, unknown> | null }) {
+  if (!metadata) return null;
+  const items: { icon: React.ReactNode; label: string }[] = [];
+
+  if (entityType === 'Loan') {
+    const amt = fmtSAR(metadata.principal);
+    if (amt) items.push({ icon: <Banknote className="w-3 h-3" />, label: amt });
+    if (metadata.employeeName) items.push({ icon: <User className="w-3 h-3" />, label: String(metadata.employeeName) });
+    if (metadata.installmentsTotal) items.push({ icon: null, label: `${metadata.installmentsTotal} installments` });
+  }
+
+  if (entityType === 'PaymentCertificate') {
+    const amt = fmtSAR(metadata.amount ?? metadata.certificateAmount);
+    if (amt) items.push({ icon: <Banknote className="w-3 h-3" />, label: amt });
+    if (metadata.projectName) items.push({ icon: null, label: String(metadata.projectName) });
+  }
+
+  if (!items.length) return null;
+
+  return (
+    <div className="flex flex-wrap gap-1.5 mt-1.5">
+      {items.map((item, i) => (
+        <span key={i} className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-slate-100 text-slate-600 border border-slate-200">
+          {item.icon}
+          {item.label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
 // ─── KPI Card ─────────────────────────────────────────────────────────────────
 
 function KpiCard({ label, value, color }: { label: string; value: number; color: string }) {
   return (
-    <div className={`rounded-xl border bg-white p-4 shadow-sm`}>
+    <div className="rounded-xl border bg-white p-4 shadow-sm">
       <p className={`text-xs font-semibold uppercase tracking-wide ${color} mb-1`}>{label}</p>
       <p className="text-2xl font-bold text-slate-800">{value}</p>
     </div>
   );
 }
 
+// ─── Approve/Reject Dialog ────────────────────────────────────────────────────
+
+interface ActionDialogProps {
+  open: boolean;
+  decision: 'APPROVE' | 'REJECT';
+  onClose: () => void;
+  onConfirm: (comment: string) => Promise<void>;
+}
+
+function ActionDialog({ open, decision, onClose, onConfirm }: ActionDialogProps) {
+  const [comment, setComment] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleConfirm = async () => {
+    setLoading(true);
+    await onConfirm(comment);
+    setLoading(false);
+    setComment('');
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={v => { if (!v) onClose(); }}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className={decision === 'APPROVE' ? 'text-emerald-700' : 'text-rose-700'}>
+            {decision === 'APPROVE' ? 'Approve Request' : 'Reject Request'}
+          </DialogTitle>
+        </DialogHeader>
+        <div className="space-y-3 py-2">
+          <div>
+            <Label htmlFor="comment" className="text-sm text-slate-600">
+              Comment {decision === 'REJECT' && <span className="text-rose-500">*</span>}
+            </Label>
+            <Textarea
+              id="comment"
+              placeholder={decision === 'APPROVE' ? 'Optional comment…' : 'Reason for rejection…'}
+              value={comment}
+              onChange={e => setComment(e.target.value)}
+              className="mt-1 min-h-[80px]"
+            />
+          </div>
+        </div>
+        <DialogFooter className="gap-2">
+          <Button variant="outline" onClick={onClose} disabled={loading}>Cancel</Button>
+          <Button
+            disabled={loading || (decision === 'REJECT' && !comment.trim())}
+            className={decision === 'APPROVE'
+              ? 'bg-emerald-600 hover:bg-emerald-700 text-white'
+              : 'bg-rose-600 hover:bg-rose-700 text-white'}
+            onClick={handleConfirm}
+          >
+            {loading ? <Loader2 className="w-4 h-4 animate-spin mr-1" /> : null}
+            {decision === 'APPROVE' ? 'Approve' : 'Reject'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 // ─── Instance Row ─────────────────────────────────────────────────────────────
 
-function InstanceRow({ instance }: { instance: WorkflowInstance }) {
+function InstanceRow({
+  instance,
+  currentUserId,
+  onRefresh,
+}: {
+  instance: WorkflowInstance;
+  currentUserId: string;
+  onRefresh: () => void;
+}) {
   const [expanded, setExpanded] = useState(false);
+  const [actionDialog, setActionDialog] = useState<'APPROVE' | 'REJECT' | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
   const idle = idleLabel(instance.stepInstances);
   const stepInfo = currentStepInfo(instance.stepInstances);
+  const pendingStep = getPendingActionStep(instance.stepInstances, currentUserId);
 
   const timelineSteps = instance.stepInstances.map(s => ({
     id: s.id,
@@ -133,70 +264,133 @@ function InstanceRow({ instance }: { instance: WorkflowInstance }) {
     activatedAt: s.activatedAt,
   }));
 
+  const handleDecision = async (decision: 'APPROVE' | 'REJECT', comment: string) => {
+    setActionError(null);
+    try {
+      const res = await fetch(`/api/workflow/instances/${instance.id}/decide`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ decision, comment: comment || undefined }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error ?? 'Failed to record decision');
+      }
+      setActionDialog(null);
+      onRefresh();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to record decision');
+    }
+  };
+
   return (
-    <Card className="overflow-hidden">
-      <CardContent className="p-0">
-        {/* Main row */}
-        <button
-          className="w-full text-left p-4 hover:bg-slate-50 transition-colors"
-          onClick={() => setExpanded(e => !e)}
-        >
-          <div className="flex flex-col sm:flex-row sm:items-start gap-3">
-            {/* Left: workflow + entity */}
-            <div className="flex-1 min-w-0">
-              <div className="flex flex-wrap items-center gap-2 mb-1">
-                <span className="font-semibold text-slate-800 text-sm">{instance.definition.name}</span>
-                <span className="text-xs px-2 py-0.5 rounded-full bg-violet-50 text-violet-700 border border-violet-200 font-mono">
-                  {instance.entityType} #{instance.entityId.slice(0, 8)}
-                </span>
+    <>
+      <Card className="overflow-hidden">
+        <CardContent className="p-0">
+          {/* Main row */}
+          <button
+            className="w-full text-left p-4 hover:bg-slate-50 transition-colors"
+            onClick={() => setExpanded(e => !e)}
+          >
+            <div className="flex flex-col sm:flex-row sm:items-start gap-3">
+              {/* Left: workflow + entity */}
+              <div className="flex-1 min-w-0">
+                <div className="flex flex-wrap items-center gap-2 mb-1">
+                  <span className="font-semibold text-slate-800 text-sm">{instance.definition.name}</span>
+                  <span className="text-xs px-2 py-0.5 rounded-full bg-violet-50 text-violet-700 border border-violet-200 font-mono">
+                    {instance.entityType} #{instance.entityId.slice(0, 8)}
+                  </span>
+                </div>
+                <p className="text-xs text-slate-500">
+                  Submitted by <span className="font-medium text-slate-700">{instance.initiatedBy.name}</span>
+                  {' · '}{formatDate(instance.createdAt)}
+                </p>
+
+                <EntityContext entityType={instance.entityType} metadata={instance.metadata} />
+
+                {/* Mini horizontal timeline */}
+                {timelineSteps.length > 0 && (
+                  <div className="mt-3">
+                    <HorizontalStepsTimeline steps={timelineSteps} compact />
+                  </div>
+                )}
               </div>
-              <p className="text-xs text-slate-500">
-                Submitted by <span className="font-medium text-slate-700">{instance.initiatedBy.name}</span>
-                {' · '}{formatDate(instance.createdAt)}
-              </p>
 
-              {/* Mini horizontal timeline */}
-              {timelineSteps.length > 0 && (
-                <div className="mt-3">
-                  <HorizontalStepsTimeline steps={timelineSteps} compact />
-                </div>
-              )}
+              {/* Right: status + step info */}
+              <div className="flex flex-col items-start sm:items-end gap-2 shrink-0">
+                {statusBadge(instance.status)}
+
+                {idle && (
+                  <span className={`flex items-center gap-1 text-xs font-medium ${idle.urgent ? 'text-red-600' : 'text-slate-500'}`}>
+                    <Clock className="w-3.5 h-3.5" />
+                    {idle.label}
+                  </span>
+                )}
+
+                {stepInfo && (
+                  <div className="text-right">
+                    <p className="text-xs font-medium text-slate-700">{stepInfo.name}</p>
+                    <p className="text-xs text-slate-400">{stepInfo.approvers}</p>
+                  </div>
+                )}
+
+                {expanded
+                  ? <ChevronUp className="w-4 h-4 text-slate-400 mt-1" />
+                  : <ChevronDown className="w-4 h-4 text-slate-400 mt-1" />
+                }
+              </div>
             </div>
+          </button>
 
-            {/* Right: status + step info */}
-            <div className="flex flex-col items-start sm:items-end gap-2 shrink-0">
-              {statusBadge(instance.status)}
-
-              {idle && (
-                <span className={`flex items-center gap-1 text-xs font-medium ${idle.urgent ? 'text-red-600' : 'text-slate-500'}`}>
-                  <Clock className="w-3.5 h-3.5" />
-                  {idle.label}
-                </span>
-              )}
-
-              {stepInfo && (
-                <div className="text-right">
-                  <p className="text-xs font-medium text-slate-700">{stepInfo.name}</p>
-                  <p className="text-xs text-slate-400">{stepInfo.approvers}</p>
-                </div>
-              )}
-
-              {expanded
-                ? <ChevronUp className="w-4 h-4 text-slate-400 mt-1" />
-                : <ChevronDown className="w-4 h-4 text-slate-400 mt-1" />
-              }
+          {/* Inline action buttons for current-user approver */}
+          {pendingStep && (
+            <div className="px-4 pb-3 pt-1 border-t bg-amber-50/50 flex flex-wrap items-center gap-2">
+              <span className="text-xs text-amber-700 font-medium flex-1">
+                Your approval is needed for: <strong>{pendingStep.step.name}</strong>
+              </span>
+              <Button
+                size="sm"
+                className="bg-emerald-600 hover:bg-emerald-700 text-white h-8 text-xs gap-1"
+                onClick={e => { e.stopPropagation(); setActionDialog('APPROVE'); }}
+              >
+                <CheckCircle2 className="w-3.5 h-3.5" /> Approve
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                className="border-rose-300 text-rose-600 hover:bg-rose-50 h-8 text-xs gap-1"
+                onClick={e => { e.stopPropagation(); setActionDialog('REJECT'); }}
+              >
+                <XCircle className="w-3.5 h-3.5" /> Reject
+              </Button>
             </div>
-          </div>
-        </button>
+          )}
 
-        {/* Expanded full timeline */}
-        {expanded && (
-          <div className="border-t px-4 py-4 bg-slate-50">
-            <WorkflowTimeline instance={instance} />
-          </div>
-        )}
-      </CardContent>
-    </Card>
+          {actionError && (
+            <div className="px-4 py-2 text-xs text-rose-600 border-t flex items-center gap-1.5 bg-rose-50">
+              <AlertTriangle className="w-3.5 h-3.5 shrink-0" />
+              {actionError}
+            </div>
+          )}
+
+          {/* Expanded full timeline */}
+          {expanded && (
+            <div className="border-t px-4 py-4 bg-slate-50">
+              <WorkflowTimeline instance={instance} />
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {actionDialog && (
+        <ActionDialog
+          open
+          decision={actionDialog}
+          onClose={() => setActionDialog(null)}
+          onConfirm={comment => handleDecision(actionDialog, comment)}
+        />
+      )}
+    </>
   );
 }
 
@@ -204,7 +398,7 @@ function InstanceRow({ instance }: { instance: WorkflowInstance }) {
 
 const ENTITY_TYPES = ['Loan', 'NCRReport', 'ImsRevision', 'ImsChangeRequest', 'Document'];
 
-export function ApprovalsTrackingClient({ isAdmin }: ApprovalsTrackingClientProps) {
+export function ApprovalsTrackingClient({ isAdmin, currentUserId }: ApprovalsTrackingClientProps) {
   const [data, setData] = useState<AllApprovalsResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -358,7 +552,12 @@ export function ApprovalsTrackingClient({ isAdmin }: ApprovalsTrackingClientProp
         ) : (
           <div className="space-y-3">
             {filteredItems.map(inst => (
-              <InstanceRow key={inst.id} instance={inst} />
+              <InstanceRow
+                key={inst.id}
+                instance={inst}
+                currentUserId={currentUserId}
+                onRefresh={() => load(page)}
+              />
             ))}
           </div>
         )}

--- a/src/app/workflow/approvals/page.tsx
+++ b/src/app/workflow/approvals/page.tsx
@@ -18,5 +18,5 @@ export default async function ApprovalsPage() {
 
   if (!canViewAll && !canViewOwn) redirect('/unauthorized?from=/workflow/approvals');
 
-  return <ApprovalsTrackingClient isAdmin={canViewAll} />;
+  return <ApprovalsTrackingClient isAdmin={canViewAll} currentUserId={session!.sub} />;
 }

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -337,6 +337,7 @@ const navigationSections: NavigationSection[] = [
       { name: 'Absence Analytics', href: '/hr/analytics', icon: TrendingUp, newSince: '2026-04-18' },
       { name: 'Employees', href: '/hr/employees', icon: Users, newSince: '2026-04-12' },
       { name: 'Organization Chart', href: '/hr/organization-chart', icon: Network, newSince: '2026-05-08' },
+      { name: 'Organization Setup', href: '/hr/organization-setup', icon: GitBranch, newSince: '2026-05-08' },
       { name: 'Attendance', href: '/hr/attendance', icon: Calendar, newSince: '2026-04-12' },
       { name: 'Agencies', href: '/hr/agencies', icon: Briefcase, newSince: '2026-04-12' },
       { name: 'Leaves', href: '/hr/leaves', icon: CalendarClock, newSince: '2026-04-12' },

--- a/src/lib/api-utils.ts
+++ b/src/lib/api-utils.ts
@@ -71,8 +71,14 @@ export function withApiContext<T = any>(
         'API'
       );
       
+      // Next.js 15: context.params is a Promise — resolve before passing to handler
+      let resolvedContext = context;
+      if (context?.params && typeof (context.params as unknown as Promise<Record<string, string>>).then === 'function') {
+        resolvedContext = { params: await (context.params as unknown as Promise<Record<string, string>>) };
+      }
+
       return await runWithContextAsync(requestContext, async () => {
-        return handler(request, session, context);
+        return handler(request, session, resolvedContext);
       });
     } catch (error) {
       logger.error({ error }, '[API] Unhandled error in route handler');

--- a/src/lib/navigation-permissions.ts
+++ b/src/lib/navigation-permissions.ts
@@ -180,6 +180,7 @@ export const NAVIGATION_PERMISSIONS: NavigationPermissionMap = {
 
   // HR Foundation (Phase 1 of OTS-MSS-HR-PAYROLL-v1)
   '/hr/organization-chart': ['hr.employee.view'],
+  '/hr/organization-setup': ['hr.employee.edit'],
   '/hr/dashboard': ['hr.employee.view'],
   '/hr/employees/me': ['hr.employee.viewOwn'],
   '/hr/employees': ['hr.employee.view', 'hr.employee.viewOwn'],

--- a/src/lib/services/supply-chain/supplier-portal.service.ts
+++ b/src/lib/services/supply-chain/supplier-portal.service.ts
@@ -211,7 +211,17 @@ export async function getSupplierList(
       ON sas.dolibarr_id = dt.dolibarr_id AND sas.deletedAt IS NULL
     LEFT JOIN fin_supplier_classification sc
       ON sc.supplier_id = dt.dolibarr_id
-    WHERE dt.supplier_type = 1 AND dt.is_active = 1 ${searchFilter}
+    WHERE dt.is_active = 1
+      AND (
+        dt.supplier_type = 1
+        OR EXISTS (
+          SELECT 1 FROM fin_supplier_invoices si WHERE si.socid = dt.dolibarr_id AND si.is_active = 1
+        )
+        OR EXISTS (
+          SELECT 1 FROM ScApprovedSupplier sas2 WHERE sas2.dolibarr_id = dt.dolibarr_id AND sas2.deletedAt IS NULL
+        )
+      )
+      ${searchFilter}
     ORDER BY dt.name ASC
     LIMIT ? OFFSET ?
   `, ...searchArgs, limit, offset);
@@ -219,7 +229,17 @@ export async function getSupplierList(
   const countRows = await prisma.$queryRawUnsafe<[{ cnt: bigint }]>(`
     SELECT COUNT(*) AS cnt
     FROM dolibarr_thirdparties dt
-    WHERE dt.supplier_type = 1 AND dt.is_active = 1 ${searchFilter}
+    WHERE dt.is_active = 1
+      AND (
+        dt.supplier_type = 1
+        OR EXISTS (
+          SELECT 1 FROM fin_supplier_invoices si WHERE si.socid = dt.dolibarr_id AND si.is_active = 1
+        )
+        OR EXISTS (
+          SELECT 1 FROM ScApprovedSupplier sas WHERE sas.dolibarr_id = dt.dolibarr_id AND sas.deletedAt IS NULL
+        )
+      )
+      ${searchFilter}
   `, ...searchArgs);
 
   return {

--- a/src/lib/services/workflow.service.ts
+++ b/src/lib/services/workflow.service.ts
@@ -7,6 +7,7 @@
 import prisma from '@/lib/db';
 import { logger } from '@/lib/logger';
 import { systemEventService } from '@/services/system-events.service';
+import { NotificationService } from '@/lib/services/notification.service';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -504,6 +505,22 @@ class WorkflowService {
         data: { currentStepId: candidate.id },
       });
 
+      // Notify each resolved approver
+      const wfInstance = await prisma.workflowInstance.findUnique({
+        where: { id: instanceId },
+        select: { entityType: true, entityId: true, definition: { select: { name: true } } },
+      });
+      for (const approver of resolvedApprovers) {
+        NotificationService.createNotification({
+          userId: approver.userId,
+          type: 'APPROVAL_REQUIRED',
+          title: 'Approval Required',
+          message: `Your approval is needed for ${wfInstance?.definition.name ?? 'a workflow'} (${wfInstance?.entityType} #${wfInstance?.entityId.slice(0, 8)})`,
+          relatedEntityType: wfInstance?.entityType,
+          relatedEntityId: instanceId,
+        }).catch(err => logger.error({ err, approverUserId: approver.userId }, 'Failed to send approval notification'));
+      }
+
       return; // activated a step — done
     }
 
@@ -513,7 +530,23 @@ class WorkflowService {
       data: { status: 'APPROVED', currentStepId: null, completedAt: new Date() },
     });
 
-    const instance = await prisma.workflowInstance.findUnique({ where: { id: instanceId } });
+    const instance = await prisma.workflowInstance.findUnique({
+      where: { id: instanceId },
+      select: { entityType: true, entityId: true, initiatedById: true, definition: { select: { name: true } } },
+    });
+
+    // Notify the initiator that the workflow was fully approved
+    if (instance?.initiatedById) {
+      NotificationService.createNotification({
+        userId: instance.initiatedById,
+        type: 'APPROVED',
+        title: 'Request Approved',
+        message: `Your ${instance.definition.name ?? 'workflow'} request has been fully approved.`,
+        relatedEntityType: instance.entityType,
+        relatedEntityId: instanceId,
+      }).catch(err => logger.error({ err, initiatedById: instance.initiatedById }, 'Failed to send approval complete notification'));
+    }
+
     await systemEventService.log({
       eventType: 'WORKFLOW_COMPLETED',
       eventCategory: 'BUSINESS',
@@ -558,6 +591,15 @@ class WorkflowService {
         where: { id: instanceId },
         data: { status: 'REJECTED', currentStepId: null, completedAt: new Date() },
       });
+      // Notify initiator that request was rejected
+      NotificationService.createNotification({
+        userId: instance.initiatedById,
+        type: 'REJECTED',
+        title: 'Request Rejected',
+        message: `Your workflow request has been rejected at step ${rejectedStepInstance.sequence}.`,
+        relatedEntityType: instance.entityType,
+        relatedEntityId: instanceId,
+      }).catch(err => logger.error({ err }, 'Failed to send rejection notification'));
       return;
     }
 


### PR DESCRIPTION
- Fix customer detail 404: withApiContext now resolves Next.js 15 Promise params before passing to handlers
- Workflow tracker: add inline Approve/Reject buttons for the current user's pending steps, with comment dialog
- Workflow tracker: show entity context (loan amount, employee name, installments) from instance metadata
- Workflow tracker: include metadata in all-approvals API response; add onRejectBehavior to step include
- Workflow service: send APPROVAL_REQUIRED notification to each resolved approver when a step activates; send APPROVED/REJECTED notifications to initiator on completion/termination
- Loan creation: include employeeName in workflow metadata so the tracker shows the requester
- Supplier portal: broaden list query to include companies that have supplier invoices or an approved-supplier record, not just supplier_type=1 from Dolibarr flag
- Organization Setup page (/hr/organization-setup): new bulk manager-assignment table to set Employee.reportsToId without opening individual profiles; affects org chart immediately
- Sidebar + nav permissions wired for Organization Setup

https://claude.ai/code/session_01Dads4P1EcmMzqeUAcLySsZ