### PR TITLE
fix: define add_column_if_missing procedure in v24_2 migration

### DIFF
--- a/prisma/manual_migrations/v24_2_audit_tracker_rebuild.sql
+++ b/prisma/manual_migrations/v24_2_audit_tracker_rebuild.sql
@@ -5,6 +5,31 @@
 -- Procedure: Hexa-ISP-004
 -- ============================================================
 
+-- ── 0. Helper procedure (conditional column addition) ───────
+
+DROP PROCEDURE IF EXISTS add_column_if_missing;
+DELIMITER $$
+CREATE PROCEDURE add_column_if_missing(
+  IN p_table VARCHAR(64),
+  IN p_col   VARCHAR(64),
+  IN p_def   TEXT
+)
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME   = p_table
+      AND COLUMN_NAME  = p_col
+  ) THEN
+    SET @_sql = CONCAT('ALTER TABLE `', p_table, '` ADD COLUMN `', p_col, '` ', p_def);
+    PREPARE _s FROM @_sql;
+    EXECUTE _s;
+    DEALLOCATE PREPARE _s;
+  END IF;
+END$$
+DELIMITER ;
+
 -- ── 1. Expand ImsAudit (FRM-004 & FRM-005 fields) ──────────
 
 -- FRM-004 schedule enhancements


### PR DESCRIPTION
The migration called CALL add_column_if_missing() but the procedure
was never defined, causing v24_2 to fail and leaving the new ImsAudit
columns (processArea, riskLevel, isoClausesInScope, etc.) absent,
which in turn caused v24_3 seed to fail with "Unknown column 'processArea'".

Adds the CREATE PROCEDURE block at the top of v24_2 so all subsequent
CALL statements succeed on a fresh run or replay.

https://claude.ai/code/session_01KWhn5iESeWFxKc7qBBuwg6