### PR TITLE
feat(ims/audit): split audit PDFs into separate FRM-004 and FRM-005 documents

### DIFF
--- a/prisma/manual_migrations/v24_4_settings_pdf_font.sql
+++ b/prisma/manual_migrations/v24_4_settings_pdf_font.sql
@@ -1,0 +1,22 @@
+-- Migration: v24_4_settings_pdf_font
+-- Adds pdfFont column to system_settings for configurable PDF font family
+
+DROP PROCEDURE IF EXISTS add_pdf_font_column;
+
+DELIMITER $$
+CREATE PROCEDURE add_pdf_font_column()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name   = 'system_settings'
+      AND column_name  = 'pdfFont'
+  ) THEN
+    ALTER TABLE system_settings
+      ADD COLUMN pdfFont VARCHAR(50) NOT NULL DEFAULT 'helvetica';
+  END IF;
+END$$
+DELIMITER ;
+
+CALL add_pdf_font_column();
+DROP PROCEDURE IF EXISTS add_pdf_font_column;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2738,6 +2738,7 @@ model SystemSettings {
 
   // Report Settings
   defaultReportTheme String @default("blue") // blue | green | orange | purple | red
+  pdfFont            String @default("helvetica") // helvetica | courier | times
   reportFooterText   String @default("HEXA STEEL - Professional Report")
 
   // System Settings

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -18,6 +18,7 @@ const settingsSchema = z.object({
   companyEmail: z.string().email().or(z.literal('')).transform(val => val === '' ? null : val).nullable().optional(),
   companyWebsite: z.string().url().or(z.literal('')).transform(val => val === '' ? null : val).nullable().optional(),
   defaultReportTheme: z.enum(['blue', 'green', 'orange', 'purple', 'red']).optional(),
+  pdfFont: z.enum(['helvetica', 'courier', 'times']).optional(),
   reportFooterText: z.string().optional(),
   dateFormat: z.string().optional(),
   timezone: z.string().optional(),
@@ -43,8 +44,8 @@ export async function GET(req: Request) {
     const SAFE_SELECT = {
       id: true, companyName: true, companyTagline: true, companyLogo: true,
       companyAddress: true, companyPhone: true, companyEmail: true,
-      companyWebsite: true, defaultReportTheme: true, reportFooterText: true,
-      dateFormat: true, timezone: true, currency: true,
+      companyWebsite: true, defaultReportTheme: true, pdfFont: true,
+      reportFooterText: true, dateFormat: true, timezone: true, currency: true,
       emailNotifications: true, smsNotifications: true,
       createdAt: true, updatedAt: true,
     } as const;

--- a/src/app/ims/audit-plans/[id]/_page-client.tsx
+++ b/src/app/ims/audit-plans/[id]/_page-client.tsx
@@ -13,7 +13,8 @@ import {
   ArrowLeft, Plus, CheckCircle2, Loader2, FileDown, Search,
   ChevronRight, FileText, Shield,
 } from 'lucide-react';
-import { generateAuditPlanPDF, type AuditPlanPDFData } from '@/lib/ims-pdf-generator';
+import { generateAuditSchedulePDF, type AuditSchedulePDFData } from '@/lib/ims-audit-schedule-pdf-generator';
+import { generateInternalAuditReportPDF, type InternalAuditReportPDFData } from '@/lib/ims-audit-report-pdf-generator';
 
 type Audit = {
   id: string;
@@ -147,6 +148,7 @@ export function AuditPlanDetailClient({ planId }: { planId: string }) {
   const [auditeeSearch, setAuditeeSearch] = useState('');
   const [savingApproval, setSavingApproval] = useState(false);
   const [savingReport, setSavingReport] = useState(false);
+  const [downloadingReport, setDownloadingReport] = useState(false);
 
   const [isoClauseInput, setIsoClauseInput] = useState('');
 
@@ -371,16 +373,11 @@ export function AuditPlanDetailClient({ planId }: { planId: string }) {
     }
   };
 
-  const downloadPDF = async () => {
+  const downloadSchedule = async () => {
     if (!plan) return;
     setDownloading(true);
     try {
-      const allFindings: Record<string, Finding[]> = {};
-      for (const a of plan.audits) {
-        const fr = await fetch(`/api/ims/audit-findings?auditId=${a.id}`);
-        allFindings[a.id] = fr.ok ? await fr.json() : [];
-      }
-      const pdfData: AuditPlanPDFData = {
+      const pdfData: AuditSchedulePDFData = {
         planNumber: plan.planNumber,
         year: plan.year,
         auditType: plan.auditType,
@@ -388,17 +385,82 @@ export function AuditPlanDetailClient({ planId }: { planId: string }) {
         audits: plan.audits.map(a => ({
           auditNumber: a.auditNumber,
           scope: a.scope,
+          processArea: a.processArea ?? null,
+          riskLevel: a.riskLevel ?? null,
+          isoClausesInScope: a.isoClausesInScope ?? null,
           scheduledDate: a.scheduledDate,
-          actualDate: a.actualDate,
-          status: a.status,
+          actualDate: a.actualDate ?? null,
           auditor: a.auditor?.name ?? null,
           auditee: a.auditee?.name ?? null,
-          findings: allFindings[a.id] ?? [],
+          status: a.status,
+          auditorIndependenceConfirmed: a.auditorIndependenceConfirmed,
+          approvedByImsManagerName: a.approvedByImsManagerName ?? null,
+          approvedByImsManagerDate: a.approvedByImsManagerDate ?? null,
+          approvedByImsManagerSigned: a.approvedByImsManagerSigned,
+          approvedByTopMgmtName: a.approvedByTopMgmtName ?? null,
+          approvedByTopMgmtDate: a.approvedByTopMgmtDate ?? null,
+          approvedByTopMgmtSigned: a.approvedByTopMgmtSigned,
+          findingsCount: a._count.findings,
         })),
       };
-      await generateAuditPlanPDF(pdfData);
+      await generateAuditSchedulePDF(pdfData);
     } finally {
       setDownloading(false);
+    }
+  };
+
+  const downloadAuditReport = async (audit: Audit) => {
+    if (!plan) return;
+    setDownloadingReport(true);
+    try {
+      const fr = await fetch(`/api/ims/audit-findings?auditId=${audit.id}`);
+      const auditFindings: Finding[] = fr.ok ? await fr.json() : [];
+
+      const pdfData: InternalAuditReportPDFData = {
+        auditNumber: audit.auditNumber,
+        planNumber: plan.planNumber,
+        auditDate: audit.scheduledDate,
+        department: audit.scope,
+        scope: audit.scope,
+        auditor: audit.auditor?.name ?? '—',
+        auditee: audit.auditee?.name ?? '—',
+        standard: 'ISO 9001:2015',
+        processArea: audit.processArea ?? null,
+        riskLevel: audit.riskLevel ?? null,
+        isoClausesInScope: audit.isoClausesInScope ?? null,
+        auditorIndependenceConfirmed: audit.auditorIndependenceConfirmed,
+        reportExecutiveSummary: audit.reportExecutiveSummary ?? null,
+        reportAuditMethod: audit.reportAuditMethod ?? null,
+        reportPositiveFindings: audit.reportPositiveFindings ?? null,
+        reportConclusion: audit.reportConclusion ?? null,
+        reportRecommendation: audit.reportRecommendation ?? null,
+        reportLeadAuditorName: audit.reportLeadAuditorName ?? null,
+        reportLeadAuditorDate: audit.reportLeadAuditorDate ?? null,
+        reportLeadAuditorSigned: audit.reportLeadAuditorSigned,
+        reportImsMgrName: audit.reportImsMgrName ?? null,
+        reportImsMgrDate: audit.reportImsMgrDate ?? null,
+        reportImsMgrSigned: audit.reportImsMgrSigned,
+        findings: auditFindings.map(f => ({
+          findingNumber: f.findingNumber,
+          type: f.type,
+          clause: f.clause,
+          description: f.description,
+          evidence: null,
+          correctiveAction: null,
+          targetDate: f.targetDate ?? null,
+          status: f.status,
+        })),
+      };
+
+      const blob = await generateInternalAuditReportPDF(pdfData);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${audit.auditNumber}-FRM-005-Audit-Report.pdf`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } finally {
+      setDownloadingReport(false);
     }
   };
 
@@ -445,11 +507,12 @@ export function AuditPlanDetailClient({ planId }: { planId: string }) {
         <Button
           size="sm" variant="outline"
           className="gap-1.5 text-xs border-[#2c3e50]/30 text-[#2c3e50] hover:bg-[#2c3e50] hover:text-white transition-colors"
-          onClick={downloadPDF}
+          onClick={downloadSchedule}
           disabled={downloading}
+          title="Download HEXA-FRM-004 Audit Schedule"
         >
           {downloading ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <FileDown className="w-3.5 h-3.5" />}
-          Download PDF
+          FRM-004 Schedule
         </Button>
       </div>
 
@@ -531,7 +594,19 @@ export function AuditPlanDetailClient({ planId }: { planId: string }) {
               {selectedAudit ? `Findings — ${selectedAudit.auditNumber}` : 'Select an audit'}
             </CardTitle>
             {selectedAudit && (
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-2 flex-wrap">
+                <Button
+                  size="sm" variant="outline"
+                  className="gap-1 text-xs border-emerald-300 text-emerald-700 hover:bg-emerald-50"
+                  onClick={() => downloadAuditReport(selectedAudit)}
+                  disabled={downloadingReport}
+                  title="Download HEXA-FRM-005 Internal Audit Report"
+                >
+                  {downloadingReport
+                    ? <Loader2 className="w-3 h-3 animate-spin" />
+                    : <FileDown className="w-3 h-3" />}
+                  FRM-005 Report
+                </Button>
                 <Link href={`/ims/audit-checklist/${selectedAudit.id}`}>
                   <Button size="sm" variant="outline" className="gap-1 text-xs border-indigo-300 text-indigo-700 hover:bg-indigo-50">
                     <FileText className="w-3 h-3" /> Open Checklist <ChevronRight className="w-3 h-3" />
@@ -835,7 +910,19 @@ export function AuditPlanDetailClient({ planId }: { planId: string }) {
                 </div>
               </div>
 
-              <div className="flex justify-end">
+              <div className="flex items-center justify-between">
+                <Button
+                  size="sm" variant="outline"
+                  onClick={() => selectedAudit && downloadAuditReport(selectedAudit)}
+                  disabled={downloadingReport}
+                  className="gap-1.5 border-emerald-300 text-emerald-700 hover:bg-emerald-50"
+                  title="Download HEXA-FRM-005 Internal Audit Report PDF"
+                >
+                  {downloadingReport
+                    ? <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                    : <FileDown className="w-3.5 h-3.5" />}
+                  Download FRM-005 Report
+                </Button>
                 <Button
                   size="sm"
                   onClick={saveReport}

--- a/src/app/ims/audit-plans/_page-client.tsx
+++ b/src/app/ims/audit-plans/_page-client.tsx
@@ -12,7 +12,7 @@ import Link from 'next/link';
 import {
   SearchCheck, Plus, RefreshCw, ChevronRight, CheckCircle2, Clock, FileDown, Loader2,
 } from 'lucide-react';
-import { generateAuditPlanPDF, type AuditPlanPDFData } from '@/lib/ims-pdf-generator';
+import { generateAuditSchedulePDF, type AuditSchedulePDFData } from '@/lib/ims-audit-schedule-pdf-generator';
 
 type Plan = {
   id: string;
@@ -89,41 +89,52 @@ export function AuditPlansClient() {
     }
   };
 
-  const downloadPDF = async (plan: Plan) => {
+  const downloadSchedule = async (plan: Plan) => {
     setDownloading(plan.id);
     try {
       const res = await fetch(`/api/ims/audit-plans/${plan.id}`);
       if (!res.ok) return;
       const detail = await res.json();
 
-      const findingsMap: Record<string, AuditPlanPDFData['audits'][0]['findings']> = {};
-      for (const a of (detail.audits ?? [])) {
-        const fr = await fetch(`/api/ims/audit-findings?auditId=${a.id}`);
-        findingsMap[a.id] = fr.ok ? await fr.json() : [];
-      }
-
-      const pdfData: AuditPlanPDFData = {
+      const pdfData: AuditSchedulePDFData = {
         planNumber: plan.planNumber,
         year: plan.year,
         auditType: plan.auditType,
         status: plan.status,
         audits: (detail.audits ?? []).map((a: {
-          id: string; auditNumber: string; scope: string;
+          auditNumber: string; scope: string; processArea?: string | null;
+          riskLevel?: string | null; isoClausesInScope?: string[] | null;
           scheduledDate: string; actualDate?: string | null; status: string;
           auditor?: { name: string } | null; auditee?: { name: string } | null;
+          auditorIndependenceConfirmed?: boolean;
+          approvedByImsManagerName?: string | null; approvedByImsManagerDate?: string | null;
+          approvedByImsManagerSigned?: boolean;
+          approvedByTopMgmtName?: string | null; approvedByTopMgmtDate?: string | null;
+          approvedByTopMgmtSigned?: boolean;
+          _count?: { findings: number };
         }) => ({
           auditNumber: a.auditNumber,
           scope: a.scope,
+          processArea: a.processArea ?? null,
+          riskLevel: a.riskLevel ?? null,
+          isoClausesInScope: a.isoClausesInScope ?? null,
           scheduledDate: a.scheduledDate,
-          actualDate: a.actualDate,
-          status: a.status,
+          actualDate: a.actualDate ?? null,
           auditor: a.auditor?.name ?? null,
           auditee: a.auditee?.name ?? null,
-          findings: findingsMap[a.id] ?? [],
+          status: a.status,
+          auditorIndependenceConfirmed: a.auditorIndependenceConfirmed ?? false,
+          approvedByImsManagerName: a.approvedByImsManagerName ?? null,
+          approvedByImsManagerDate: a.approvedByImsManagerDate ?? null,
+          approvedByImsManagerSigned: a.approvedByImsManagerSigned ?? false,
+          approvedByTopMgmtName: a.approvedByTopMgmtName ?? null,
+          approvedByTopMgmtDate: a.approvedByTopMgmtDate ?? null,
+          approvedByTopMgmtSigned: a.approvedByTopMgmtSigned ?? false,
+          findingsCount: a._count?.findings ?? 0,
         })),
       };
 
-      await generateAuditPlanPDF(pdfData);
+      await generateAuditSchedulePDF(pdfData);
     } finally {
       setDownloading(null);
     }
@@ -141,7 +152,7 @@ export function AuditPlansClient() {
           <div>
             <h1 className="text-2xl font-bold tracking-tight">Internal Audit Tracker</h1>
             <p className="text-slate-300 text-sm mt-0.5">ISO 9001 / 14001 / 45001 §9.2 — Audit programme management</p>
-            <p className="text-slate-400/70 text-xs font-mono mt-1">HEXA-FRM-006 · HEXA-FRM-007 · HEXA-FRM-009 · Procedure: Hexa-ISP-002</p>
+            <p className="text-slate-400/70 text-xs font-mono mt-1">HEXA-FRM-004 · HEXA-FRM-005 · HEXA-FRM-006 · Procedure: Hexa-ISP-004</p>
           </div>
         </div>
       </div>
@@ -238,14 +249,15 @@ export function AuditPlansClient() {
                       <div className="flex items-center justify-end gap-1.5">
                         <Button
                           size="sm" variant="ghost"
-                          className="h-7 w-7 p-0 text-slate-400 hover:text-emerald-600 hover:bg-emerald-50"
-                          onClick={() => downloadPDF(p)}
+                          className="h-7 px-2 text-xs gap-1 text-slate-400 hover:text-emerald-600 hover:bg-emerald-50"
+                          onClick={() => downloadSchedule(p)}
                           disabled={downloading === p.id}
-                          title="Download PDF"
+                          title="Download HEXA-FRM-004 Audit Schedule PDF"
                         >
                           {downloading === p.id
                             ? <Loader2 className="w-3.5 h-3.5 animate-spin" />
                             : <FileDown className="w-3.5 h-3.5" />}
+                          <span className="hidden sm:inline">FRM-004</span>
                         </Button>
                         <Link href={`/ims/audit-plans/${p.id}`}>
                           <Button size="sm" variant="ghost" className="h-7 px-2 text-xs text-slate-500 hover:text-[#2c3e50] hover:bg-slate-100 gap-1">

--- a/src/app/settings/_page-client.tsx
+++ b/src/app/settings/_page-client.tsx
@@ -25,6 +25,7 @@ type Settings = {
   companyEmail: string | null;
   companyWebsite: string | null;
   defaultReportTheme: string;
+  pdfFont: string;
   reportFooterText: string;
   dateFormat: string;
   timezone: string;
@@ -747,6 +748,23 @@ export default function SettingsPage() {
                   </select>
                   <p className="text-xs text-muted-foreground">
                     Users can still choose different themes when exporting
+                  </p>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="pdfFont">PDF Document Font</Label>
+                  <select
+                    id="pdfFont"
+                    value={settings.pdfFont ?? 'helvetica'}
+                    onChange={(e) => setSettings({ ...settings, pdfFont: e.target.value })}
+                    className="w-full h-10 px-3 rounded-md border bg-background"
+                  >
+                    <option value="helvetica">Helvetica (Default)</option>
+                    <option value="courier">Courier</option>
+                    <option value="times">Times New Roman</option>
+                  </select>
+                  <p className="text-xs text-muted-foreground">
+                    Font used in all generated PDF documents — applies to audit schedules, reports, and all IMS exports
                   </p>
                 </div>
 

--- a/src/lib/ims-audit-report-pdf-generator.ts
+++ b/src/lib/ims-audit-report-pdf-generator.ts
@@ -1,24 +1,29 @@
 'use client';
 
-import { PDFReportBuilder, type LogoData } from './pdf-builder';
+import { PDFReportBuilder, type LogoData, type PDFFontFamily } from './pdf-builder';
 
 const COMPANY = 'Hexa Steel®';
 const TAGLINE = 'Integrated Management System — ISO 9001:2015 / ISO 14001:2015 / ISO 45001:2018';
 const FOOTER = 'Hexa Steel® OTS · Confidential IMS Document · hexasteel.sa/ots';
 
-async function loadLogoForPDF(): Promise<LogoData | undefined> {
+async function loadSettingsForPDF(): Promise<{ logo?: LogoData; font: PDFFontFamily }> {
   try {
     const res = await fetch('/api/settings');
-    if (!res.ok) return undefined;
+    if (!res.ok) return { font: 'helvetica' };
     const data = await res.json();
+
+    const font: PDFFontFamily = (['helvetica', 'courier', 'times'] as PDFFontFamily[]).includes(data.pdfFont)
+      ? (data.pdfFont as PDFFontFamily)
+      : 'helvetica';
+
     const whitePath: string | undefined = data.logoWhite;
     const colorPath: string | undefined = data.companyLogo;
     const logoPath = whitePath || colorPath;
-    if (!logoPath) return undefined;
+    if (!logoPath) return { font };
     const isWhite = !!whitePath;
 
     const imgRes = await fetch(logoPath);
-    if (!imgRes.ok) return undefined;
+    if (!imgRes.ok) return { font };
     const blob = await imgRes.blob();
     const base64 = await new Promise<string>((resolve) => {
       const reader = new FileReader();
@@ -33,170 +38,260 @@ async function loadLogoForPDF(): Promise<LogoData | undefined> {
       img.src = base64;
     });
 
-    return { base64, aspectRatio, isWhite };
+    return { logo: { base64, aspectRatio, isWhite }, font };
   } catch {
-    return undefined;
+    return { font: 'helvetica' };
   }
 }
 
 export type InternalAuditReportPDFData = {
+  // Identifiers
   auditNumber: string;
+  planNumber: string;          // Cross-reference to HEXA-FRM-004
+
+  // Audit info
   auditDate: string;
   department: string;
   scope: string;
   auditor: string;
   auditee: string;
   standard: string;
+  processArea: string | null;
+  riskLevel: string | null;
+  isoClausesInScope: string[] | null;
+  auditorIndependenceConfirmed: boolean;
+
+  // FRM-005 report fields
+  reportExecutiveSummary: string | null;
+  reportAuditMethod: string[] | null;
+  reportPositiveFindings: string | null;
+  reportConclusion: string | null;
+  reportRecommendation: string | null;
+
+  // Sign-offs
+  reportLeadAuditorName: string | null;
+  reportLeadAuditorDate: string | null;
+  reportLeadAuditorSigned: boolean;
+  reportImsMgrName: string | null;
+  reportImsMgrDate: string | null;
+  reportImsMgrSigned: boolean;
+
+  // Findings
   findings: {
     findingNumber: string;
     type: string;
     clause: string;
     description: string;
-    evidence?: string | null;
-    correctiveAction?: string | null;
-    targetDate?: string | null;
+    evidence: string | null;
+    correctiveAction: string | null;
+    targetDate: string | null;
     status: string;
   }[];
+
+  // Optional enrichment
   strengths?: string[];
   opportunities?: string[];
-  conclusion?: string;
-  recommendations?: string;
 };
 
 function fmt(d: string | null | undefined): string {
   if (!d) return '—';
-  return new Date(d).toLocaleDateString('en-SA-u-ca-gregory', { 
-    day: '2-digit', 
-    month: 'short', 
-    year: 'numeric' 
+  return new Date(d).toLocaleDateString('en-SA-u-ca-gregory', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
   });
 }
 
-export async function generateInternalAuditReportPDF(data: InternalAuditReportPDFData): Promise<Blob> {
-  const logo = await loadLogoForPDF();
-  const pdf = new PDFReportBuilder('portrait', 'steel');
+function statusLabel(s: string): string {
+  const map: Record<string, string> = {
+    OPEN: 'Open', CLOSED: 'Closed', IN_PROGRESS: 'In Progress',
+    PLANNED: 'Planned', COMPLETED: 'Completed',
+    NC: 'Non-Conformance', OFI: 'OFI', Observation: 'Observation', Conforming: 'Conforming',
+  };
+  return map[s] ?? s.replace(/_/g, ' ');
+}
 
+export async function generateInternalAuditReportPDF(
+  data: InternalAuditReportPDFData
+): Promise<Blob> {
+  const { logo, font } = await loadSettingsForPDF();
+  const pdf = new PDFReportBuilder('portrait', 'steel', font);
+
+  // ── Header ──────────────────────────────────────────────────────────────────
   pdf.addHeader(COMPANY, TAGLINE, logo);
-  
+
   pdf.addTitle(
-    'Internal Audit Report',
-    'HEXA-FRM-005 · Procedure: Hexa-ISP-004 · ISO 9001:2015 §9.2'
+    'HEXA-FRM-005 — Internal Audit Report',
+    `${data.auditNumber} · Ref. Plan: ${data.planNumber} · ISO 9001:2015 §9.2`
   );
 
   pdf.addMetadataBox({
     'Audit No.': data.auditNumber,
-    'Date': fmt(data.auditDate),
-    'Standard': data.standard,
-    'Status': 'Completed',
+    'Plan Ref.': data.planNumber,
+    Date: fmt(data.auditDate),
+    Standard: data.standard,
+    'ISO Ref.': '§9.2',
+    Procedure: 'Hexa-ISP-004',
   });
 
-  pdf.addSectionHeader('Audit Information');
-  pdf.addInfoGrid({
-    'Department/Process': data.department,
-    'Audit Scope': data.scope,
-    'Lead Auditor': data.auditor,
-    'Auditee': data.auditee,
-    'Audit Date': fmt(data.auditDate),
-    'Standard': data.standard,
-  }, 2);
+  // ── Section 1: Audit Information ─────────────────────────────────────────
+  pdf.addSectionHeader('1 — Audit Information (§9.2.2)');
+  pdf.addInfoGrid(
+    {
+      'Department / Process': data.department,
+      'Audit Scope': data.scope,
+      'Lead Auditor': data.auditor,
+      Auditee: data.auditee,
+      'Audit Date': fmt(data.auditDate),
+      Standard: data.standard,
+      'Process Area': data.processArea ?? '—',
+      'Risk Level': data.riskLevel ?? '—',
+      'Auditor Independence': data.auditorIndependenceConfirmed ? 'Confirmed ✓' : 'Not Confirmed',
+      'ISO Clauses in Scope': data.isoClausesInScope?.join(', ') ?? '—',
+    },
+    2
+  );
 
-  // Findings Summary
-  const ncCount = data.findings.filter(f => f.type === 'NC').length;
-  const obsCount = data.findings.filter(f => f.type === 'OBS').length;
-  const oppCount = data.findings.filter(f => f.type === 'OFI').length;
+  // ── Section 2: Audit Method ───────────────────────────────────────────────
+  if (data.reportAuditMethod && data.reportAuditMethod.length > 0) {
+    pdf.addSectionHeader('2 — Audit Method');
+    pdf.addParagraph(data.reportAuditMethod.join(' · '));
+  }
 
-  pdf.addSectionHeader('Findings Summary');
-  pdf.addInfoGrid({
-    'Non-Conformities (NC)': ncCount.toString(),
-    'Observations (OBS)': obsCount.toString(),
-    'Opportunities for Improvement (OFI)': oppCount.toString(),
-    'Total Findings': data.findings.length.toString(),
-  }, 2);
+  // ── Section 3: Executive Summary ─────────────────────────────────────────
+  if (data.reportExecutiveSummary) {
+    pdf.addSectionHeader('3 — Executive Summary');
+    pdf.addParagraph(data.reportExecutiveSummary);
+  }
 
-  // Detailed Findings
+  // ── Section 4: Findings Summary ──────────────────────────────────────────
+  const ncCount  = data.findings.filter(f => f.type === 'NC').length;
+  const obsCount = data.findings.filter(f => f.type === 'Observation').length;
+  const ofiCount = data.findings.filter(f => f.type === 'OFI').length;
+  const confCount = data.findings.filter(f => f.type === 'Conforming').length;
+
+  pdf.addSectionHeader('4 — Findings Summary');
+  pdf.addInfoGrid(
+    {
+      'Non-Conformities (NC)': ncCount,
+      'Observations': obsCount,
+      'Opportunities for Improvement (OFI)': ofiCount,
+      'Conforming': confCount,
+      'Total Findings': data.findings.length,
+      'Open Items': data.findings.filter(f => f.status === 'OPEN' || f.status === 'IN_PROGRESS').length,
+    },
+    3
+  );
+
+  // ── Section 5: Detailed Findings ─────────────────────────────────────────
   if (data.findings.length > 0) {
-    pdf.addSectionHeader('Detailed Findings');
-    
-    const findingsData = data.findings.map(f => [
-      f.findingNumber,
-      f.type,
-      f.clause || '—',
-      f.description,
-      f.status,
-    ]);
+    pdf.addSectionHeader('5 — Detailed Findings Register');
 
     pdf.addTable(
-      ['Finding #', 'Type', 'Clause', 'Description', 'Status'],
-      findingsData,
-      {
-        alternateRows: true,
-      }
+      ['Finding #', 'Type', 'Clause', 'Description', 'Evidence', 'Status'],
+      data.findings.map((f) => [
+        f.findingNumber,
+        f.type,
+        f.clause || '—',
+        f.description.length > 55 ? f.description.slice(0, 52) + '…' : f.description,
+        (f.evidence ?? '—').length > 30 ? (f.evidence ?? '').slice(0, 27) + '…' : (f.evidence ?? '—'),
+        statusLabel(f.status),
+      ]),
+      { alternateRows: true }
     );
 
-    // Corrective Actions
-    const findingsWithCA = data.findings.filter(f => f.correctiveAction);
-    if (findingsWithCA.length > 0) {
-      pdf.addSectionHeader('Corrective Actions');
-      
-      findingsWithCA.forEach(f => {
-        pdf.addParagraph(`**${f.findingNumber}** (${f.type}): ${f.correctiveAction}`, 8);
-        if (f.targetDate) {
-          pdf.addParagraph(`Target Date: ${fmt(f.targetDate)}`, 7);
-        }
-      });
+    // NC / OFI detail blocks
+    const actionRequired = data.findings.filter(f => f.type === 'NC' || f.type === 'OFI');
+    if (actionRequired.length > 0) {
+      pdf.addSectionHeader('5a — Non-Conformities & OFIs — Detail');
+      for (const f of actionRequired) {
+        pdf.addInfoGrid(
+          {
+            'Finding No.': f.findingNumber,
+            Type: f.type,
+            Clause: f.clause || '—',
+            Status: statusLabel(f.status),
+            'Target Date': fmt(f.targetDate),
+          },
+          3
+        );
+        pdf.addLabelValue('Description', f.description);
+        if (f.evidence) pdf.addLabelValue('Evidence', f.evidence);
+        if (f.correctiveAction) pdf.addLabelValue('Corrective Action', f.correctiveAction);
+        pdf.addDivider();
+      }
     }
   } else {
-    pdf.addParagraph('No findings identified during this audit. All processes were found to be in conformance with the applicable standards and procedures.');
+    pdf.addSectionHeader('5 — Findings');
+    pdf.addParagraph(
+      'No findings were identified during this audit. All processes were found to be in ' +
+      'conformance with the applicable standards, procedures, and planned arrangements.'
+    );
   }
 
-  // Strengths
-  if (data.strengths && data.strengths.length > 0) {
-    pdf.addSectionHeader('Strengths Identified');
-    data.strengths.forEach(strength => {
-      pdf.addParagraph(`• ${strength}`, 9);
-    });
+  // ── Section 6: Positive Findings / Strengths ─────────────────────────────
+  const hasPositive = data.reportPositiveFindings || (data.strengths && data.strengths.length > 0);
+  if (hasPositive) {
+    pdf.addSectionHeader('6 — Positive Findings & Strengths');
+    if (data.reportPositiveFindings) pdf.addParagraph(data.reportPositiveFindings);
+    if (data.strengths) data.strengths.forEach(s => pdf.addParagraph(`• ${s}`));
   }
 
-  // Opportunities
+  // ── Section 7: Opportunities for Improvement ─────────────────────────────
   if (data.opportunities && data.opportunities.length > 0) {
-    pdf.addSectionHeader('Opportunities for Improvement');
-    data.opportunities.forEach(opp => {
-      pdf.addParagraph(`• ${opp}`, 9);
-    });
+    pdf.addSectionHeader('7 — Opportunities for Improvement');
+    data.opportunities.forEach(o => pdf.addParagraph(`• ${o}`));
   }
 
-  // Conclusion
-  pdf.addSectionHeader('Audit Conclusion');
-  if (data.conclusion) {
-    pdf.addParagraph(data.conclusion);
+  // ── Section 8: Audit Conclusion ──────────────────────────────────────────
+  pdf.addSectionHeader('8 — Audit Conclusion (§9.2.2 f)');
+  if (data.reportConclusion) {
+    pdf.addParagraph(data.reportConclusion);
   } else {
-    const defaultConclusion = ncCount === 0 
-      ? 'The audit confirmed that the audited processes are effectively implemented and maintained in accordance with the applicable standards. The management system demonstrates conformity and effectiveness.'
-      : `The audit identified ${ncCount} non-conformity(ies) that require corrective action. The auditee is required to submit corrective action plans within 10 working days. Follow-up audit will be conducted to verify implementation.`;
+    const defaultConclusion = ncCount === 0
+      ? 'The audit confirmed that the audited processes are effectively implemented and ' +
+        'maintained in accordance with the applicable management system standards. ' +
+        'The system demonstrates conformity and effectiveness.'
+      : `The audit identified ${ncCount} non-conformity(ies) and ${ofiCount} opportunity(ies) for improvement. ` +
+        'The auditee is required to submit a corrective action plan within 10 working days of receiving this report. ' +
+        'A follow-up audit will be conducted to verify effective implementation and closure.';
     pdf.addParagraph(defaultConclusion);
   }
 
-  // Recommendations
-  if (data.recommendations) {
-    pdf.addSectionHeader('Recommendations');
-    pdf.addParagraph(data.recommendations);
+  // ── Section 9: Recommendations ───────────────────────────────────────────
+  if (data.reportRecommendation) {
+    pdf.addSectionHeader('9 — Recommendations');
+    pdf.addParagraph(data.reportRecommendation);
   }
 
-  // Compliance Statement
-  pdf.addSectionHeader('ISO 9001:2015 Compliance');
+  // ── Section 10: ISO Compliance Statement ─────────────────────────────────
+  pdf.addSectionHeader('10 — ISO 9001:2015 §9.2 Compliance Statement');
   pdf.addParagraph(
-    'This internal audit was conducted in accordance with ISO 9001:2015 clause 9.2 requirements. ' +
-    'The audit program ensures that all processes are audited at planned intervals, taking into account ' +
-    'the importance of the processes concerned, changes affecting the organization, and the results of previous audits.'
+    'This internal audit was conducted in accordance with the documented audit programme ' +
+    '(HEXA-FRM-004) and Procedure Hexa-ISP-004. The audit programme considers the importance ' +
+    'of the processes concerned, changes affecting the organization, and the results of ' +
+    'previous audits. Audit results have been communicated to relevant management.'
   );
 
+  // ── Signatures ───────────────────────────────────────────────────────────
   pdf.addSignatureSection([
-    { label: 'Lead Auditor', name: data.auditor, date: fmt(data.auditDate) },
-    { label: 'Auditee', name: data.auditee },
-    { label: 'Management Representative', name: 'IMS Manager' },
+    {
+      label: `Lead Auditor${data.reportLeadAuditorSigned ? ' ✓ Signed' : ''}`,
+      name: data.reportLeadAuditorName || data.auditor || undefined,
+      date: data.reportLeadAuditorDate ? fmt(data.reportLeadAuditorDate) : fmt(data.auditDate),
+    },
+    {
+      label: 'Auditee / Process Owner',
+      name: data.auditee || undefined,
+    },
+    {
+      label: `IMS Manager${data.reportImsMgrSigned ? ' ✓ Signed' : ''}`,
+      name: data.reportImsMgrName || undefined,
+      date: data.reportImsMgrDate ? fmt(data.reportImsMgrDate) : '',
+    },
   ]);
 
-  pdf.addFooter(FOOTER, 'HEXA-FRM-005 · Hexa-ISP-004 · ISO §9.2');
+  pdf.addFooter(FOOTER, 'HEXA-FRM-005 · Hexa-ISP-004 · ISO 9001:2015 §9.2');
 
   return pdf.getBlob();
 }

--- a/src/lib/ims-audit-schedule-pdf-generator.ts
+++ b/src/lib/ims-audit-schedule-pdf-generator.ts
@@ -1,0 +1,218 @@
+'use client';
+
+import { PDFReportBuilder, type LogoData, type PDFFontFamily } from './pdf-builder';
+
+const COMPANY = 'Hexa Steel®';
+const TAGLINE = 'Integrated Management System — ISO 9001:2015 / ISO 14001:2015 / ISO 45001:2018';
+const FOOTER = 'Hexa Steel® OTS · Confidential IMS Document · hexasteel.sa/ots';
+
+async function loadSettingsForPDF(): Promise<{ logo?: LogoData; font: PDFFontFamily }> {
+  try {
+    const res = await fetch('/api/settings');
+    if (!res.ok) return { font: 'helvetica' };
+    const data = await res.json();
+
+    const font: PDFFontFamily = (['helvetica', 'courier', 'times'] as PDFFontFamily[]).includes(data.pdfFont)
+      ? (data.pdfFont as PDFFontFamily)
+      : 'helvetica';
+
+    const whitePath: string | undefined = data.logoWhite;
+    const colorPath: string | undefined = data.companyLogo;
+    const logoPath = whitePath || colorPath;
+    if (!logoPath) return { font };
+    const isWhite = !!whitePath;
+
+    const imgRes = await fetch(logoPath);
+    if (!imgRes.ok) return { font };
+    const blob = await imgRes.blob();
+    const base64 = await new Promise<string>((resolve) => {
+      const reader = new FileReader();
+      reader.onloadend = () => resolve(reader.result as string);
+      reader.readAsDataURL(blob);
+    });
+
+    const aspectRatio = await new Promise<number>((resolve) => {
+      const img = new Image();
+      img.onload = () => resolve(img.naturalWidth / img.naturalHeight || 1);
+      img.onerror = () => resolve(1);
+      img.src = base64;
+    });
+
+    return { logo: { base64, aspectRatio, isWhite }, font };
+  } catch {
+    return { font: 'helvetica' };
+  }
+}
+
+export type AuditScheduleAudit = {
+  auditNumber: string;
+  scope: string;
+  processArea: string | null;
+  riskLevel: string | null;
+  isoClausesInScope: string[] | null;
+  scheduledDate: string;
+  actualDate: string | null;
+  auditor: string | null;
+  auditee: string | null;
+  status: string;
+  // FRM-004 approval fields
+  auditorIndependenceConfirmed: boolean;
+  approvedByImsManagerName: string | null;
+  approvedByImsManagerDate: string | null;
+  approvedByImsManagerSigned: boolean;
+  approvedByTopMgmtName: string | null;
+  approvedByTopMgmtDate: string | null;
+  approvedByTopMgmtSigned: boolean;
+  findingsCount: number;
+};
+
+export type AuditSchedulePDFData = {
+  planNumber: string;
+  year: number;
+  auditType: string;
+  status: string;
+  audits: AuditScheduleAudit[];
+};
+
+function fmt(d: string | null | undefined): string {
+  if (!d) return '—';
+  return new Date(d).toLocaleDateString('en-SA-u-ca-gregory', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+function statusLabel(s: string): string {
+  const map: Record<string, string> = {
+    OPEN: 'Open', CLOSED: 'Closed', IN_PROGRESS: 'In Progress',
+    PLANNED: 'Planned', COMPLETED: 'Completed', SCHEDULED: 'Scheduled',
+    DRAFT: 'Draft', APPROVED: 'Approved',
+  };
+  return map[s] ?? s.replace(/_/g, ' ');
+}
+
+function riskColor(level: string | null): string {
+  if (!level) return '';
+  if (level === 'High') return 'High';
+  if (level === 'Medium') return 'Medium';
+  return 'Low';
+}
+
+export async function generateAuditSchedulePDF(data: AuditSchedulePDFData): Promise<void> {
+  const { logo, font } = await loadSettingsForPDF();
+  const pdf = new PDFReportBuilder('landscape', 'steel', font);
+
+  // ── Header ──────────────────────────────────────────────────────────────────
+  pdf.addHeader(COMPANY, TAGLINE, logo);
+
+  pdf.addTitle(
+    'HEXA-FRM-004 — Internal Audit Schedule',
+    `${data.planNumber} · ${data.auditType} Audit Programme · ${data.year}`
+  );
+
+  pdf.addMetadataBox({
+    'Plan No.': data.planNumber,
+    Year: String(data.year),
+    Type: data.auditType,
+    Status: statusLabel(data.status),
+    'Total Audits': String(data.audits.length),
+    Issued: fmt(new Date().toISOString()),
+    'ISO Ref.': '§9.2',
+    Procedure: 'Hexa-ISP-004',
+  });
+
+  // ── Programme Overview ────────────────────────────────────────────────────
+  pdf.addSectionHeader('§9.2.1 — Annual Audit Programme');
+
+  if (data.audits.length === 0) {
+    pdf.addParagraph('No audits have been scheduled under this plan yet.');
+  } else {
+    pdf.addTable(
+      [
+        'Audit No.',
+        'Process / Scope',
+        'Area',
+        'Risk',
+        'ISO Clauses',
+        'Scheduled Date',
+        'Actual Date',
+        'Auditor',
+        'Auditee',
+        'Status',
+        'Findings',
+      ],
+      data.audits.map((a) => [
+        a.auditNumber,
+        a.scope.length > 30 ? a.scope.slice(0, 27) + '…' : a.scope,
+        a.processArea ?? '—',
+        riskColor(a.riskLevel),
+        a.isoClausesInScope?.join(', ') ?? '—',
+        fmt(a.scheduledDate),
+        fmt(a.actualDate),
+        a.auditor ?? '—',
+        a.auditee ?? '—',
+        statusLabel(a.status),
+        String(a.findingsCount),
+      ]),
+      { alternateRows: true }
+    );
+  }
+
+  // ── Status Summary ────────────────────────────────────────────────────────
+  const planned = data.audits.filter(a => a.status === 'PLANNED' || a.status === 'SCHEDULED').length;
+  const inProg  = data.audits.filter(a => a.status === 'IN_PROGRESS').length;
+  const done    = data.audits.filter(a => a.status === 'COMPLETED').length;
+  const highRisk = data.audits.filter(a => a.riskLevel === 'High').length;
+
+  pdf.addSectionHeader('Programme Summary');
+  pdf.addInfoGrid(
+    {
+      'Total Audits': data.audits.length,
+      'Planned / Scheduled': planned,
+      'In Progress': inProg,
+      Completed: done,
+      'High Risk Audits': highRisk,
+      'Independence Confirmed': data.audits.filter(a => a.auditorIndependenceConfirmed).length,
+    },
+    3
+  );
+
+  // ── ISO Clause Coverage ───────────────────────────────────────────────────
+  const allClauses = data.audits.flatMap(a => a.isoClausesInScope ?? []);
+  const uniqueClauses = [...new Set(allClauses)].sort();
+  if (uniqueClauses.length > 0) {
+    pdf.addSectionHeader('ISO Clause Coverage');
+    pdf.addParagraph(`Clauses covered in this programme: ${uniqueClauses.join(' · ')}`);
+  }
+
+  // ── Approval Section ──────────────────────────────────────────────────────
+  pdf.addSectionHeader('HEXA-FRM-004 — Schedule Approvals');
+
+  // Use the most recent audit's approval data if available
+  const lastApproved = [...data.audits]
+    .reverse()
+    .find(a => a.approvedByImsManagerSigned || a.approvedByTopMgmtSigned);
+
+  const imsMgrName = lastApproved?.approvedByImsManagerName ?? '';
+  const imsMgrDate = lastApproved?.approvedByImsManagerDate;
+  const topMgmtName = lastApproved?.approvedByTopMgmtName ?? '';
+  const topMgmtDate = lastApproved?.approvedByTopMgmtDate;
+
+  pdf.addSignatureSection([
+    { label: 'Prepared By (Lead Auditor)', date: fmt(new Date().toISOString()) },
+    {
+      label: `IMS Manager${imsMgrName ? ' ✓' : ''}`,
+      name: imsMgrName || undefined,
+      date: imsMgrDate ? fmt(imsMgrDate) : '',
+    },
+    {
+      label: `Top Management${topMgmtName ? ' ✓' : ''}`,
+      name: topMgmtName || undefined,
+      date: topMgmtDate ? fmt(topMgmtDate) : '',
+    },
+  ]);
+
+  pdf.addFooter(FOOTER, 'HEXA-FRM-004 · Procedure: Hexa-ISP-004 · ISO 9001:2015 §9.2');
+  pdf.save(`${data.planNumber}-FRM-004-Audit-Schedule.pdf`);
+}

--- a/src/lib/ims-pdf-generator.ts
+++ b/src/lib/ims-pdf-generator.ts
@@ -1,24 +1,29 @@
 'use client';
 
-import { PDFReportBuilder, type LogoData } from './pdf-builder';
+import { PDFReportBuilder, type LogoData, type PDFFontFamily } from './pdf-builder';
 
 const COMPANY = 'Hexa Steel®';
 const TAGLINE = 'Integrated Management System — ISO 9001:2015 / ISO 14001:2015 / ISO 45001:2018';
 const FOOTER = 'Hexa Steel® OTS · Confidential IMS Document · hexasteel.sa/ots';
 
-async function loadLogoForPDF(): Promise<LogoData | undefined> {
+async function loadSettingsForPDF(): Promise<{ logo?: LogoData; font: PDFFontFamily }> {
   try {
     const res = await fetch('/api/settings');
-    if (!res.ok) return undefined;
+    if (!res.ok) return { font: 'helvetica' };
     const data = await res.json();
+
+    const font: PDFFontFamily = (['helvetica', 'courier', 'times'] as PDFFontFamily[]).includes(data.pdfFont)
+      ? (data.pdfFont as PDFFontFamily)
+      : 'helvetica';
+
     const whitePath: string | undefined = data.logoWhite;
     const colorPath: string | undefined = data.companyLogo;
     const logoPath = whitePath || colorPath;
-    if (!logoPath) return undefined;
+    if (!logoPath) return { font };
     const isWhite = !!whitePath;
 
     const imgRes = await fetch(logoPath);
-    if (!imgRes.ok) return undefined;
+    if (!imgRes.ok) return { font };
     const blob = await imgRes.blob();
     const base64 = await new Promise<string>((resolve) => {
       const reader = new FileReader();
@@ -33,9 +38,9 @@ async function loadLogoForPDF(): Promise<LogoData | undefined> {
       img.src = base64;
     });
 
-    return { base64, aspectRatio, isWhite };
+    return { logo: { base64, aspectRatio, isWhite }, font };
   } catch {
-    return undefined;
+    return { font: 'helvetica' };
   }
 }
 
@@ -241,12 +246,12 @@ function statusDot(s: string): string {
 }
 
 export async function generateAuditPlanPDF(data: AuditPlanPDFData): Promise<void> {
-  const logo = await loadLogoForPDF();
-  const pdf = new PDFReportBuilder('portrait', 'steel');
+  const { logo, font } = await loadSettingsForPDF();
+  const pdf = new PDFReportBuilder('portrait', 'steel', font);
 
   pdf.addHeader(COMPANY, TAGLINE, logo);
   pdf.addTitle(
-    `HEXA-FRM-006/007 — Internal Audit Plan`,
+    `HEXA-FRM-004 — Internal Audit Schedule`,
     `${data.planNumber} · ${data.auditType} · ${data.year}`
   );
   pdf.addMetadataBox({
@@ -283,7 +288,7 @@ export async function generateAuditPlanPDF(data: AuditPlanPDFData): Promise<void
   );
 
   if (allFindings.length > 0) {
-    pdf.addSectionHeader('HEXA-FRM-008 — Audit Findings / NCR Register');
+    pdf.addSectionHeader('Audit Findings Register');
     pdf.addTable(
       ['Finding No.', 'Audit', 'Type', 'Clause', 'Description', 'Status', 'Target Date'],
       allFindings.map((f) => [
@@ -300,7 +305,7 @@ export async function generateAuditPlanPDF(data: AuditPlanPDFData): Promise<void
 
     const ncrs = allFindings.filter((f) => f.type === 'NC');
     if (ncrs.length > 0) {
-      pdf.addSectionHeader('Non-Conformance Details (HEXA-FRM-008)');
+      pdf.addSectionHeader('Non-Conformance Details');
       for (const f of ncrs) {
         pdf.addInfoGrid({
           'Finding No.': f.findingNumber,
@@ -323,13 +328,13 @@ export async function generateAuditPlanPDF(data: AuditPlanPDFData): Promise<void
     { label: 'Top Management', date: '' },
   ]);
 
-  pdf.addFooter(FOOTER, 'HEXA-FRM-006 · HEXA-FRM-007 · HEXA-FRM-009 · Procedure: Hexa-ISP-002');
-  pdf.save(`${data.planNumber}-Audit-Plan.pdf`);
+  pdf.addFooter(FOOTER, 'HEXA-FRM-004 · Procedure: Hexa-ISP-004 · ISO 9001:2015 §9.2');
+  pdf.save(`${data.planNumber}-FRM-004-Audit-Schedule.pdf`);
 }
 
 export async function generateManagementReviewMOMPDF(data: ManagementReviewPDFData): Promise<void> {
-  const logo = await loadLogoForPDF();
-  const pdf = new PDFReportBuilder('portrait', 'steel');
+  const { logo, font } = await loadSettingsForPDF();
+  const pdf = new PDFReportBuilder('portrait', 'steel', font);
 
   pdf.addHeader(COMPANY, TAGLINE, logo);
   pdf.addTitle(
@@ -422,8 +427,8 @@ export async function generateManagementReviewMOMPDF(data: ManagementReviewPDFDa
 }
 
 export async function generateManagementReviewReportPDF(data: ManagementReviewPDFData): Promise<void> {
-  const logo = await loadLogoForPDF();
-  const pdf = new PDFReportBuilder('portrait', 'steel');
+  const { logo, font } = await loadSettingsForPDF();
+  const pdf = new PDFReportBuilder('portrait', 'steel', font);
 
   pdf.addHeader(COMPANY, TAGLINE, logo);
   pdf.addTitle(
@@ -531,8 +536,8 @@ export async function generateManagementReviewReportPDF(data: ManagementReviewPD
 }
 
 export async function generateProcessesPDF(processes: ProcessPDFData[]): Promise<void> {
-  const logo = await loadLogoForPDF();
-  const pdf = new PDFReportBuilder('landscape', 'steel');
+  const { logo, font } = await loadSettingsForPDF();
+  const pdf = new PDFReportBuilder('landscape', 'steel', font);
 
   pdf.addHeader(COMPANY, TAGLINE, logo);
   pdf.addTitle(
@@ -581,8 +586,8 @@ export async function generateProcessesPDF(processes: ProcessPDFData[]): Promise
 }
 
 export async function generateObjectivesPDF(objectives: ObjectivePDFData[], year: number): Promise<void> {
-  const logo = await loadLogoForPDF();
-  const pdf = new PDFReportBuilder('portrait', 'steel');
+  const { logo, font } = await loadSettingsForPDF();
+  const pdf = new PDFReportBuilder('portrait', 'steel', font);
 
   pdf.addHeader(COMPANY, TAGLINE, logo);
   pdf.addTitle(
@@ -678,8 +683,8 @@ export type ProductNCRPDFData = {
 };
 
 export async function generateProductNCRPDF(data: ProductNCRPDFData): Promise<void> {
-  const logo = await loadLogoForPDF();
-  const pdf = new PDFReportBuilder('portrait', 'red');
+  const { logo, font } = await loadSettingsForPDF();
+  const pdf = new PDFReportBuilder('portrait', 'red', font);
 
   pdf.addHeader(COMPANY, TAGLINE, logo);
   pdf.addTitle(
@@ -781,8 +786,8 @@ export type RiskRegisterPDFRisk = {
 };
 
 export async function generateRiskRegisterPDF(risks: RiskRegisterPDFRisk[]): Promise<void> {
-  const logo = await loadLogoForPDF();
-  const pdf = new PDFReportBuilder('landscape', 'red');
+  const { logo, font } = await loadSettingsForPDF();
+  const pdf = new PDFReportBuilder('landscape', 'red', font);
 
   pdf.addHeader(COMPANY, TAGLINE, logo);
   pdf.addTitle(

--- a/src/lib/pdf-builder.ts
+++ b/src/lib/pdf-builder.ts
@@ -67,9 +67,18 @@ export type LogoData = {
   isWhite: boolean;
 };
 
+export type PDFFontFamily = 'helvetica' | 'courier' | 'times';
+
+export const PDF_FONT_LABELS: Record<PDFFontFamily, string> = {
+  helvetica: 'Helvetica',
+  courier: 'Courier',
+  times: 'Times New Roman',
+};
+
 export class PDFReportBuilder {
   private doc: jsPDF;
   private theme: ReportTheme;
+  private font: PDFFontFamily;
   private currentY: number = 20;
   private pageWidth: number;
   private pageHeight: number;
@@ -77,14 +86,16 @@ export class PDFReportBuilder {
 
   constructor(
     orientation: 'portrait' | 'landscape' = 'portrait',
-    themeName: keyof typeof themes = 'blue'
+    themeName: keyof typeof themes = 'blue',
+    fontFamily: PDFFontFamily = 'helvetica'
   ) {
     this.doc = new jsPDF({
       orientation,
       unit: 'mm',
       format: 'a4',
     });
-    this.doc.setFont('helvetica', 'normal');
+    this.font = fontFamily;
+    this.doc.setFont(this.font, 'normal');
     this.theme = themes[themeName];
     this.pageWidth = this.doc.internal.pageSize.getWidth();
     this.pageHeight = this.doc.internal.pageSize.getHeight();
@@ -122,28 +133,28 @@ export class PDFReportBuilder {
 
     this.doc.setTextColor(this.theme.headerText);
     this.doc.setFontSize(15);
-    this.doc.setFont('helvetica', 'bold');
+    this.doc.setFont(this.font, 'bold');
     this.doc.text(companyName, textOffsetX, 13);
 
     this.doc.setFontSize(7.5);
-    this.doc.setFont('helvetica', 'normal');
+    this.doc.setFont(this.font, 'normal');
     this.doc.text(companyTagline, textOffsetX, 20);
 
     this.currentY = headerHeight + 5;
     this.doc.setTextColor(this.theme.textColor);
-    this.doc.setFont('helvetica', 'normal');
+    this.doc.setFont(this.font, 'normal');
   }
 
   addTitle(title: string, subtitle?: string): void {
     this.doc.setFontSize(17);
-    this.doc.setFont('helvetica', 'bold');
+    this.doc.setFont(this.font, 'bold');
     this.doc.setTextColor(this.theme.primaryColor);
     this.doc.text(title, this.pageWidth / 2, this.currentY, { align: 'center' });
     this.currentY += 8;
 
     if (subtitle) {
       this.doc.setFontSize(9.5);
-      this.doc.setFont('helvetica', 'italic');
+      this.doc.setFont(this.font, 'italic');
       this.doc.setTextColor(80, 80, 80);
       this.doc.text(subtitle, this.pageWidth / 2, this.currentY, { align: 'center' });
       this.currentY += 6;
@@ -151,7 +162,7 @@ export class PDFReportBuilder {
 
     this.currentY += 4;
     this.doc.setTextColor(this.theme.textColor);
-    this.doc.setFont('helvetica', 'normal');
+    this.doc.setFont(this.font, 'normal');
   }
 
   addMetadataBox(metadata: Record<string, string>): void {
@@ -170,10 +181,10 @@ export class PDFReportBuilder {
     let metaY = this.currentY + 5;
 
     Object.entries(metadata).forEach(([key, value]) => {
-      this.doc.setFont('helvetica', 'bold');
+      this.doc.setFont(this.font, 'bold');
       this.doc.setTextColor(60, 60, 60);
       this.doc.text(`${key}:`, boxX + 2, metaY);
-      this.doc.setFont('helvetica', 'normal');
+      this.doc.setFont(this.font, 'normal');
       this.doc.setTextColor(this.theme.textColor);
       this.doc.text(value, boxX + 22, metaY);
       metaY += lineHeight;
@@ -190,12 +201,12 @@ export class PDFReportBuilder {
 
     this.doc.setTextColor(this.theme.headerText);
     this.doc.setFontSize(10);
-    this.doc.setFont('helvetica', 'bold');
+    this.doc.setFont(this.font, 'bold');
     this.doc.text(title, this.margin + 3, this.currentY + 5);
 
     this.currentY += 10;
     this.doc.setTextColor(this.theme.textColor);
-    this.doc.setFont('helvetica', 'normal');
+    this.doc.setFont(this.font, 'normal');
   }
 
   addInfoGrid(data: Record<string, string | number>, columns: number = 2): void {
@@ -212,11 +223,11 @@ export class PDFReportBuilder {
       const y = this.currentY + row * lineHeight;
 
       this.doc.setFontSize(8);
-      this.doc.setFont('helvetica', 'bold');
+      this.doc.setFont(this.font, 'bold');
       this.doc.setTextColor(80, 80, 80);
       this.doc.text(`${key}:`, x, y);
 
-      this.doc.setFont('helvetica', 'normal');
+      this.doc.setFont(this.font, 'normal');
       this.doc.setTextColor(this.theme.textColor);
       this.doc.text(String(value), x + 35, y);
 
@@ -251,13 +262,13 @@ export class PDFReportBuilder {
         fillColor: options?.headerBg || this.theme.primaryColor,
         textColor: options?.headerText || this.theme.headerText,
         fontStyle: 'bold',
-        font: 'helvetica',
+        font: this.font,
         fontSize: 8.5,
       },
       bodyStyles: {
         fontSize: 8,
         textColor: this.theme.textColor,
-        font: 'times',
+        font: this.font,
       },
       alternateRowStyles: options?.alternateRows ? { fillColor: [248, 249, 250] } : undefined,
     });
@@ -269,12 +280,33 @@ export class PDFReportBuilder {
     this.checkPageBreak(20);
 
     this.doc.setFontSize(fontSize);
-    this.doc.setFont('helvetica', 'normal');
+    this.doc.setFont(this.font, 'normal');
     this.doc.setTextColor(this.theme.textColor);
 
     const lines = this.doc.splitTextToSize(text, this.pageWidth - 2 * this.margin);
     this.doc.text(lines, this.margin, this.currentY);
     this.currentY += lines.length * (fontSize * 0.42) + 4;
+  }
+
+  addDivider(): void {
+    this.checkPageBreak(8);
+    this.doc.setDrawColor(220, 220, 220);
+    this.doc.setLineWidth(0.3);
+    this.doc.line(this.margin, this.currentY, this.pageWidth - this.margin, this.currentY);
+    this.currentY += 5;
+  }
+
+  addLabelValue(label: string, value: string, fontSize: number = 9): void {
+    this.checkPageBreak(8);
+    this.doc.setFontSize(fontSize);
+    this.doc.setFont(this.font, 'bold');
+    this.doc.setTextColor(80, 80, 80);
+    this.doc.text(`${label}:`, this.margin, this.currentY);
+    this.doc.setFont(this.font, 'normal');
+    this.doc.setTextColor(this.theme.textColor);
+    const lines = this.doc.splitTextToSize(value || '—', this.pageWidth - this.margin - 40);
+    this.doc.text(lines, this.margin + 38, this.currentY);
+    this.currentY += Math.max(lines.length * (fontSize * 0.42), 5) + 3;
   }
 
   addSignatureSection(
@@ -288,7 +320,7 @@ export class PDFReportBuilder {
       const x = this.margin + index * sigWidth;
 
       this.doc.setFontSize(8);
-      this.doc.setFont('helvetica', 'bold');
+      this.doc.setFont(this.font, 'bold');
       this.doc.setTextColor(this.theme.textColor);
       this.doc.text(sig.label, x, this.currentY);
 
@@ -297,14 +329,14 @@ export class PDFReportBuilder {
       this.doc.line(x, this.currentY + 16, x + sigWidth - 8, this.currentY + 16);
 
       if (sig.name) {
-        this.doc.setFont('helvetica', 'normal');
+        this.doc.setFont(this.font, 'normal');
         this.doc.setFontSize(7.5);
         this.doc.setTextColor(80, 80, 80);
         this.doc.text(sig.name, x, this.currentY + 20);
       }
 
       if (sig.date) {
-        this.doc.setFont('helvetica', 'normal');
+        this.doc.setFont(this.font, 'normal');
         this.doc.setFontSize(7.5);
         this.doc.setTextColor(120, 120, 120);
         this.doc.text(sig.date, x, this.currentY + 24);
@@ -314,7 +346,7 @@ export class PDFReportBuilder {
     this.currentY += 32;
   }
 
-  // formRef: e.g. "HEXA-FRM-011 · HEXA-FRM-012 · Procedure: Hexa-ISP-003"
+  // formRef: e.g. "HEXA-FRM-004 · Procedure: Hexa-ISP-004"
   addFooter(text: string, formRef?: string): void {
     const pageCount = this.doc.getNumberOfPages();
 
@@ -326,7 +358,7 @@ export class PDFReportBuilder {
       this.doc.setLineWidth(0.3);
       this.doc.line(this.margin, this.pageHeight - 16, this.pageWidth - this.margin, this.pageHeight - 16);
 
-      this.doc.setFont('helvetica', 'normal');
+      this.doc.setFont(this.font, 'normal');
       this.doc.setFontSize(6.5);
       this.doc.setTextColor(140, 140, 140);
 


### PR DESCRIPTION
- Create dedicated HEXA-FRM-004 Audit Schedule PDF generator
  (ims-audit-schedule-pdf-generator.ts) — landscape, programme table
  with risk, ISO clauses, independence flag, and approval sign-offs
- Rewrite HEXA-FRM-005 Internal Audit Report PDF generator with full
  FRM-005 fields: executive summary, audit method, findings detail
  blocks, positive findings, conclusion, recommendations, and
  cross-reference back to the parent FRM-004 plan number
- Fix wrong form numbers in ims-pdf-generator.ts (was HEXA-FRM-006/007,
  now correctly HEXA-FRM-004 per the approved form register)
- Add configurable PDF font to PDFReportBuilder (helvetica default,
  courier, times) — applied uniformly across all PDF generators
- Add pdfFont field to SystemSettings schema + migration v24_4
- Expose pdfFont in settings API (GET safe select + PATCH schema)
- Add font selector to Settings → Reports tab
- Update audit-plans list page: FRM-004 Schedule download per plan
- Update audit-plan detail page: FRM-004 Schedule + per-audit
  FRM-005 Report download buttons (in findings card and report card)

https://claude.ai/code/session_019RgZhstsvQJxsLeGzp9LUq