### PR TITLE
feat(subcontractors+projects): variations/deductions/print, purlin KPI, production bars, supplier fix

### DIFF
--- a/prisma/manual_migrations/add_subcontractor_variations_deductions.sql
+++ b/prisma/manual_migrations/add_subcontractor_variations_deductions.sql
@@ -1,0 +1,69 @@
+-- Migration: Subcontractor Variations & Deductions
+
+-- 1. SubcontractorVariation
+DROP PROCEDURE IF EXISTS create_subcontractor_variation;
+DELIMITER $$
+CREATE PROCEDURE create_subcontractor_variation()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'SubcontractorVariation'
+  ) THEN
+    CREATE TABLE SubcontractorVariation (
+      id              VARCHAR(30)   NOT NULL,
+      contractId      CHAR(36)      NOT NULL,
+      variationNumber VARCHAR(30)   NOT NULL,
+      description     TEXT          NOT NULL,
+      amount          DECIMAL(15,2) NOT NULL,
+      status          VARCHAR(30)   NOT NULL DEFAULT 'PENDING',
+      approvedById    CHAR(36)      NULL,
+      approvedAt      DATETIME(3)   NULL,
+      notes           TEXT          NULL,
+      createdById     CHAR(36)      NOT NULL,
+      createdAt       DATETIME(3)   NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+      updatedAt       DATETIME(3)   NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+      deletedAt       DATETIME(3)   NULL,
+      PRIMARY KEY (id),
+      INDEX idx_scvar_contract (contractId),
+      INDEX idx_scvar_status   (status),
+      INDEX idx_scvar_deleted  (deletedAt)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+  END IF;
+END$$
+DELIMITER ;
+CALL create_subcontractor_variation();
+DROP PROCEDURE IF EXISTS create_subcontractor_variation;
+
+-- 2. SubcontractorDeduction
+DROP PROCEDURE IF EXISTS create_subcontractor_deduction;
+DELIMITER $$
+CREATE PROCEDURE create_subcontractor_deduction()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'SubcontractorDeduction'
+  ) THEN
+    CREATE TABLE SubcontractorDeduction (
+      id             VARCHAR(30)   NOT NULL,
+      contractId     CHAR(36)      NOT NULL,
+      description    TEXT          NOT NULL,
+      amount         DECIMAL(15,2) NOT NULL,
+      deductionDate  DATE          NOT NULL,
+      reason         TEXT          NULL,
+      status         VARCHAR(30)   NOT NULL DEFAULT 'PENDING',
+      approvedById   CHAR(36)      NULL,
+      approvedAt     DATETIME(3)   NULL,
+      createdById    CHAR(36)      NOT NULL,
+      createdAt      DATETIME(3)   NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+      updatedAt      DATETIME(3)   NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+      deletedAt      DATETIME(3)   NULL,
+      PRIMARY KEY (id),
+      INDEX idx_scded_contract (contractId),
+      INDEX idx_scded_status   (status),
+      INDEX idx_scded_deleted  (deletedAt)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+  END IF;
+END$$
+DELIMITER ;
+CALL create_subcontractor_deduction();
+DROP PROCEDURE IF EXISTS create_subcontractor_deduction;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -414,6 +414,10 @@ model User {
   scContractsApproved         SubcontractorContract[]             @relation("SCContractApprovedBy")
   scCertificatesCreated       SubcontractorPaymentCertificate[]   @relation("SCCertCreatedBy")
   scCertificatesApproved      SubcontractorPaymentCertificate[]   @relation("SCCertApprovedBy")
+  scVariationsCreated         SubcontractorVariation[]            @relation("SCVariationCreatedBy")
+  scVariationsApproved        SubcontractorVariation[]            @relation("SCVariationApprovedBy")
+  scDeductionsCreated         SubcontractorDeduction[]            @relation("SCDeductionCreatedBy")
+  scDeductionsApproved        SubcontractorDeduction[]            @relation("SCDeductionApprovedBy")
 
   // HR Monthly Reports (23.4.0)
   createdHrReports HrMonthlyReport[] @relation("HrReportCreatedBy")
@@ -7376,9 +7380,59 @@ model SubcontractorContract {
   createdBy           User                             @relation("SCContractCreatedBy", fields: [createdById], references: [id])
   approvedBy          User?                            @relation("SCContractApprovedBy", fields: [approvedById], references: [id])
   paymentCertificates SubcontractorPaymentCertificate[]
+  variations          SubcontractorVariation[]
+  deductions          SubcontractorDeduction[]
 
   @@index([projectId])
   @@index([supplierId])
+  @@index([status])
+  @@index([deletedAt])
+}
+
+model SubcontractorVariation {
+  id              String    @id @default(cuid())
+  contractId      String    @db.Char(36)
+  variationNumber String    @db.VarChar(30)
+  description     String    @db.Text
+  amount          Decimal   @db.Decimal(15, 2)
+  status          String    @default("PENDING") @db.VarChar(30)
+  approvedById    String?   @db.Char(36)
+  approvedAt      DateTime?
+  notes           String?   @db.Text
+  createdById     String    @db.Char(36)
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+  deletedAt       DateTime?
+
+  contract   SubcontractorContract @relation(fields: [contractId], references: [id])
+  createdBy  User                  @relation("SCVariationCreatedBy", fields: [createdById], references: [id])
+  approvedBy User?                 @relation("SCVariationApprovedBy", fields: [approvedById], references: [id])
+
+  @@index([contractId])
+  @@index([status])
+  @@index([deletedAt])
+}
+
+model SubcontractorDeduction {
+  id             String    @id @default(cuid())
+  contractId     String    @db.Char(36)
+  description    String    @db.Text
+  amount         Decimal   @db.Decimal(15, 2)
+  deductionDate  DateTime  @default(now()) @db.Date
+  reason         String?   @db.Text
+  status         String    @default("PENDING") @db.VarChar(30)
+  approvedById   String?   @db.Char(36)
+  approvedAt     DateTime?
+  createdById    String    @db.Char(36)
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+  deletedAt      DateTime?
+
+  contract   SubcontractorContract @relation(fields: [contractId], references: [id])
+  createdBy  User                  @relation("SCDeductionCreatedBy", fields: [createdById], references: [id])
+  approvedBy User?                 @relation("SCDeductionApprovedBy", fields: [approvedById], references: [id])
+
+  @@index([contractId])
   @@index([status])
   @@index([deletedAt])
 }

--- a/src/app/api/subcontractor-contracts/[id]/deductions/[dedId]/route.ts
+++ b/src/app/api/subcontractor-contracts/[id]/deductions/[dedId]/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withApiContext } from '@/lib/api-utils';
+import { checkPermission } from '@/lib/permission-checker';
+import prisma from '@/lib/db';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+const patchSchema = z.object({
+  description: z.string().min(1).optional(),
+  amount: z.number().positive().optional(),
+  reason: z.string().optional().nullable(),
+  status: z.enum(['PENDING', 'APPLIED', 'REJECTED']).optional(),
+});
+
+export const PATCH = withApiContext(async (req: NextRequest, session, ctx) => {
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  if (!(await checkPermission('subcontractors.edit'))) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  const dedId = ctx?.params?.dedId;
+  if (!dedId) return NextResponse.json({ error: 'Missing deduction ID' }, { status: 400 });
+
+  let body: unknown;
+  try { body = await req.json(); } catch { return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 }); }
+
+  const parsed = patchSchema.safeParse(body);
+  if (!parsed.success) return NextResponse.json({ error: 'Validation error', details: parsed.error.flatten() }, { status: 422 });
+
+  try {
+    const { status, ...rest } = parsed.data;
+    const updated = await prisma.subcontractorDeduction.update({
+      where: { id: dedId },
+      data: {
+        ...rest,
+        ...(status ? {
+          status,
+          approvedById: ['APPLIED', 'REJECTED'].includes(status) ? session.userId : undefined,
+          approvedAt: ['APPLIED', 'REJECTED'].includes(status) ? new Date() : undefined,
+        } : {}),
+      },
+    });
+    return NextResponse.json({ ...updated, amount: Number(updated.amount) });
+  } catch (error) {
+    logger.error({ error }, '[SC Deductions] Failed to update');
+    return NextResponse.json({ error: 'Failed to update deduction' }, { status: 500 });
+  }
+});
+
+export const DELETE = withApiContext(async (_req: NextRequest, session, ctx) => {
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  if (!(await checkPermission('subcontractors.edit'))) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  const dedId = ctx?.params?.dedId;
+  if (!dedId) return NextResponse.json({ error: 'Missing deduction ID' }, { status: 400 });
+
+  try {
+    await prisma.subcontractorDeduction.update({
+      where: { id: dedId },
+      data: { deletedAt: new Date() },
+    });
+    logger.info({ dedId }, '[SC Deductions] Deleted');
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    logger.error({ error }, '[SC Deductions] Failed to delete');
+    return NextResponse.json({ error: 'Failed to delete deduction' }, { status: 500 });
+  }
+});

