### PR TITLE
fix(supply-chain): enforce admin/CEO-only CRUD on subcontractors and fix supplier detail 404

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -62,7 +62,11 @@ export function middleware(req: NextRequest) {
                           pathname.startsWith('/business-planning') ||
                           pathname.startsWith('/changelog') ||
                           pathname.startsWith('/initiatives') ||
-                          pathname.startsWith('/rfis');
+                          pathname.startsWith('/rfis') ||
+                          pathname.startsWith('/supply-chain') ||
+                          pathname.startsWith('/hr') ||
+                          pathname.startsWith('/workflow') ||
+                          pathname.startsWith('/financial');
   const isProtectedApi = pathname.startsWith('/api') && !pathname.startsWith('/api/auth');
 
   if (isProtectedPage || isProtectedApi) {

--- a/prisma/manual_migrations/v24_5_fin_supplier_coa_default.sql
+++ b/prisma/manual_migrations/v24_5_fin_supplier_coa_default.sql
@@ -1,0 +1,30 @@
+-- Ensure fin_supplier_coa_default exists for supplier portal COA mapping.
+-- This table is referenced by getSupplierOverview but was previously created
+-- lazily via the financial API route, causing "Supplier not found" errors when
+-- the financial route had never been called.
+
+DROP PROCEDURE IF EXISTS ensure_fin_supplier_coa_default;
+
+CREATE PROCEDURE ensure_fin_supplier_coa_default()
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'fin_supplier_coa_default'
+    ) THEN
+        CREATE TABLE fin_supplier_coa_default (
+            id                   INT AUTO_INCREMENT PRIMARY KEY,
+            supplier_dolibarr_id INT          NOT NULL COMMENT 'FK to dolibarr_thirdparties.dolibarr_id',
+            coa_account_code     VARCHAR(20)  NOT NULL COMMENT 'FK to fin_chart_of_accounts.account_code',
+            notes                TEXT         NULL,
+            created_at           TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at           TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            created_by           INT          NULL,
+            UNIQUE KEY uk_supplier_coa (supplier_dolibarr_id),
+            INDEX idx_coa_account (coa_account_code)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+    END IF;
+END;
+
+CALL ensure_fin_supplier_coa_default();
+DROP PROCEDURE IF EXISTS ensure_fin_supplier_coa_default;

--- a/src/app/api/subcontractor-contracts/[id]/payment-certificates/[certId]/route.ts
+++ b/src/app/api/subcontractor-contracts/[id]/payment-certificates/[certId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { withApiContext } from '@/lib/api-utils';
+import { checkPermission } from '@/lib/permission-checker';
 import prisma from '@/lib/db';
 import { logger } from '@/lib/logger';
 
@@ -29,6 +30,7 @@ const CERT_ACTION_TO_STATUS: Record<string, string> = {
 
 export const GET = withApiContext(async (_req: NextRequest, session, context) => {
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  if (!(await checkPermission('subcontractors.certs.view'))) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   const certId = context?.params.certId;
   if (!certId) return NextResponse.json({ error: 'Missing cert id' }, { status: 400 });
 
@@ -63,6 +65,10 @@ export const PATCH = withApiContext(async (req: NextRequest, session, context) =
   if (!parsed.success) return NextResponse.json({ error: 'Validation error', details: parsed.error.flatten() }, { status: 422 });
 
   const { action, paidAmount, dolibarrInvoiceRef, dolibarrInvoiceId, notes } = parsed.data;
+
+  const requiredPerm = (action === 'approve' || action === 'reject') ? 'subcontractors.certs.approve' : 'subcontractors.certs.create';
+  if (!(await checkPermission(requiredPerm))) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
   const newStatus = CERT_ACTION_TO_STATUS[action];
 
   try {

--- a/src/app/api/subcontractor-contracts/[id]/payment-certificates/route.ts
+++ b/src/app/api/subcontractor-contracts/[id]/payment-certificates/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { withApiContext } from '@/lib/api-utils';
+import { checkPermission } from '@/lib/permission-checker';
 import prisma from '@/lib/db';
 import { logger } from '@/lib/logger';
 import {
@@ -21,6 +22,7 @@ const createCertSchema = z.object({
 
 export const GET = withApiContext(async (_req: NextRequest, session, context) => {
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  if (!(await checkPermission('subcontractors.certs.view'))) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   const contractId = context?.params.id;
   if (!contractId) return NextResponse.json({ error: 'Missing contract id' }, { status: 400 });
 
@@ -42,6 +44,7 @@ export const GET = withApiContext(async (_req: NextRequest, session, context) =>
 
 export const POST = withApiContext(async (req: NextRequest, session, context) => {
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  if (!(await checkPermission('subcontractors.certs.create'))) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   const contractId = context?.params.id;
   if (!contractId) return NextResponse.json({ error: 'Missing contract id' }, { status: 400 });
 

--- a/src/app/api/subcontractor-contracts/[id]/route.ts
+++ b/src/app/api/subcontractor-contracts/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { withApiContext } from '@/lib/api-utils';
+import { checkPermission } from '@/lib/permission-checker';
 import prisma from '@/lib/db';
 import { logger } from '@/lib/logger';
 
@@ -17,6 +18,7 @@ const updateSchema = z.object({
 
 export const GET = withApiContext(async (_req: NextRequest, session, context) => {
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  if (!(await checkPermission('subcontractors.view'))) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   const id = context?.params.id;
   if (!id) return NextResponse.json({ error: 'Missing id' }, { status: 400 });
 
@@ -50,6 +52,7 @@ export const GET = withApiContext(async (_req: NextRequest, session, context) =>
 
 export const PATCH = withApiContext(async (req: NextRequest, session, context) => {
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  if (!(await checkPermission('subcontractors.edit'))) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   const id = context?.params.id;
   if (!id) return NextResponse.json({ error: 'Missing id' }, { status: 400 });
 
@@ -77,6 +80,7 @@ export const PATCH = withApiContext(async (req: NextRequest, session, context) =
 
 export const DELETE = withApiContext(async (req: NextRequest, session, context) => {
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  if (!(await checkPermission('subcontractors.delete'))) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   const id = context?.params.id;
   if (!id) return NextResponse.json({ error: 'Missing id' }, { status: 400 });
 

--- a/src/app/api/subcontractor-contracts/[id]/status/route.ts
+++ b/src/app/api/subcontractor-contracts/[id]/status/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { withApiContext } from '@/lib/api-utils';
+import { checkPermission } from '@/lib/permission-checker';
 import prisma from '@/lib/db';
 import { logger } from '@/lib/logger';
 import { VALID_TRANSITIONS } from '@/lib/services/subcontractor-contract.service';
@@ -32,6 +33,11 @@ export const POST = withApiContext(async (req: NextRequest, session, context) =>
   if (!parsed.success) return NextResponse.json({ error: 'Validation error', details: parsed.error.flatten() }, { status: 422 });
 
   const { action, reason } = parsed.data;
+
+  // Approve/reject requires approve permission; all other status changes require edit permission
+  const requiredPerm = (action === 'approve' || action === 'reject') ? 'subcontractors.approve' : 'subcontractors.edit';
+  if (!(await checkPermission(requiredPerm))) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
   const newStatus = ACTION_TO_STATUS[action];
 
   try {

--- a/src/app/api/subcontractor-contracts/dashboard/route.ts
+++ b/src/app/api/subcontractor-contracts/dashboard/route.ts
@@ -1,10 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { withApiContext } from '@/lib/api-utils';
+import { checkPermission } from '@/lib/permission-checker';
 import { logger } from '@/lib/logger';
 import { getDashboardStats } from '@/lib/services/subcontractor-contract.service';
 
 export const GET = withApiContext(async (_req: NextRequest, session) => {
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  if (!(await checkPermission('subcontractors.view'))) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
 
   try {
     const stats = await getDashboardStats();

--- a/src/app/api/subcontractor-contracts/route.ts
+++ b/src/app/api/subcontractor-contracts/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { withApiContext } from '@/lib/api-utils';
+import { checkPermission } from '@/lib/permission-checker';
 import prisma from '@/lib/db';
 import { logger } from '@/lib/logger';
 import {
@@ -44,6 +45,7 @@ const createSchema = z.object({
 
 export const GET = withApiContext(async (req: NextRequest, session) => {
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  if (!(await checkPermission('subcontractors.view'))) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
 
   const { searchParams } = new URL(req.url);
   const status = searchParams.get('status');
@@ -91,6 +93,7 @@ export const GET = withApiContext(async (req: NextRequest, session) => {
 
 export const POST = withApiContext(async (req: NextRequest, session) => {
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  if (!(await checkPermission('subcontractors.create'))) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
 
   let body: unknown;
   try {

--- a/src/app/supply-chain/subcontractors/[id]/_page-client.tsx
+++ b/src/app/supply-chain/subcontractors/[id]/_page-client.tsx
@@ -102,7 +102,14 @@ function fmtDate(d: string | null) {
   return new Date(d).toLocaleDateString('en-SA-u-ca-gregory', { day: '2-digit', month: 'short', year: 'numeric' });
 }
 
-export default function SubcontractorContractDetailPage() {
+interface Props {
+  canEdit: boolean;
+  canApprove: boolean;
+  canCertCreate: boolean;
+  canCertApprove: boolean;
+}
+
+export default function SubcontractorContractDetailPage({ canEdit, canApprove: hasApprovePermission, canCertCreate, canCertApprove }: Props) {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
 
@@ -217,14 +224,14 @@ export default function SubcontractorContractDetailPage() {
     .filter(c => c.status === 'APPROVED')
     .reduce((s, c) => s + Number(c.netAmountDue), 0);
 
-  const canSubmit = contract.status === 'DRAFT';
-  const canApprove = contract.status === 'SUBMITTED';
-  const canActivate = contract.status === 'APPROVED';
-  const canSuspend = contract.status === 'ACTIVE';
-  const canResume = contract.status === 'SUSPENDED';
-  const canComplete = contract.status === 'ACTIVE';
-  const canCancel = ['DRAFT', 'SUBMITTED', 'APPROVED'].includes(contract.status);
-  const canAddCert = contract.status === 'ACTIVE';
+  const canSubmit   = canEdit && contract.status === 'DRAFT';
+  const canApprove  = hasApprovePermission && contract.status === 'SUBMITTED';
+  const canActivate = canEdit && contract.status === 'APPROVED';
+  const canSuspend  = canEdit && contract.status === 'ACTIVE';
+  const canResume   = canEdit && contract.status === 'SUSPENDED';
+  const canComplete = canEdit && contract.status === 'ACTIVE';
+  const canCancel   = canEdit && ['DRAFT', 'SUBMITTED', 'APPROVED'].includes(contract.status);
+  const canAddCert  = canCertCreate && contract.status === 'ACTIVE';
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-slate-50 to-white">
@@ -516,17 +523,17 @@ export default function SubcontractorContractDetailPage() {
                         </TableCell>
                         <TableCell>
                           <div className="flex gap-1">
-                            {cert.status === 'DRAFT' && (
+                            {canCertCreate && cert.status === 'DRAFT' && (
                               <Button size="sm" variant="outline" className="h-7 text-xs" onClick={() => handleCertAction(cert.id, 'submit')}>
                                 <Send className="size-3 mr-1" /> Submit
                               </Button>
                             )}
-                            {cert.status === 'SUBMITTED' && (
+                            {canCertApprove && cert.status === 'SUBMITTED' && (
                               <Button size="sm" variant="outline" className="h-7 text-xs text-blue-700 border-blue-300" onClick={() => handleCertAction(cert.id, 'approve')}>
                                 <ThumbsUp className="size-3 mr-1" /> Approve
                               </Button>
                             )}
-                            {cert.status === 'APPROVED' && (
+                            {canCertApprove && cert.status === 'APPROVED' && (
                               <Button size="sm" variant="outline" className="h-7 text-xs text-emerald-700 border-emerald-300" onClick={() => handleCertAction(cert.id, 'mark_paid')}>
                                 <CheckCircle2 className="size-3 mr-1" /> Mark Paid
                               </Button>

--- a/src/app/supply-chain/subcontractors/[id]/page.tsx
+++ b/src/app/supply-chain/subcontractors/[id]/page.tsx
@@ -1,3 +1,34 @@
 import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import { getCurrentUserPermissions } from '@/lib/permission-checker';
+import SubcontractorContractDetailPage from './_page-client';
+
 export const metadata: Metadata = { title: 'Subcontractor Contract' };
-export { default } from './_page-client';
+export const dynamic = 'force-dynamic';
+
+export default async function SubcontractorDetailPage() {
+  const store = await cookies();
+  const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+  const session = token ? verifySession(token) : null;
+  if (!session) redirect('/login');
+
+  const permissions = await getCurrentUserPermissions();
+  const canView    = permissions.includes('subcontractors.view');
+  const canEdit    = permissions.includes('subcontractors.edit');
+  const canApprove = permissions.includes('subcontractors.approve');
+  const canCertCreate  = permissions.includes('subcontractors.certs.create');
+  const canCertApprove = permissions.includes('subcontractors.certs.approve');
+
+  if (!canView) redirect('/unauthorized?from=/supply-chain/subcontractors');
+
+  return (
+    <SubcontractorContractDetailPage
+      canEdit={canEdit}
+      canApprove={canApprove}
+      canCertCreate={canCertCreate}
+      canCertApprove={canCertApprove}
+    />
+  );
+}

--- a/src/app/supply-chain/subcontractors/_page-client.tsx
+++ b/src/app/supply-chain/subcontractors/_page-client.tsx
@@ -89,7 +89,14 @@ function ProgressBar({ value }: { value: number }) {
   );
 }
 
-export default function SubcontractorsPage() {
+interface Props {
+  canCreate: boolean;
+  canEdit: boolean;
+  canDelete: boolean;
+  canApprove: boolean;
+}
+
+export default function SubcontractorsPage({ canCreate, canEdit, canDelete, canApprove }: Props) {
   const router = useRouter();
   const [contracts, setContracts] = useState<Contract[]>([]);
   const [stats, setStats] = useState<DashStats | null>(null);
@@ -163,12 +170,14 @@ export default function SubcontractorsPage() {
               >
                 <RefreshCw className="size-4" />
               </Button>
-              <Link href="/supply-chain/subcontractors/new">
-                <Button className="bg-white text-orange-700 hover:bg-orange-50 font-semibold shadow">
-                  <Plus className="size-4 mr-2" />
-                  New Contract
-                </Button>
-              </Link>
+              {canCreate && (
+                <Link href="/supply-chain/subcontractors/new">
+                  <Button className="bg-white text-orange-700 hover:bg-orange-50 font-semibold shadow">
+                    <Plus className="size-4 mr-2" />
+                    New Contract
+                  </Button>
+                </Link>
+              )}
             </div>
           </div>
         </div>
@@ -245,7 +254,7 @@ export default function SubcontractorsPage() {
                 <p className="text-muted-foreground">
                   {search || statusFilter !== 'ALL' ? 'No contracts match your filters.' : 'No contracts yet.'}
                 </p>
-                {!search && statusFilter === 'ALL' && (
+                {!search && statusFilter === 'ALL' && canCreate && (
                   <Link href="/supply-chain/subcontractors/new">
                     <Button variant="outline" size="sm" className="mt-4">
                       <Plus className="size-4 mr-1" />
@@ -332,7 +341,7 @@ export default function SubcontractorsPage() {
                                 <DropdownMenuItem onClick={() => router.push(`/supply-chain/subcontractors/${c.id}`)}>
                                   <Eye className="size-4 mr-2" /> View
                                 </DropdownMenuItem>
-                                {c.status === 'DRAFT' && (
+                                {canEdit && c.status === 'DRAFT' && (
                                   <DropdownMenuItem onClick={() => router.push(`/supply-chain/subcontractors/${c.id}?edit=1`)}>
                                     <Edit className="size-4 mr-2" /> Edit
                                   </DropdownMenuItem>

--- a/src/app/supply-chain/subcontractors/new/page.tsx
+++ b/src/app/supply-chain/subcontractors/new/page.tsx
@@ -1,3 +1,21 @@
 import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import { checkPermission } from '@/lib/permission-checker';
+import NewSubcontractorContractPage from './_page-client';
+
 export const metadata: Metadata = { title: 'New Subcontractor Contract' };
-export { default } from './_page-client';
+export const dynamic = 'force-dynamic';
+
+export default async function NewContractPage() {
+  const store = await cookies();
+  const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+  const session = token ? verifySession(token) : null;
+  if (!session) redirect('/login');
+
+  const canCreate = await checkPermission('subcontractors.create');
+  if (!canCreate) redirect('/unauthorized?from=/supply-chain/subcontractors/new');
+
+  return <NewSubcontractorContractPage />;
+}

--- a/src/app/supply-chain/subcontractors/page.tsx
+++ b/src/app/supply-chain/subcontractors/page.tsx
@@ -1,3 +1,34 @@
 import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import { getCurrentUserPermissions } from '@/lib/permission-checker';
+import SubcontractorsPage from './_page-client';
+
 export const metadata: Metadata = { title: 'Subcontractor Contracts' };
-export { default } from './_page-client';
+export const dynamic = 'force-dynamic';
+
+export default async function SubcontractorContractsPage() {
+  const store = await cookies();
+  const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+  const session = token ? verifySession(token) : null;
+  if (!session) redirect('/login');
+
+  const permissions = await getCurrentUserPermissions();
+  const canView    = permissions.includes('subcontractors.view');
+  const canCreate  = permissions.includes('subcontractors.create');
+  const canEdit    = permissions.includes('subcontractors.edit');
+  const canDelete  = permissions.includes('subcontractors.delete');
+  const canApprove = permissions.includes('subcontractors.approve');
+
+  if (!canView) redirect('/unauthorized?from=/supply-chain/subcontractors');
+
+  return (
+    <SubcontractorsPage
+      canCreate={canCreate}
+      canEdit={canEdit}
+      canDelete={canDelete}
+      canApprove={canApprove}
+    />
+  );
+}

--- a/src/app/supply-chain/suppliers/_page-client.tsx
+++ b/src/app/supply-chain/suppliers/_page-client.tsx
@@ -166,7 +166,9 @@ export function SupplierListClient() {
               ) : suppliers.map(s => (
                 <tr key={s.dolibarr_id} className="border-b last:border-0 hover:bg-muted/30 transition-colors">
                   <td className="px-4 py-3">
-                    <p className="font-medium">{s.name}</p>
+                    <Link href={`/supply-chain/suppliers/${s.dolibarr_id}`} className="hover:underline">
+                      <p className="font-medium">{s.name}</p>
+                    </Link>
                     {s.email && <p className="text-xs text-muted-foreground">{s.email}</p>}
                   </td>
                   <td className="px-4 py-3 hidden sm:table-cell">

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -765,15 +765,9 @@ export const DEFAULT_ROLE_PERMISSIONS: Record<string, string[]> = {
     'supply_chain.view',
     'supply_chain.sync',
     'supply_chain.alias',
-    // Subcontractors
+    // Subcontractors — read-only for Managers; CRUD restricted to Admin/CEO
     'subcontractors.view',
-    'subcontractors.create',
-    'subcontractors.edit',
-    'subcontractors.delete',
-    'subcontractors.approve',
     'subcontractors.certs.view',
-    'subcontractors.certs.create',
-    'subcontractors.certs.approve',
     // Project Tracker
     'project_tracker.view',
     'project_tracker.export',


### PR DESCRIPTION
- Add v24_5 migration to ensure fin_supplier_coa_default table exists on startup,
  fixing 'Supplier not found' error when supplier detail page queried missing table
- Make supplier name in the list a clickable link to the detail page
- Add checkPermission() guards to all subcontractor API routes (view/create/edit/
  delete/approve, certs view/create/approve)
- Remove subcontractor CRUD permissions from Manager role defaults — Managers now
  have view-only access; Admin and CEO retain full CRUD
- Convert subcontractor page/detail/new page.tsx files to server components that
  resolve permissions and gate create/edit/approve/cert-action UI buttons
- Add /supply-chain, /hr, /workflow, /financial to middleware protected paths

https://claude.ai/code/session_01LFwBbqfykZxrPs38SLjo5F