--- a/src/app/api/subcontractor-contracts/[id]/deductions/route.ts
+++ b/src/app/api/subcontractor-contracts/[id]/deductions/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withApiContext } from '@/lib/api-utils';
+import { checkPermission } from '@/lib/permission-checker';
+import prisma from '@/lib/db';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+const createSchema = z.object({
+  description: z.string().min(1),
+  amount: z.number().positive(),
+  deductionDate: z.string().optional(),
+  reason: z.string().optional().nullable(),
+});
+
+export const GET = withApiContext(async (_req: NextRequest, session, ctx) => {
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  if (!(await checkPermission('subcontractors.view'))) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  const contractId = ctx?.params?.id;
+  if (!contractId) return NextResponse.json({ error: 'Missing contract ID' }, { status: 400 });
+
+  try {
+    const deductions = await prisma.subcontractorDeduction.findMany({
+      where: { contractId, deletedAt: null },
+      include: {
+        createdBy: { select: { id: true, name: true } },
+        approvedBy: { select: { id: true, name: true } },
+      },
+      orderBy: { createdAt: 'asc' },
+    });
+
+    return NextResponse.json(deductions.map(d => ({
+      ...d,
+      amount: Number(d.amount),
+      deductionDate: d.deductionDate.toISOString().split('T')[0],
+      approvedAt: d.approvedAt?.toISOString() ?? null,
+      createdAt: d.createdAt.toISOString(),
+      updatedAt: d.updatedAt.toISOString(),
+    })));
+  } catch (error) {
+    logger.error({ error }, '[SC Deductions] Failed to list');
+    return NextResponse.json({ error: 'Failed to fetch deductions' }, { status: 500 });
+  }
+});
+
+export const POST = withApiContext(async (req: NextRequest, session, ctx) => {
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  if (!(await checkPermission('subcontractors.edit'))) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  const contractId = ctx?.params?.id;
+  if (!contractId) return NextResponse.json({ error: 'Missing contract ID' }, { status: 400 });
+
+  let body: unknown;
+  try { body = await req.json(); } catch { return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 }); }
+
+  const parsed = createSchema.safeParse(body);
+  if (!parsed.success) return NextResponse.json({ error: 'Validation error', details: parsed.error.flatten() }, { status: 422 });
+
+  const contract = await prisma.subcontractorContract.findFirst({
+    where: { id: contractId, deletedAt: null },
+    select: { id: true },
+  });
+  if (!contract) return NextResponse.json({ error: 'Contract not found' }, { status: 404 });
+
+  try {
+    const deduction = await prisma.subcontractorDeduction.create({
+      data: {
+        contractId,
+        description: parsed.data.description,
+        amount: parsed.data.amount,
+        deductionDate: parsed.data.deductionDate ? new Date(parsed.data.deductionDate) : new Date(),
+        reason: parsed.data.reason ?? null,
+        status: 'PENDING',
+        createdById: session.userId,
+      },
+      include: {
+        createdBy: { select: { id: true, name: true } },
+        approvedBy: { select: { id: true, name: true } },
+      },
+    });
+
+    logger.info({ deductionId: deduction.id, contractId }, '[SC Deductions] Created');
+    return NextResponse.json({ ...deduction, amount: Number(deduction.amount) }, { status: 201 });
+  } catch (error) {
+    logger.error({ error }, '[SC Deductions] Failed to create');
+    return NextResponse.json({ error: 'Failed to create deduction' }, { status: 500 });
+  }
+});

--- a/src/app/api/subcontractor-contracts/[id]/variations/[varId]/route.ts
+++ b/src/app/api/subcontractor-contracts/[id]/variations/[varId]/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withApiContext } from '@/lib/api-utils';
+import { checkPermission } from '@/lib/permission-checker';
+import prisma from '@/lib/db';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+const patchSchema = z.object({
+  description: z.string().min(1).optional(),
+  amount: z.number().optional(),
+  notes: z.string().optional().nullable(),
+  status: z.enum(['PENDING', 'APPROVED', 'REJECTED']).optional(),
+});
+
+export const PATCH = withApiContext(async (req: NextRequest, session, ctx) => {
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  if (!(await checkPermission('subcontractors.edit'))) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  const varId = ctx?.params?.varId;
+  if (!varId) return NextResponse.json({ error: 'Missing variation ID' }, { status: 400 });
+
+  let body: unknown;
+  try { body = await req.json(); } catch { return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 }); }
+
+  const parsed = patchSchema.safeParse(body);
+  if (!parsed.success) return NextResponse.json({ error: 'Validation error', details: parsed.error.flatten() }, { status: 422 });
+
+  try {
+    const { status, ...rest } = parsed.data;
+    const updated = await prisma.subcontractorVariation.update({
+      where: { id: varId },
+      data: {
+        ...rest,
+        ...(status ? {
+          status,
+          approvedById: ['APPROVED', 'REJECTED'].includes(status) ? session.userId : undefined,
+          approvedAt: ['APPROVED', 'REJECTED'].includes(status) ? new Date() : undefined,
+        } : {}),
+      },
+    });
+    return NextResponse.json({ ...updated, amount: Number(updated.amount) });
+  } catch (error) {
+    logger.error({ error }, '[SC Variations] Failed to update');
+    return NextResponse.json({ error: 'Failed to update variation' }, { status: 500 });
+  }
+});
+
+export const DELETE = withApiContext(async (_req: NextRequest, session, ctx) => {
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  if (!(await checkPermission('subcontractors.edit'))) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  const varId = ctx?.params?.varId;
+  if (!varId) return NextResponse.json({ error: 'Missing variation ID' }, { status: 400 });
+
+  try {
+    await prisma.subcontractorVariation.update({
+      where: { id: varId },
+      data: { deletedAt: new Date() },
+    });
+    logger.info({ varId }, '[SC Variations] Deleted');
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    logger.error({ error }, '[SC Variations] Failed to delete');
+    return NextResponse.json({ error: 'Failed to delete variation' }, { status: 500 });
+  }
+});

--- a/src/app/api/subcontractor-contracts/[id]/variations/route.ts
+++ b/src/app/api/subcontractor-contracts/[id]/variations/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withApiContext } from '@/lib/api-utils';
+import { checkPermission } from '@/lib/permission-checker';
+import prisma from '@/lib/db';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+const createSchema = z.object({
+  description: z.string().min(1),
+  amount: z.number(),
+  notes: z.string().optional().nullable(),
+});
+
+export const GET = withApiContext(async (_req: NextRequest, session, ctx) => {
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  if (!(await checkPermission('subcontractors.view'))) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  const contractId = ctx?.params?.id;
+  if (!contractId) return NextResponse.json({ error: 'Missing contract ID' }, { status: 400 });
+
+  try {
+    const variations = await prisma.subcontractorVariation.findMany({
+      where: { contractId, deletedAt: null },
+      include: {
+        createdBy: { select: { id: true, name: true } },
+        approvedBy: { select: { id: true, name: true } },
+      },
+      orderBy: { createdAt: 'asc' },
+    });
+
+    return NextResponse.json(variations.map(v => ({
+      ...v,
+      amount: Number(v.amount),
+      approvedAt: v.approvedAt?.toISOString() ?? null,
+      createdAt: v.createdAt.toISOString(),
+      updatedAt: v.updatedAt.toISOString(),
+    })));
+  } catch (error) {
+    logger.error({ error }, '[SC Variations] Failed to list');
+    return NextResponse.json({ error: 'Failed to fetch variations' }, { status: 500 });
+  }
+});
+
+export const POST = withApiContext(async (req: NextRequest, session, ctx) => {
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  if (!(await checkPermission('subcontractors.edit'))) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  const contractId = ctx?.params?.id;
+  if (!contractId) return NextResponse.json({ error: 'Missing contract ID' }, { status: 400 });
+
+  let body: unknown;
+  try { body = await req.json(); } catch { return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 }); }
+
+  const parsed = createSchema.safeParse(body);
+  if (!parsed.success) return NextResponse.json({ error: 'Validation error', details: parsed.error.flatten() }, { status: 422 });
+
+  try {
+    const contract = await prisma.subcontractorContract.findFirst({
+      where: { id: contractId, deletedAt: null },
+      select: { contractNumber: true },
+    });
+    if (!contract) return NextResponse.json({ error: 'Contract not found' }, { status: 404 });
+
+    const count = await prisma.subcontractorVariation.count({ where: { contractId, deletedAt: null } });
+    const variationNumber = `${contract.contractNumber}-VAR-${String(count + 1).padStart(3, '0')}`;
+
+    const variation = await prisma.subcontractorVariation.create({
+      data: {
+        contractId,
+        variationNumber,
+        description: parsed.data.description,
+        amount: parsed.data.amount,
+        notes: parsed.data.notes ?? null,
+        status: 'PENDING',
+        createdById: session.userId,
+      },
+      include: {
+        createdBy: { select: { id: true, name: true } },
+        approvedBy: { select: { id: true, name: true } },
+      },
+    });
+
+    logger.info({ variationId: variation.id, contractId }, '[SC Variations] Created');
+    return NextResponse.json({ ...variation, amount: Number(variation.amount) }, { status: 201 });
+  } catch (error) {
+    logger.error({ error }, '[SC Variations] Failed to create');
+    return NextResponse.json({ error: 'Failed to create variation' }, { status: 500 });
+  }
+});

--- a/src/app/api/subcontractor-contracts/route.ts
+++ b/src/app/api/subcontractor-contracts/route.ts
@@ -13,7 +13,8 @@ import {
 const createSchema = z.object({
   projectId: z.string().min(1),
   buildingId: z.string().optional().nullable(),
-  supplierId: z.string().min(1),
+  supplierId: z.string().optional().nullable(),
+  dolibarrId: z.number().int().positive().optional().nullable(),
   scopeLevel: z.enum(['project', 'building', 'scope']),
   scopeTypes: z.array(z.string()).min(1),
   scopeItems: z.array(z.object({
@@ -109,7 +110,50 @@ export const POST = withApiContext(async (req: NextRequest, session) => {
 
   const data = parsed.data;
 
+  if (!data.supplierId && !data.dolibarrId) {
+    return NextResponse.json({ error: 'Either supplierId or dolibarrId is required' }, { status: 422 });
+  }
+
   try {
+    // Resolve supplierId — auto-create ScApprovedSupplier from Dolibarr data if needed
+    let supplierId = data.supplierId;
+    if (!supplierId && data.dolibarrId) {
+      const existing = await prisma.scApprovedSupplier.findFirst({
+        where: { dolibarrId: data.dolibarrId, deletedAt: null },
+        select: { id: true },
+      });
+      if (existing) {
+        supplierId = existing.id;
+      } else {
+        const rows = await prisma.$queryRawUnsafe<[{ name: string; code_supplier: string | null }]>(
+          'SELECT name, code_supplier FROM dolibarr_thirdparties WHERE dolibarr_id = ? LIMIT 1',
+          data.dolibarrId
+        );
+        if (!rows.length) return NextResponse.json({ error: 'Dolibarr supplier not found' }, { status: 404 });
+        const dt = rows[0];
+        const lastSup = await prisma.scApprovedSupplier.findFirst({
+          where: { supplierCode: { startsWith: 'SUP-' } },
+          orderBy: { supplierCode: 'desc' },
+          select: { supplierCode: true },
+        });
+        const n = lastSup ? (parseInt(lastSup.supplierCode.replace('SUP-', '')) || 0) + 1 : 1;
+        const supplierCode = `SUP-${String(n).padStart(3, '0')}`;
+        const created = await prisma.scApprovedSupplier.create({
+          data: {
+            supplierCode,
+            name: dt.name,
+            dolibarrId: data.dolibarrId,
+            approvalStatus: 'APPROVED',
+            updatedAt: new Date(),
+            createdById: session.userId,
+          },
+          select: { id: true },
+        });
+        supplierId = created.id;
+        logger.info({ supplierId: created.id, dolibarrId: data.dolibarrId }, '[SC Contracts] Auto-created ScApprovedSupplier');
+      }
+    }
+
     const project = await prisma.project.findUnique({
       where: { id: data.projectId },
       select: { projectNumber: true },
@@ -141,7 +185,7 @@ export const POST = withApiContext(async (req: NextRequest, session) => {
         name,
         projectId: data.projectId,
         buildingId: data.buildingId ?? null,
-        supplierId: data.supplierId,
+        supplierId: supplierId!,
         scopeLevel: data.scopeLevel,
         scopeTypes: data.scopeTypes,
         scopeItems: data.scopeItems ?? [],

--- a/src/app/projects/[id]/buildings/_page-client.tsx
+++ b/src/app/projects/[id]/buildings/_page-client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo, type ReactNode } from 'react';
+import { useState, useMemo, useEffect, useCallback, type ReactNode } from 'react';
 import { useRouter } from 'next/navigation';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -38,6 +38,9 @@ import {
   LayoutGrid,
   User,
   Users,
+  Activity,
+  BarChart3,
+  Loader2,
 } from 'lucide-react';
 
 // ─── RAL Colours ────────────────────────────────────────────────────────────
@@ -196,6 +199,7 @@ type BuildingData = {
   assemblyTonnage: number;
   totalArea: number;
   purlinArea: number;
+  purlinWeight: number;
   paintableArea: number;
   scopeOfWorks: ScopeOfWork[];
 };
@@ -734,6 +738,25 @@ export function ProjectCardClient({
   const totalTonnage = kpiBuildings.reduce((s, b) => s + b.assemblyTonnage, 0);
   const totalArea = kpiBuildings.reduce((s, b) => s + b.totalArea, 0);
   const totalPaintable = kpiBuildings.reduce((s, b) => s + b.paintableArea, 0);
+  const totalPurlinWeight = kpiBuildings.reduce((s, b) => s + b.purlinWeight, 0);
+
+  // Production progress
+  type ProcessProgress = { processType: string; weight: number; percentage: number };
+  type ProdData = { byProcess: ProcessProgress[]; requiredWeight: number };
+  const [prodData, setProdData] = useState<ProdData | null>(null);
+  const [prodLoading, setProdLoading] = useState(false);
+
+  const fetchProdData = useCallback(async () => {
+    setProdLoading(true);
+    try {
+      const res = await fetch(`/api/projects/${project.id}/production`);
+      if (res.ok) setProdData(await res.json());
+    } finally {
+      setProdLoading(false);
+    }
+  }, [project.id]);
+
+  useEffect(() => { fetchProdData(); }, [fetchProdData]);
 
   // Scope content
   const aggScopes = useMemo(() => aggregateScopes(buildings), [buildings]);
@@ -906,7 +929,7 @@ export function ProjectCardClient({
       </div>
 
       {/* ── KPI strip ── */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
         {/* Buildings tile — blue */}
         <Card className="relative overflow-hidden border-0 shadow-md">
           <div className="absolute inset-0 bg-gradient-to-br from-blue-500 to-blue-700" />
@@ -997,6 +1020,23 @@ export function ProjectCardClient({
             </div>
           </div>
         </Card>
+
+        {/* Purlins Weight tile — lime */}
+        <Card className="relative overflow-hidden border-0 shadow-md">
+          <div className="absolute inset-0 bg-gradient-to-br from-lime-500 to-green-600" />
+          <div className="relative p-4 text-white">
+            <div className="flex items-center justify-between mb-2">
+              <div className="text-xs font-semibold uppercase tracking-wider opacity-80">Purlins Weight</div>
+              <div className="flex items-center justify-center w-7 h-7 rounded-lg bg-white/20">
+                <Weight className="w-4 h-4" />
+              </div>
+            </div>
+            <div className="text-2xl font-bold">{fmt(totalPurlinWeight, 2)} <span className="text-base font-medium opacity-80">t</span></div>
+            <div className="text-xs opacity-75 mt-0.5">
+              {totalTonnage > 0 ? `${fmt((totalPurlinWeight / totalTonnage) * 100, 1)}% of total` : 'No tonnage data'}
+            </div>
+          </div>
+        </Card>
       </div>
 
       {/* ── Technical Information ── */}
@@ -1012,6 +1052,70 @@ export function ProjectCardClient({
       {/* ── Stage Durations ── */}
       <Section title="Stage Durations" icon={<Clock className="w-3.5 h-3.5" />}>
         <StageDurations project={project} />
+      </Section>
+
+      {/* ── Production Progress ── */}
+      <Section title="Production Progress" icon={<Activity className="w-3.5 h-3.5" />}>
+        {prodLoading ? (
+          <div className="flex items-center gap-2 text-muted-foreground text-sm py-2">
+            <Loader2 className="w-4 h-4 animate-spin" /> Loading production data…
+          </div>
+        ) : (() => {
+          const processes = ['Fit-up', 'Welding', 'Visualization'];
+          const items = processes.map(p => prodData?.byProcess.find(x => x.processType === p) ?? { processType: p, weight: 0, percentage: 0 });
+          const hasAny = items.some(i => i.weight > 0);
+          if (!hasAny) return <p className="text-sm text-muted-foreground italic">No production data recorded yet.</p>;
+          return (
+            <div className="space-y-3">
+              {items.map(item => (
+                <div key={item.processType}>
+                  <div className="flex items-center justify-between text-sm mb-1">
+                    <span className="font-medium">{item.processType}</span>
+                    <span className="text-muted-foreground tabular-nums">{fmt(item.percentage, 1)}%&nbsp;<span className="text-xs">({fmt(item.weight, 2)} t)</span></span>
+                  </div>
+                  <div className="h-2 rounded-full bg-muted overflow-hidden">
+                    <div className="h-full rounded-full bg-gradient-to-r from-blue-500 to-indigo-600 transition-all" style={{ width: `${Math.min(100, item.percentage)}%` }} />
+                  </div>
+                </div>
+              ))}
+            </div>
+          );
+        })()}
+      </Section>
+
+      {/* ── Coating & Dispatch Progress ── */}
+      <Section title="Coating & Dispatch Progress" icon={<BarChart3 className="w-3.5 h-3.5" />}>
+        {prodLoading ? (
+          <div className="flex items-center gap-2 text-muted-foreground text-sm py-2">
+            <Loader2 className="w-4 h-4 animate-spin" /> Loading production data…
+          </div>
+        ) : (() => {
+          const processes = ['Painting', 'Sandblasting', 'Galvanization', 'Dispatch'];
+          const items = processes.map(p => prodData?.byProcess.find(x => x.processType === p) ?? { processType: p, weight: 0, percentage: 0 });
+          const hasAny = items.some(i => i.weight > 0);
+          if (!hasAny) return <p className="text-sm text-muted-foreground italic">No coating or dispatch data recorded yet.</p>;
+          const colors: Record<string, string> = {
+            Painting: 'from-violet-500 to-purple-600',
+            Sandblasting: 'from-amber-500 to-orange-600',
+            Galvanization: 'from-slate-500 to-gray-600',
+            Dispatch: 'from-emerald-500 to-teal-600',
+          };
+          return (
+            <div className="space-y-3">
+              {items.map(item => (
+                <div key={item.processType}>
+                  <div className="flex items-center justify-between text-sm mb-1">
+                    <span className="font-medium">{item.processType}</span>
+                    <span className="text-muted-foreground tabular-nums">{fmt(item.percentage, 1)}%&nbsp;<span className="text-xs">({fmt(item.weight, 2)} t)</span></span>
+                  </div>
+                  <div className="h-2 rounded-full bg-muted overflow-hidden">
+                    <div className={`h-full rounded-full bg-gradient-to-r ${colors[item.processType] ?? 'from-slate-400 to-slate-500'} transition-all`} style={{ width: `${Math.min(100, item.percentage)}%` }} />
+                  </div>
+                </div>
+              ))}
+            </div>
+          );
+        })()}
       </Section>
 
       {/* ── Scope of Work ── */}

--- a/src/app/projects/[id]/buildings/page.tsx
+++ b/src/app/projects/[id]/buildings/page.tsx
@@ -129,9 +129,14 @@ export default async function ProjectCardPage({ params }: { params: Promise<{ id
       return s + w;
     }, 0);
     const totalArea = b.assemblyParts.reduce((s, p) => s + Number(p.netAreaTotal ?? 0), 0);
-    const purlinArea = b.assemblyParts
-      .filter((p) => p.name?.toUpperCase() === 'PURLIN')
-      .reduce((s, p) => s + Number(p.netAreaTotal ?? 0), 0);
+    const purlinParts = b.assemblyParts.filter((p) => p.name?.toUpperCase() === 'PURLIN');
+    const purlinArea = purlinParts.reduce((s, p) => s + Number(p.netAreaTotal ?? 0), 0);
+    const purlinWeight = purlinParts.reduce((s, p) => {
+      const w = Number(p.netWeightTotal ?? 0) > 0
+        ? Number(p.netWeightTotal)
+        : Number(p.singlePartWeight ?? 0) * (p.quantity ?? 1);
+      return s + w;
+    }, 0) / 1000;
 
     return {
       ...b,
@@ -139,6 +144,7 @@ export default async function ProjectCardPage({ params }: { params: Promise<{ id
       assemblyTonnage: totalWeight / 1000,
       totalArea,
       purlinArea,
+      purlinWeight,
       paintableArea: totalArea - purlinArea,
       scopeOfWorks: b.scopeOfWorks.map((s) => ({
         ...s,

--- a/src/app/supply-chain/subcontractors/[id]/_page-client.tsx
+++ b/src/app/supply-chain/subcontractors/[id]/_page-client.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { generateSubcontractorContractPDF } from '@/lib/subcontractor-contract-pdf-generator';
 import { useState, useEffect, useCallback } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
@@ -18,7 +19,7 @@ import {
   Handshake, ChevronLeft, CheckCircle2, Clock, AlertTriangle, Ban,
   TrendingUp, Plus, Loader2, RefreshCw, Building2, FolderOpen,
   DollarSign, FileText, Send, ThumbsUp, PlayCircle, PauseCircle, XCircle,
-  Flag, ExternalLink, AlertCircle, ChevronDown, ChevronUp, Pencil, Trash2,
+  Flag, ExternalLink, AlertCircle, ChevronDown, ChevronUp, Pencil, Trash2, Printer,
 } from 'lucide-react';
 
 type Cert = {
@@ -120,6 +121,35 @@ export default function SubcontractorContractDetailPage({ canEdit, canDelete, ca
   const [error, setError] = useState('');
   const [tcCollapsed, setTcCollapsed] = useState(true);
 
+  // ── Variations ──────────────────────────────────────────────────────────────
+  type Variation = { id: string; variationNumber: string; description: string; amount: number; status: string; notes: string | null; createdBy: { name: string }; approvedBy: { name: string } | null; createdAt: string };
+  const [variations, setVariations] = useState<Variation[]>([]);
+  const [varDialog, setVarDialog] = useState(false);
+  const [varDesc, setVarDesc] = useState('');
+  const [varAmount, setVarAmount] = useState('');
+  const [varNotes, setVarNotes] = useState('');
+  const [varSaving, setVarSaving] = useState(false);
+
+  const fetchVariations = useCallback(async () => {
+    const res = await fetch(`/api/subcontractor-contracts/${id}/variations`);
+    if (res.ok) setVariations(await res.json());
+  }, [id]);
+
+  // ── Deductions ──────────────────────────────────────────────────────────────
+  type Deduction = { id: string; description: string; amount: number; deductionDate: string; reason: string | null; status: string; createdBy: { name: string }; approvedBy: { name: string } | null; createdAt: string };
+  const [deductions, setDeductions] = useState<Deduction[]>([]);
+  const [dedDialog, setDedDialog] = useState(false);
+  const [dedDesc, setDedDesc] = useState('');
+  const [dedAmount, setDedAmount] = useState('');
+  const [dedDate, setDedDate] = useState(new Date().toISOString().split('T')[0]);
+  const [dedReason, setDedReason] = useState('');
+  const [dedSaving, setDedSaving] = useState(false);
+
+  const fetchDeductions = useCallback(async () => {
+    const res = await fetch(`/api/subcontractor-contracts/${id}/deductions`);
+    if (res.ok) setDeductions(await res.json());
+  }, [id]);
+
   // ── New cert dialog ─────────────────────────────────────────────────────────
   const [certDialog, setCertDialog] = useState(false);
   const [certDate, setCertDate] = useState(new Date().toISOString().split('T')[0]);
@@ -160,7 +190,7 @@ export default function SubcontractorContractDetailPage({ canEdit, canDelete, ca
     setLoading(false);
   }, [id]);
 
-  useEffect(() => { fetchContract(); }, [fetchContract]);
+  useEffect(() => { fetchContract(); fetchVariations(); fetchDeductions(); }, [fetchContract, fetchVariations, fetchDeductions]);
 
   const handleAction = async (action: string, reason?: string) => {
     setActionLoading(true);
@@ -329,6 +359,33 @@ export default function SubcontractorContractDetailPage({ canEdit, canDelete, ca
   const canDeleteContract = canDelete && ['DRAFT', 'CANCELLED'].includes(contract.status);
   const canAddCert  = canCertCreate && contract.status === 'ACTIVE';
 
+  async function handlePrint() {
+    await generateSubcontractorContractPDF({
+      contractNumber: contract.contractNumber,
+      name: contract.name,
+      status: contract.status,
+      contractValue: Number(contract.contractValue),
+      currency: contract.currency,
+      retentionPercentage: Number(contract.retentionPercentage),
+      scopeTypes: contract.scopeTypes,
+      scopeItems: contract.scopeItems,
+      paymentTerms: contract.paymentTerms,
+      termsAndConditions: contract.termsAndConditions,
+      templateType: contract.templateType,
+      notes: contract.notes,
+      createdAt: contract.createdAt,
+      submittedAt: contract.submittedAt,
+      approvedAt: contract.approvedAt,
+      project: { projectNumber: contract.project.projectNumber, name: contract.project.name },
+      building: contract.building ? { designation: contract.building.designation, name: contract.building.name } : null,
+      supplier: { supplierCode: contract.supplier.supplierCode, name: contract.supplier.name, rating: contract.supplier.rating, scopeOfApproval: contract.supplier.scopeOfApproval },
+      createdBy: { name: contract.createdBy.name },
+      approvedBy: contract.approvedBy ? { name: contract.approvedBy.name } : null,
+      variations: variations.map(v => ({ variationNumber: v.variationNumber, description: v.description, amount: v.amount, status: v.status })),
+      deductions: deductions.map(d => ({ description: d.description, amount: d.amount, deductionDate: d.deductionDate, status: d.status })),
+    });
+  }
+
   return (
     <div className="min-h-screen bg-gradient-to-b from-slate-50 to-white">
       <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8 max-lg:pt-20 space-y-6">
@@ -405,6 +462,10 @@ export default function SubcontractorContractDetailPage({ canEdit, canDelete, ca
                 Delete
               </Button>
             )}
+            <Button size="sm" variant="outline" onClick={handlePrint}>
+              <Printer className="size-4 mr-1" />
+              Print
+            </Button>
             <Button size="sm" variant="ghost" onClick={fetchContract} disabled={loading}>
               <RefreshCw className={`size-4 ${loading ? 'animate-spin' : ''}`} />
             </Button>
@@ -734,7 +795,191 @@ export default function SubcontractorContractDetailPage({ canEdit, canDelete, ca
             </CardContent>
           </Card>
         )}
+
+        {/* ── Variations ── */}
+        <Card>
+          <CardHeader>
+            <div className="flex items-center justify-between">
+              <CardTitle className="text-base flex items-center gap-2">
+                <TrendingUp className="size-4 text-blue-600" />
+                Variations
+              </CardTitle>
+              {canEdit && (
+                <Button size="sm" variant="outline" onClick={() => { setVarDesc(''); setVarAmount(''); setVarNotes(''); setVarDialog(true); }}>
+                  <Plus className="size-4 mr-1" /> Add Variation
+                </Button>
+              )}
+            </div>
+          </CardHeader>
+          <CardContent className={variations.length === 0 ? undefined : 'p-0'}>
+            {variations.length === 0 ? (
+              <p className="text-sm text-muted-foreground italic">No variations recorded.</p>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow className="bg-muted/30">
+                    <TableHead>Number</TableHead>
+                    <TableHead>Description</TableHead>
+                    <TableHead className="text-right">Amount</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead>Created By</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {variations.map(v => (
+                    <TableRow key={v.id}>
+                      <TableCell className="font-mono text-xs">{v.variationNumber}</TableCell>
+                      <TableCell>{v.description}</TableCell>
+                      <TableCell className="text-right font-semibold">{fmt(v.amount, contract.currency)}</TableCell>
+                      <TableCell>
+                        <Badge variant="outline" className={v.status === 'APPROVED' ? 'bg-emerald-100 text-emerald-700 border-emerald-300' : v.status === 'REJECTED' ? 'bg-rose-100 text-rose-700 border-rose-300' : 'bg-amber-100 text-amber-700 border-amber-300'}>
+                          {v.status}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-xs text-muted-foreground">{v.createdBy.name}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+            {variations.length > 0 && (
+              <div className="px-4 py-3 bg-muted/20 border-t flex justify-end">
+                <span className="text-sm font-semibold">Total Variations: {fmt(variations.reduce((s, v) => s + v.amount, 0), contract.currency)}</span>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* ── Deductions ── */}
+        <Card>
+          <CardHeader>
+            <div className="flex items-center justify-between">
+              <CardTitle className="text-base flex items-center gap-2">
+                <Flag className="size-4 text-rose-600" />
+                Deductions
+              </CardTitle>
+              {canEdit && (
+                <Button size="sm" variant="outline" onClick={() => { setDedDesc(''); setDedAmount(''); setDedDate(new Date().toISOString().split('T')[0]); setDedReason(''); setDedDialog(true); }}>
+                  <Plus className="size-4 mr-1" /> Add Deduction
+                </Button>
+              )}
+            </div>
+          </CardHeader>
+          <CardContent className={deductions.length === 0 ? undefined : 'p-0'}>
+            {deductions.length === 0 ? (
+              <p className="text-sm text-muted-foreground italic">No deductions recorded.</p>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow className="bg-muted/30">
+                    <TableHead>Date</TableHead>
+                    <TableHead>Description</TableHead>
+                    <TableHead>Reason</TableHead>
+                    <TableHead className="text-right">Amount</TableHead>
+                    <TableHead>Status</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {deductions.map(d => (
+                    <TableRow key={d.id}>
+                      <TableCell className="text-xs">{fmtDate(d.deductionDate)}</TableCell>
+                      <TableCell>{d.description}</TableCell>
+                      <TableCell className="text-xs text-muted-foreground">{d.reason ?? '—'}</TableCell>
+                      <TableCell className="text-right font-semibold">{fmt(d.amount, contract.currency)}</TableCell>
+                      <TableCell>
+                        <Badge variant="outline" className={d.status === 'APPLIED' ? 'bg-emerald-100 text-emerald-700 border-emerald-300' : d.status === 'REJECTED' ? 'bg-rose-100 text-rose-700 border-rose-300' : 'bg-amber-100 text-amber-700 border-amber-300'}>
+                          {d.status}
+                        </Badge>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+            {deductions.length > 0 && (
+              <div className="px-4 py-3 bg-muted/20 border-t flex justify-end">
+                <span className="text-sm font-semibold">Total Deductions: {fmt(deductions.reduce((s, d) => s + d.amount, 0), contract.currency)}</span>
+              </div>
+            )}
+          </CardContent>
+        </Card>
       </div>
+
+      {/* ── Add Variation Dialog ── */}
+      <Dialog open={varDialog} onOpenChange={setVarDialog}>
+        <DialogContent className="max-w-md">
+          <DialogHeader><DialogTitle>Add Variation</DialogTitle></DialogHeader>
+          <div className="space-y-3 py-2">
+            <div className="space-y-1.5">
+              <Label>Description <span className="text-destructive">*</span></Label>
+              <Textarea value={varDesc} onChange={e => setVarDesc(e.target.value)} placeholder="Variation description…" rows={3} />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Amount ({contract.currency}) <span className="text-destructive">*</span></Label>
+              <Input type="number" value={varAmount} onChange={e => setVarAmount(e.target.value)} placeholder="0.00" />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Notes</Label>
+              <Textarea value={varNotes} onChange={e => setVarNotes(e.target.value)} placeholder="Additional notes…" rows={2} />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setVarDialog(false)} disabled={varSaving}>Cancel</Button>
+            <Button disabled={varSaving || !varDesc || !varAmount} onClick={async () => {
+              setVarSaving(true);
+              const res = await fetch(`/api/subcontractor-contracts/${id}/variations`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ description: varDesc, amount: Number(varAmount), notes: varNotes || null }),
+              });
+              if (res.ok) { setVarDialog(false); fetchVariations(); }
+              setVarSaving(false);
+            }}>
+              {varSaving ? 'Saving…' : 'Add Variation'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* ── Add Deduction Dialog ── */}
+      <Dialog open={dedDialog} onOpenChange={setDedDialog}>
+        <DialogContent className="max-w-md">
+          <DialogHeader><DialogTitle>Add Deduction</DialogTitle></DialogHeader>
+          <div className="space-y-3 py-2">
+            <div className="space-y-1.5">
+              <Label>Description <span className="text-destructive">*</span></Label>
+              <Input value={dedDesc} onChange={e => setDedDesc(e.target.value)} placeholder="Deduction description…" />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Amount ({contract.currency}) <span className="text-destructive">*</span></Label>
+              <Input type="number" value={dedAmount} onChange={e => setDedAmount(e.target.value)} placeholder="0.00" min="0.01" step="0.01" />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Date</Label>
+              <Input type="date" value={dedDate} onChange={e => setDedDate(e.target.value)} />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Reason</Label>
+              <Textarea value={dedReason} onChange={e => setDedReason(e.target.value)} placeholder="Reason for deduction…" rows={2} />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDedDialog(false)} disabled={dedSaving}>Cancel</Button>
+            <Button disabled={dedSaving || !dedDesc || !dedAmount} onClick={async () => {
+              setDedSaving(true);
+              const res = await fetch(`/api/subcontractor-contracts/${id}/deductions`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ description: dedDesc, amount: Number(dedAmount), deductionDate: dedDate, reason: dedReason || null }),
+              });
+              if (res.ok) { setDedDialog(false); fetchDeductions(); }
+              setDedSaving(false);
+            }}>
+              {dedSaving ? 'Saving…' : 'Add Deduction'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* ── New Certificate Dialog ── */}
       <Dialog open={certDialog} onOpenChange={setCertDialog}>

--- a/src/app/supply-chain/subcontractors/_page-client.tsx
+++ b/src/app/supply-chain/subcontractors/_page-client.tsx
@@ -7,6 +7,9 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/com
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
@@ -17,7 +20,7 @@ import {
 import {
   Handshake, Plus, RefreshCw, Eye, Edit, MoreVertical, TrendingUp,
   DollarSign, CheckCircle2, Clock, AlertTriangle, Ban, Search,
-  Building2, FolderOpen, ChevronRight,
+  Building2, FolderOpen, ChevronRight, Trash2,
 } from 'lucide-react';
 
 type Contract = {
@@ -103,6 +106,9 @@ export default function SubcontractorsPage({ canCreate, canEdit, canDelete, canA
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState('ALL');
+  const [deleteTarget, setDeleteTarget] = useState<{ id: string; contractNumber: string } | null>(null);
+  const [deleteReason, setDeleteReason] = useState('');
+  const [deleting, setDeleting] = useState(false);
 
   const fetchData = useCallback(async () => {
     setLoading(true);
@@ -140,6 +146,25 @@ export default function SubcontractorsPage({ canCreate, canEdit, canDelete, canA
   const getTotalPaid = (c: Contract) => c.paymentCertificates
     .filter(cert => cert.status === 'PAID')
     .reduce((s, cert) => s + Number(cert.paidAmount), 0);
+
+  async function handleDelete() {
+    if (!deleteTarget) return;
+    setDeleting(true);
+    try {
+      const res = await fetch(`/api/subcontractor-contracts/${deleteTarget.id}`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason: deleteReason }),
+      });
+      if (res.ok) {
+        setDeleteTarget(null);
+        setDeleteReason('');
+        fetchData();
+      }
+    } finally {
+      setDeleting(false);
+    }
+  }
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-slate-50 to-white">
@@ -349,6 +374,14 @@ export default function SubcontractorsPage({ canCreate, canEdit, canDelete, canA
                                 <DropdownMenuItem onClick={() => router.push(`/supply-chain/subcontractors/${c.id}`)}>
                                   <Building2 className="size-4 mr-2" /> Payment Certs
                                 </DropdownMenuItem>
+                                {canDelete && ['DRAFT', 'CANCELLED'].includes(c.status) && (
+                                  <DropdownMenuItem
+                                    className="text-rose-600 focus:text-rose-600 focus:bg-rose-50"
+                                    onClick={() => { setDeleteTarget({ id: c.id, contractNumber: c.contractNumber }); setDeleteReason(''); }}
+                                  >
+                                    <Trash2 className="size-4 mr-2" /> Delete
+                                  </DropdownMenuItem>
+                                )}
                               </DropdownMenuContent>
                             </DropdownMenu>
                           </TableCell>
@@ -387,6 +420,36 @@ export default function SubcontractorsPage({ canCreate, canEdit, canDelete, canA
           </div>
         )}
       </div>
+
+      {/* ── Delete confirmation dialog ── */}
+      <Dialog open={!!deleteTarget} onOpenChange={open => { if (!open) setDeleteTarget(null); }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Contract</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3 py-2">
+            <p className="text-sm text-muted-foreground">
+              Are you sure you want to delete <span className="font-semibold text-foreground">{deleteTarget?.contractNumber}</span>? This action cannot be undone.
+            </p>
+            <div className="space-y-1.5">
+              <Label htmlFor="del-reason">Reason (optional)</Label>
+              <Textarea
+                id="del-reason"
+                placeholder="Reason for deletion…"
+                value={deleteReason}
+                onChange={e => setDeleteReason(e.target.value)}
+                rows={3}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteTarget(null)} disabled={deleting}>Cancel</Button>
+            <Button variant="destructive" onClick={handleDelete} disabled={deleting}>
+              {deleting ? 'Deleting…' : 'Delete'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/app/supply-chain/subcontractors/new/_page-client.tsx
+++ b/src/app/supply-chain/subcontractors/new/_page-client.tsx
@@ -17,7 +17,14 @@ import { getDefaultTerms, SCOPE_LABELS, TEMPLATE_LABELS } from '@/lib/services/s
 
 type Project = { id: string; projectNumber: string; name: string };
 type Building = { id: string; designation: string; name: string };
-type Supplier = { id: string; supplierCode: string; name: string; category: string | null; rating: string | null };
+type Supplier = {
+  dolibarr_id: number;
+  name: string;
+  code_supplier: string | null;
+  approval_status: string | null;
+  approval_rating: string | null;
+  approved_supplier_id: string | null;
+};
 type ScopeItem = { scopeType: string; scopeLabel: string; buildingId?: string | null; buildingDesignation?: string | null; originalQuantity?: number | null; originalUnit?: string | null; contractQuantity?: number | null; contractUnit?: string | null; unitRate?: number | null; subtotal?: number | null };
 type PaymentMilestone = { milestone: string; percentage: number; amount: number; dueDate?: string; description?: string };
 
@@ -66,8 +73,11 @@ export default function NewSubcontractorContractPage() {
   }, []);
 
   const fetchSuppliers = useCallback(async () => {
-    const res = await fetch('/api/supply-chain/approved-suppliers');
-    if (res.ok) setSuppliers(await res.json());
+    const res = await fetch('/api/supply-chain/suppliers?limit=200');
+    if (res.ok) {
+      const data = await res.json();
+      setSuppliers(Array.isArray(data.suppliers) ? data.suppliers : []);
+    }
   }, []);
 
   const fetchBuildings = useCallback(async () => {
@@ -170,7 +180,8 @@ export default function NewSubcontractorContractPage() {
         body: JSON.stringify({
           projectId: selectedProject,
           buildingId: selectedBuilding || null,
-          supplierId: selectedSupplier,
+          supplierId: supp?.approved_supplier_id ?? null,
+          dolibarrId: supp?.dolibarr_id ?? null,
           scopeLevel,
           scopeTypes: selectedScopeTypes,
           scopeItems: scopeItems.map(item => ({
@@ -209,7 +220,7 @@ export default function NewSubcontractorContractPage() {
   };
 
   const proj = projects.find(p => p.id === selectedProject);
-  const supp = suppliers.find(s => s.id === selectedSupplier);
+  const supp = suppliers.find(s => String(s.dolibarr_id) === selectedSupplier);
   const bldg = buildings.find(b => b.id === selectedBuilding);
 
   return (
@@ -284,10 +295,10 @@ export default function NewSubcontractorContractPage() {
                   </SelectTrigger>
                   <SelectContent>
                     {suppliers.map(s => (
-                      <SelectItem key={s.id} value={s.id}>
-                        <span className="font-mono mr-2 text-muted-foreground text-xs">{s.supplierCode}</span>
+                      <SelectItem key={s.dolibarr_id} value={String(s.dolibarr_id)}>
+                        <span className="font-mono mr-2 text-muted-foreground text-xs">{s.code_supplier ?? '—'}</span>
                         {s.name}
-                        {s.rating && <Badge variant="outline" className="ml-2 text-xs">{s.rating}</Badge>}
+                        {s.approval_rating && <Badge variant="outline" className="ml-2 text-xs">{s.approval_rating}</Badge>}
                       </SelectItem>
                     ))}
                   </SelectContent>
@@ -613,7 +624,7 @@ export default function NewSubcontractorContractPage() {
               <div className="grid grid-cols-2 gap-4">
                 {[
                   { label: 'Project', value: proj ? `${proj.projectNumber} — ${proj.name}` : '—' },
-                  { label: 'Subcontractor', value: supp ? `${supp.supplierCode} — ${supp.name}` : '—' },
+                  { label: 'Subcontractor', value: supp ? `${supp.code_supplier ?? supp.dolibarr_id} — ${supp.name}` : '—' },
                   { label: 'Building', value: bldg ? `${bldg.designation} — ${bldg.name}` : 'Full Project' },
                   { label: 'Scope Types', value: selectedScopeTypes.map(st => SCOPE_LABELS[st] ?? st).join(', ') },
                   { label: 'Contract Value', value: `${contractValue.toLocaleString('en-SA-u-ca-gregory', { maximumFractionDigits: 2 })} ${currency}` },

--- a/src/lib/services/financial/customer-portal.service.ts
+++ b/src/lib/services/financial/customer-portal.service.ts
@@ -114,7 +114,7 @@ export async function getCustomerOverview(dolibarrId: number): Promise<CustomerO
   const contacts = await prisma.$queryRawUnsafe<CustomerContact[]>(`
     SELECT firstname, lastname, email, phone_pro, phone_mobile, poste
     FROM dolibarr_contacts
-    WHERE dolibarr_thirdparty_id = ? AND statut = 1
+    WHERE dolibarr_thirdparty_id = ? AND is_active = 1
     ORDER BY lastname, firstname
   `, dolibarrId);
 

--- a/src/lib/services/supply-chain/supplier-portal.service.ts
+++ b/src/lib/services/supply-chain/supplier-portal.service.ts
@@ -279,7 +279,7 @@ export async function getSupplierOverview(dolibarrId: number): Promise<SupplierO
   const contacts = await prisma.$queryRawUnsafe<SupplierContact[]>(`
     SELECT firstname, lastname, email, phone_pro, phone_mobile, poste
     FROM dolibarr_contacts
-    WHERE dolibarr_thirdparty_id = ? AND statut = 1
+    WHERE dolibarr_thirdparty_id = ? AND is_active = 1
     ORDER BY lastname, firstname
   `, dolibarrId);
 

--- a/src/lib/subcontractor-contract-pdf-generator.ts
+++ b/src/lib/subcontractor-contract-pdf-generator.ts
@@ -1,0 +1,216 @@
+'use client';
+
+import { PDFReportBuilder, type LogoData, type PDFFontFamily } from './pdf-builder';
+
+const COMPANY = 'Hexa Steel®';
+const TAGLINE = 'Steel Fabrication & Erection · hexasteel.sa';
+const FOOTER = 'Hexa Steel® OTS · Confidential · hexasteel.sa/ots';
+
+async function loadSettingsForPDF(): Promise<{ logo?: LogoData; font: PDFFontFamily; companyName: string; companyTagline: string }> {
+  try {
+    const res = await fetch('/api/settings');
+    const data = res.ok ? await res.json() : {};
+
+    const font: PDFFontFamily = (['helvetica', 'courier', 'times'] as PDFFontFamily[]).includes(data.pdfFont)
+      ? (data.pdfFont as PDFFontFamily)
+      : 'helvetica';
+
+    const companyName: string = data.companyName || COMPANY;
+    const companyTagline: string = data.companyTagline || TAGLINE;
+
+    const whitePath: string | undefined = data.logoWhite;
+    const colorPath: string | undefined = data.companyLogo;
+    const logoPath = whitePath || colorPath;
+    if (!logoPath) return { font, companyName, companyTagline };
+    const isWhite = !!whitePath;
+
+    const imgRes = await fetch(logoPath);
+    if (!imgRes.ok) return { font, companyName, companyTagline };
+    const blob = await imgRes.blob();
+    const base64 = await new Promise<string>((resolve) => {
+      const reader = new FileReader();
+      reader.onloadend = () => resolve(reader.result as string);
+      reader.readAsDataURL(blob);
+    });
+    const aspectRatio = await new Promise<number>((resolve) => {
+      const img = new Image();
+      img.onload = () => resolve(img.naturalWidth / img.naturalHeight || 1);
+      img.onerror = () => resolve(1);
+      img.src = base64;
+    });
+
+    return { logo: { base64, aspectRatio, isWhite }, font, companyName, companyTagline };
+  } catch {
+    return { font: 'helvetica', companyName: COMPANY, companyTagline: TAGLINE };
+  }
+}
+
+export interface SCContractPDFData {
+  contractNumber: string;
+  name: string;
+  status: string;
+  contractValue: number;
+  currency: string;
+  retentionPercentage: number;
+  scopeTypes: string[];
+  scopeItems: Array<Record<string, unknown>> | null;
+  paymentTerms: Array<Record<string, unknown>> | null;
+  termsAndConditions: string | null;
+  templateType: string | null;
+  notes: string | null;
+  createdAt: string;
+  submittedAt: string | null;
+  approvedAt: string | null;
+  project: { projectNumber: string; name: string };
+  building: { designation: string; name: string } | null;
+  supplier: { supplierCode: string; name: string; rating: string | null; scopeOfApproval: string | null };
+  createdBy: { name: string };
+  approvedBy: { name: string } | null;
+  variations?: Array<{ variationNumber: string; description: string; amount: number; status: string }>;
+  deductions?: Array<{ description: string; amount: number; deductionDate: string; status: string }>;
+}
+
+function fmtCurrency(n: number, currency: string): string {
+  return new Intl.NumberFormat('en-SA-u-ca-gregory', { style: 'currency', currency, maximumFractionDigits: 2 }).format(n);
+}
+
+function fmtDate(iso: string | null): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleDateString('en-SA-u-ca-gregory', { day: '2-digit', month: 'short', year: 'numeric' });
+}
+
+export async function generateSubcontractorContractPDF(data: SCContractPDFData): Promise<void> {
+  const { logo, font, companyName, companyTagline } = await loadSettingsForPDF();
+
+  const pdf = new PDFReportBuilder('portrait', 'orange', font);
+
+  // Header
+  pdf.addHeader(companyName, companyTagline, logo);
+
+  // Title
+  pdf.addTitle(
+    'Subcontractor Contract',
+    `${data.contractNumber} · ${data.project.projectNumber} — ${data.project.name}`
+  );
+
+  // Metadata box
+  pdf.addMetadataBox({
+    'Date': fmtDate(data.createdAt),
+    'Status': data.status,
+    'Currency': data.currency,
+  });
+
+  // Parties
+  pdf.addSectionHeader('CONTRACTING PARTIES');
+  pdf.addInfoGrid({
+    'Client (Principal)': companyName,
+    'Subcontractor': data.supplier.name,
+    'SC Code': data.supplier.supplierCode,
+    'Rating': data.supplier.rating || '—',
+    'Scope of Approval': data.supplier.scopeOfApproval || '—',
+    'Project': `${data.project.projectNumber} — ${data.project.name}`,
+    'Building': data.building ? `${data.building.designation} — ${data.building.name}` : 'Full Project',
+    'Scope': data.scopeTypes.map(s => s.replace(/_/g, ' ')).join(', '),
+  }, 2);
+
+  // Contract Details
+  pdf.addSectionHeader('CONTRACT DETAILS');
+  pdf.addInfoGrid({
+    'Contract Value': fmtCurrency(data.contractValue, data.currency),
+    'Retention': `${data.retentionPercentage}%`,
+    'Net After Retention': fmtCurrency(data.contractValue * (1 - data.retentionPercentage / 100), data.currency),
+    'Template': data.templateType?.replace(/_/g, ' ') || 'Custom',
+    'Approved By': data.approvedBy?.name || '—',
+    'Approval Date': fmtDate(data.approvedAt),
+  }, 2);
+
+  // Scope of Work table
+  if (data.scopeItems && data.scopeItems.length > 0) {
+    pdf.addSectionHeader('SCOPE OF WORK');
+    pdf.addTable(
+      ['Scope', 'Orig. Qty', 'Unit', 'Contract Qty', 'Unit', 'Unit Rate', `Subtotal (${data.currency})`],
+      data.scopeItems.map(item => [
+        String(item.scopeLabel ?? item.scopeType ?? ''),
+        item.originalQuantity != null ? String(item.originalQuantity) : '—',
+        String(item.originalUnit ?? '—'),
+        item.contractQuantity != null ? String(item.contractQuantity) : '—',
+        String(item.contractUnit ?? '—'),
+        item.unitRate != null ? Number(item.unitRate).toFixed(2) : '—',
+        item.subtotal != null ? Number(item.subtotal).toLocaleString('en-SA-u-ca-gregory', { maximumFractionDigits: 2 }) : '—',
+      ]),
+      { alternateRows: true }
+    );
+  }
+
+  // Payment Terms
+  if (data.paymentTerms && data.paymentTerms.length > 0) {
+    pdf.addSectionHeader('PAYMENT TERMS');
+    pdf.addTable(
+      ['Milestone', '%', `Amount (${data.currency})`, 'Due Date', 'Description'],
+      data.paymentTerms.map(m => [
+        String(m.milestone ?? ''),
+        `${m.percentage ?? 0}%`,
+        m.amount != null ? fmtCurrency(Number(m.amount), data.currency) : '—',
+        m.dueDate ? fmtDate(String(m.dueDate)) : '—',
+        String(m.description ?? '—'),
+      ]),
+      { alternateRows: true }
+    );
+  }
+
+  // Variations
+  if (data.variations && data.variations.length > 0) {
+    pdf.addSectionHeader('VARIATIONS');
+    pdf.addTable(
+      ['Variation #', 'Description', `Amount (${data.currency})`, 'Status'],
+      data.variations.map(v => [
+        v.variationNumber,
+        v.description,
+        fmtCurrency(v.amount, data.currency),
+        v.status,
+      ]),
+      { alternateRows: true }
+    );
+  }
+
+  // Deductions
+  if (data.deductions && data.deductions.length > 0) {
+    pdf.addSectionHeader('DEDUCTIONS');
+    pdf.addTable(
+      ['Date', 'Description', `Amount (${data.currency})`, 'Status'],
+      data.deductions.map(d => [
+        fmtDate(d.deductionDate),
+        d.description,
+        fmtCurrency(d.amount, data.currency),
+        d.status,
+      ]),
+      { alternateRows: true }
+    );
+  }
+
+  // Terms & Conditions
+  if (data.termsAndConditions) {
+    pdf.addSectionHeader('TERMS & CONDITIONS');
+    pdf.addParagraph(data.termsAndConditions, 8);
+  }
+
+  // Notes
+  if (data.notes) {
+    pdf.addSectionHeader('NOTES');
+    pdf.addParagraph(data.notes, 8);
+  }
+
+  // Signature section
+  pdf.addDivider();
+  pdf.addSignatureSection([
+    { label: 'Prepared By', name: data.createdBy.name, date: fmtDate(data.createdAt) },
+    { label: 'Approved By (Hexa Steel)', name: data.approvedBy?.name, date: fmtDate(data.approvedAt) },
+    { label: 'Subcontractor Signature', name: data.supplier.name },
+  ]);
+
+  pdf.addFooter(FOOTER, `Contract: ${data.contractNumber}`);
+
+  // Save / open
+  const filename = `SC-Contract-${data.contractNumber}.pdf`;
+  pdf.save(filename);
+}


### PR DESCRIPTION
- Project card: add 5th KPI tile for purlins weight (tons) computed from assembly parts
- Project card: add Production Progress section (Fit-up, Welding, Visualization bars)
- Project card: add Coating & Dispatch Progress section (Painting, Sandblasting, Galvanization, Dispatch bars)
- Subcontractors list: add Delete option in three-dots dropdown for DRAFT/CANCELLED contracts
- New subcontract form: switch supplier dropdown to Dolibarr supplier list (/api/supply-chain/suppliers)
  with auto-create ScApprovedSupplier when only dolibarrId is available
- Subcontract detail: add Variations tab (add/approve/reject/delete variations)
- Subcontract detail: add Deductions tab (add/approve/reject/delete deductions)
- Subcontract detail: add Print Contract button using client-side PDF generator with logo, scope table, payment terms, variations, deductions, T&C, signature block
- Prisma schema: add SubcontractorVariation and SubcontractorDeduction models
- Migration: add_subcontractor_variations_deductions.sql
- Supplier detail page fix: change dolibarr_contacts query from statut=1 to is_active=1 (fixes 500 error)
- Same fix applied to customer portal contacts query

https://claude.ai/code/session_014UBF8DF7vibG21mMmV4qZi