### PR TITLE
feat(financial): add salary & VAT amounts to cash flow, monthly report and dashboard

### DIFF
--- a/src/app/api/financial/reports/monthly-report/route.ts
+++ b/src/app/api/financial/reports/monthly-report/route.ts
@@ -75,6 +75,29 @@ export async function GET(req: Request) {
       `, monthStart, monthEnd);
     } catch { /* table may be empty */ }
 
+    // ── VAT summary for the period ──────────────────────────────────────────────
+    let totalVatOut = 0, totalVatIn = 0;
+    try {
+      const vatOutRows: any[] = await prisma.$queryRawUnsafe(`
+        SELECT COALESCE(SUM(cil.total_tva), 0) AS total
+        FROM fin_customer_invoice_lines cil
+        JOIN fin_customer_invoices ci ON ci.dolibarr_id = cil.invoice_dolibarr_id
+        WHERE ci.status IN (1, 2) AND ci.is_active = 1
+          AND ci.date_invoice >= ? AND ci.date_invoice < ?
+      `, monthStart, monthEnd);
+      totalVatOut = Number(vatOutRows[0]?.total || 0);
+    } catch { /* */ }
+    try {
+      const vatInRows: any[] = await prisma.$queryRawUnsafe(`
+        SELECT COALESCE(SUM(sil.total_tva), 0) AS total
+        FROM fin_supplier_invoice_lines sil
+        JOIN fin_supplier_invoices si ON si.dolibarr_id = sil.invoice_dolibarr_id
+        WHERE si.status IN (1, 2) AND si.is_active = 1
+          AND si.date_invoice >= ? AND si.date_invoice < ?
+      `, monthStart, monthEnd);
+      totalVatIn = Number(vatInRows[0]?.total || 0);
+    } catch { /* */ }
+
     const income = incomeRows.map((r: any) => ({
       entityName:   r.entity_name   || 'Unknown',
       totalAmount:  Number(r.total_amount  || 0),
@@ -120,6 +143,9 @@ export async function GET(req: Request) {
         grossProfit,
         netProfit,
         netMarginPct: totalIncome > 0 ? (netProfit / totalIncome) * 100 : 0,
+        totalVatOut,
+        totalVatIn,
+        netVat: totalVatOut - totalVatIn,
       },
     });
   } catch (error: any) {

--- a/src/app/financial/_page-client.tsx
+++ b/src/app/financial/_page-client.tsx
@@ -160,6 +160,10 @@ export default function FinancialDashboardPage() {
               </div>
               <div className="text-2xl font-bold text-red-600">{formatCompact(d.totalExpenses || 0)}</div>
               <div className="text-xs text-muted-foreground mt-0.5">{formatSAR(d.totalExpenses || 0)}</div>
+              <div className="text-[10px] text-muted-foreground mt-1">Incl. supplier costs &amp; salaries</div>
+              {(d.totalCashPaidOut || 0) > 0 && (
+                <div className="text-[10px] text-orange-600 mt-0.5">Cash paid: {formatSAR(d.totalCashPaidOut || 0)}</div>
+              )}
               <div className="text-[10px] text-primary mt-1 flex items-center">Expenses Analysis <ArrowRight className="h-3 w-3 ml-1" /></div>
             </CardContent>
           </Card>

--- a/src/app/financial/reports/cash-flow/_page-client.tsx
+++ b/src/app/financial/reports/cash-flow/_page-client.tsx
@@ -100,6 +100,7 @@ export default function MonthlyCashFlowPage() {
                   <TrendingUp className="h-4 w-4 text-green-500" />
                 </div>
                 <div className="text-2xl font-bold text-green-600">{formatSAR(report.totalCashIn)}</div>
+                <div className="text-xs text-muted-foreground mt-1">Customer collections</div>
               </CardContent>
             </Card>
             <Card className="border-red-200 dark:border-red-900/50">
@@ -108,7 +109,13 @@ export default function MonthlyCashFlowPage() {
                   <span className="text-sm text-muted-foreground">Total Cash Out</span>
                   <TrendingDown className="h-4 w-4 text-red-500" />
                 </div>
-                <div className="text-2xl font-bold text-red-600">{formatSAR(report.totalCashOut)}</div>
+                <div className="text-2xl font-bold text-red-600">{formatSAR(report.grandTotalCashOut ?? report.totalCashOut)}</div>
+                {(report.totalCashOutSalaries ?? 0) > 0 && (
+                  <div className="text-xs text-muted-foreground mt-1 space-y-0.5">
+                    <div>Suppliers: {formatSAR(report.totalCashOut)}</div>
+                    <div>Salaries: {formatSAR(report.totalCashOutSalaries)}</div>
+                  </div>
+                )}
               </CardContent>
             </Card>
             <Card className="border-blue-200 dark:border-blue-900/50">
@@ -120,6 +127,11 @@ export default function MonthlyCashFlowPage() {
                 <div className={`text-2xl font-bold ${report.totalNet >= 0 ? 'text-green-600' : 'text-red-600'}`}>
                   {formatSAR(report.totalNet)}
                 </div>
+                {(report.totalVatNet ?? 0) !== 0 && (
+                  <div className="text-xs text-muted-foreground mt-1">
+                    Net VAT position: {formatSAR(report.totalVatNet)}
+                  </div>
+                )}
               </CardContent>
             </Card>
           </div>
@@ -136,7 +148,9 @@ export default function MonthlyCashFlowPage() {
                     <tr className="border-b bg-muted/50">
                       <th className="text-left p-3">Month</th>
                       <th className="text-right p-3">Cash In (Collections)</th>
-                      <th className="text-right p-3">Cash Out (Payments)</th>
+                      <th className="text-right p-3">Supplier Payments</th>
+                      <th className="text-right p-3">Salary Payments</th>
+                      <th className="text-right p-3">Total Cash Out</th>
                       <th className="text-right p-3">Net</th>
                     </tr>
                   </thead>
@@ -162,6 +176,12 @@ export default function MonthlyCashFlowPage() {
                             {formatSAR(m.cashOut)}
                           </button>
                         </td>
+                        <td className="p-3 text-right text-orange-600">
+                          {(m.cashOutSalaries ?? 0) > 0 ? formatSAR(m.cashOutSalaries) : <span className="text-muted-foreground">—</span>}
+                        </td>
+                        <td className="p-3 text-right font-medium text-red-600">
+                          {formatSAR(m.totalCashOut ?? m.cashOut)}
+                        </td>
                         <td className={`p-3 text-right font-semibold ${m.net >= 0 ? 'text-green-600' : 'text-red-600'}`}>
                           {formatSAR(m.net)}
                         </td>
@@ -171,6 +191,8 @@ export default function MonthlyCashFlowPage() {
                       <td className="p-3">Total</td>
                       <td className="p-3 text-right text-green-600">{formatSAR(report.totalCashIn)}</td>
                       <td className="p-3 text-right text-red-600">{formatSAR(report.totalCashOut)}</td>
+                      <td className="p-3 text-right text-orange-600">{formatSAR(report.totalCashOutSalaries ?? 0)}</td>
+                      <td className="p-3 text-right text-red-600">{formatSAR(report.grandTotalCashOut ?? report.totalCashOut)}</td>
                       <td className={`p-3 text-right ${report.totalNet >= 0 ? 'text-green-600' : 'text-red-600'}`}>
                         {formatSAR(report.totalNet)}
                       </td>
@@ -180,6 +202,37 @@ export default function MonthlyCashFlowPage() {
               </div>
             </CardContent>
           </Card>
+
+          {/* VAT Position Summary */}
+          {(report.totalVatOutput > 0 || report.totalVatInput > 0) && (
+            <Card className="border-amber-200 dark:border-amber-900/50">
+              <CardHeader className="pb-3">
+                <CardTitle className="text-base text-amber-700 dark:text-amber-400">VAT Position — {year}</CardTitle>
+                <p className="text-xs text-muted-foreground">Based on invoice dates. Actual ZATCA settlement timing may differ.</p>
+              </CardHeader>
+              <CardContent>
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm">
+                  <div>
+                    <div className="text-muted-foreground mb-1">Output VAT Collected</div>
+                    <div className="font-semibold text-blue-600">{formatSAR(report.totalVatOutput)}</div>
+                    <div className="text-xs text-muted-foreground">From customer invoices</div>
+                  </div>
+                  <div>
+                    <div className="text-muted-foreground mb-1">Input VAT Paid</div>
+                    <div className="font-semibold text-green-600">{formatSAR(report.totalVatInput)}</div>
+                    <div className="text-xs text-muted-foreground">From supplier invoices</div>
+                  </div>
+                  <div>
+                    <div className="text-muted-foreground mb-1">{(report.totalVatNet ?? 0) >= 0 ? 'Net VAT Payable' : 'Net VAT Refundable'}</div>
+                    <div className={`font-semibold ${(report.totalVatNet ?? 0) >= 0 ? 'text-orange-600' : 'text-emerald-600'}`}>
+                      {formatSAR(Math.abs(report.totalVatNet ?? 0))}
+                    </div>
+                    <div className="text-xs text-muted-foreground">Output − Input</div>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          )}
         </>
       )}
 

--- a/src/app/financial/reports/monthly-report/_page-client.tsx
+++ b/src/app/financial/reports/monthly-report/_page-client.tsx
@@ -88,6 +88,9 @@ interface ReportData {
     grossProfit: number;
     netProfit: number;
     netMarginPct: number;
+    totalVatOut: number;
+    totalVatIn: number;
+    netVat: number;
   };
 }
 
@@ -100,7 +103,7 @@ function KpiTile({
   value: string;
   sub?: string;
   icon: any;
-  color: 'green' | 'red' | 'blue' | 'amber';
+  color: 'green' | 'red' | 'blue' | 'amber' | 'orange' | 'emerald';
   trend?: 'up' | 'down' | 'neutral';
 }) {
   const colors = {
@@ -127,6 +130,18 @@ function KpiTile({
       icon:   'bg-amber-100 dark:bg-amber-900/30 text-amber-600 dark:text-amber-400',
       value:  'text-amber-600 dark:text-amber-400',
       glow:   'from-amber-50 to-transparent dark:from-amber-950/20',
+    },
+    orange: {
+      border: 'border-orange-200 dark:border-orange-900/50',
+      icon:   'bg-orange-100 dark:bg-orange-900/30 text-orange-600 dark:text-orange-400',
+      value:  'text-orange-600 dark:text-orange-400',
+      glow:   'from-orange-50 to-transparent dark:from-orange-950/20',
+    },
+    emerald: {
+      border: 'border-emerald-200 dark:border-emerald-900/50',
+      icon:   'bg-emerald-100 dark:bg-emerald-900/30 text-emerald-600 dark:text-emerald-400',
+      value:  'text-emerald-600 dark:text-emerald-400',
+      glow:   'from-emerald-50 to-transparent dark:from-emerald-950/20',
     },
   }[color];
 
@@ -425,7 +440,7 @@ export default function MonthlyFinancialReportPage() {
         ) : (
           <>
             {/* ── KPI Tiles ───────────────────────────────────────────────── */}
-            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
+            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
               <KpiTile
                 label="Total Income"
                 value={formatCompact(t?.totalIncome || 0)}
@@ -456,6 +471,13 @@ export default function MonthlyFinancialReportPage() {
                 sub={`${data?.salaries?.length || 0} records`}
                 icon={Users}
                 color="amber"
+              />
+              <KpiTile
+                label={(t?.netVat ?? 0) >= 0 ? 'Net VAT Payable' : 'Net VAT Refundable'}
+                value={formatCompact(Math.abs(t?.netVat ?? 0))}
+                sub={`Out: ${formatCompact(t?.totalVatOut ?? 0)} / In: ${formatCompact(t?.totalVatIn ?? 0)}`}
+                icon={Receipt}
+                color={(t?.netVat ?? 0) >= 0 ? 'orange' : 'emerald'}
               />
               <KpiTile
                 label="Net Profit"
@@ -755,6 +777,46 @@ export default function MonthlyFinancialReportPage() {
                   </CardContent>
                 </Card>
 
+                {/* VAT Summary Card */}
+                {((t?.totalVatOut ?? 0) > 0 || (t?.totalVatIn ?? 0) > 0) && (
+                  <Card className="border-orange-200 dark:border-orange-900/50">
+                    <CardHeader className="pb-3 bg-gradient-to-r from-orange-50 to-amber-50 dark:from-orange-950/30 dark:to-amber-950/20 rounded-t-xl border-b border-orange-100 dark:border-orange-900/40">
+                      <div className="flex items-center justify-between">
+                        <CardTitle className="flex items-center gap-2 text-orange-700 dark:text-orange-400">
+                          <div className="p-1.5 bg-orange-100 dark:bg-orange-900/50 rounded-lg">
+                            <Receipt className="h-4 w-4" />
+                          </div>
+                          VAT / Tax Summary
+                        </CardTitle>
+                        <Badge variant="secondary" className="bg-orange-100 text-orange-700 dark:bg-orange-900/50 dark:text-orange-300 border-0">
+                          {(t?.netVat ?? 0) >= 0 ? 'Payable' : 'Refundable'}: {formatCompact(Math.abs(t?.netVat ?? 0))}
+                        </Badge>
+                      </div>
+                    </CardHeader>
+                    <CardContent className="pt-4 pb-4">
+                      <div className="grid grid-cols-3 gap-4 text-sm">
+                        <div className="space-y-1">
+                          <div className="text-xs text-muted-foreground uppercase tracking-wide">Output VAT Collected</div>
+                          <div className="font-bold text-blue-600 tabular-nums">{formatSAR(t?.totalVatOut ?? 0)}</div>
+                          <div className="text-xs text-muted-foreground">From customer invoices</div>
+                        </div>
+                        <div className="space-y-1">
+                          <div className="text-xs text-muted-foreground uppercase tracking-wide">Input VAT Paid</div>
+                          <div className="font-bold text-green-600 tabular-nums">{formatSAR(t?.totalVatIn ?? 0)}</div>
+                          <div className="text-xs text-muted-foreground">From supplier invoices</div>
+                        </div>
+                        <div className="space-y-1">
+                          <div className="text-xs text-muted-foreground uppercase tracking-wide">{(t?.netVat ?? 0) >= 0 ? 'Net VAT Payable' : 'Net VAT Refundable'}</div>
+                          <div className={`font-bold tabular-nums ${(t?.netVat ?? 0) >= 0 ? 'text-orange-600' : 'text-emerald-600'}`}>
+                            {formatSAR(Math.abs(t?.netVat ?? 0))}
+                          </div>
+                          <div className="text-xs text-muted-foreground">Output − Input</div>
+                        </div>
+                      </div>
+                    </CardContent>
+                  </Card>
+                )}
+
               </div>{/* end Expenses column */}
             </div>{/* end side-by-side grid */}
 
@@ -781,6 +843,15 @@ export default function MonthlyFinancialReportPage() {
                       <span className="text-sm text-muted-foreground">Expenses:</span>
                       <span className="text-sm font-bold text-red-600 tabular-nums">{formatSAR(t?.totalExpenses || 0)}</span>
                     </div>
+                    {(t?.netVat ?? 0) !== 0 && (
+                      <div className="flex items-center gap-2">
+                        <span className="h-2.5 w-2.5 rounded-full bg-orange-500 shrink-0" />
+                        <span className="text-sm text-muted-foreground">{(t?.netVat ?? 0) >= 0 ? 'VAT Payable:' : 'VAT Refund:'}</span>
+                        <span className={`text-sm font-bold tabular-nums ${(t?.netVat ?? 0) >= 0 ? 'text-orange-600' : 'text-emerald-600'}`}>
+                          {formatSAR(Math.abs(t?.netVat ?? 0))}
+                        </span>
+                      </div>
+                    )}
                     <div className="flex items-center gap-2">
                       <span className={`h-2.5 w-2.5 rounded-full shrink-0 ${(t?.netProfit || 0) >= 0 ? 'bg-blue-500' : 'bg-red-500'}`} />
                       <span className="text-sm text-muted-foreground">Net:</span>

--- a/src/lib/financial/report-service.ts
+++ b/src/lib/financial/report-service.ts
@@ -795,6 +795,28 @@ export class FinancialReportService {
     // so always add them together.
     const totalExpensesWithSalaries = totalExpenses + salariesExpense;
 
+    // Cash-basis total paid out: actual supplier payments + paid salary disbursements
+    let supplierCashPaid = 0, salariesCashPaid = 0;
+    try {
+      const scRows: any[] = await prisma.$queryRawUnsafe(`
+        SELECT COALESCE(SUM(amount), 0) as total
+        FROM fin_payments
+        WHERE payment_type = 'supplier'
+          AND payment_date BETWEEN ? AND ?
+      `, fromDate, toDate);
+      supplierCashPaid = Number(scRows[0]?.total || 0);
+    } catch { /* */ }
+    try {
+      const scSalRows: any[] = await prisma.$queryRawUnsafe(`
+        SELECT COALESCE(SUM(amount), 0) as total
+        FROM fin_salaries
+        WHERE is_active = 1 AND is_paid = 1
+          AND COALESCE(date_payment, date_end) BETWEEN ? AND ?
+      `, fromDate, toDate);
+      salariesCashPaid = Number(scSalRows[0]?.total || 0);
+    } catch { /* */ }
+    const totalCashPaidOut = supplierCashPaid + salariesCashPaid;
+
     // Project count
     let projectCount = 0;
     try {
@@ -824,6 +846,9 @@ export class FinancialReportService {
       totalRevenue,
       totalExpenses: totalExpensesWithSalaries,
       totalExpensesExSalaries: totalExpenses,
+      totalCashPaidOut,
+      supplierCashPaid,
+      salariesCashPaid,
       netProfit,
       costOfSales,
       grossProfit,
@@ -997,7 +1022,8 @@ export class FinancialReportService {
         ? `${year}-12-31`
         : `${year}-${String(m + 1).padStart(2, '0')}-01`;
 
-      let cashIn = 0, cashOut = 0;
+      let cashIn = 0, cashOut = 0, cashOutSalaries = 0;
+      let vatOutput = 0, vatInput = 0;
 
       try {
         const inRows: any[] = await prisma.$queryRawUnsafe(`
@@ -1046,24 +1072,75 @@ export class FinancialReportService {
         } catch { /* */ }
       }
 
+      // Paid salary disbursements for the month (use date_payment, fall back to date_end)
+      try {
+        const salRows: any[] = await prisma.$queryRawUnsafe(`
+          SELECT COALESCE(SUM(amount), 0) as total
+          FROM fin_salaries
+          WHERE is_active = 1 AND is_paid = 1
+            AND COALESCE(date_payment, date_end) >= ? AND COALESCE(date_payment, date_end) < ?
+        `, monthStart, monthEnd);
+        cashOutSalaries = Number(salRows[0]?.total || 0);
+      } catch { /* */ }
+
+      // VAT output (collected on customer invoices dated this month)
+      try {
+        const vatOutRows: any[] = await prisma.$queryRawUnsafe(`
+          SELECT COALESCE(SUM(cil.total_tva), 0) as total
+          FROM fin_customer_invoice_lines cil
+          JOIN fin_customer_invoices ci ON ci.dolibarr_id = cil.invoice_dolibarr_id
+          WHERE ci.status IN (1, 2) AND ci.is_active = 1
+            AND ci.date_invoice >= ? AND ci.date_invoice < ?
+        `, monthStart, monthEnd);
+        vatOutput = Number(vatOutRows[0]?.total || 0);
+      } catch { /* */ }
+
+      // VAT input (paid on supplier invoices dated this month)
+      try {
+        const vatInRows: any[] = await prisma.$queryRawUnsafe(`
+          SELECT COALESCE(SUM(sil.total_tva), 0) as total
+          FROM fin_supplier_invoice_lines sil
+          JOIN fin_supplier_invoices si ON si.dolibarr_id = sil.invoice_dolibarr_id
+          WHERE si.status IN (1, 2) AND si.is_active = 1
+            AND si.date_invoice >= ? AND si.date_invoice < ?
+        `, monthStart, monthEnd);
+        vatInput = Number(vatInRows[0]?.total || 0);
+      } catch { /* */ }
+
+      const totalCashOut = cashOut + cashOutSalaries;
+
       months.push({
         month: m,
         monthName: new Date(year, m - 1, 1).toLocaleString('en', { month: 'short' }),
         cashIn,
         cashOut,
-        net: cashIn - cashOut,
+        cashOutSalaries,
+        totalCashOut,
+        vatOutput,
+        vatInput,
+        vatNet: vatOutput - vatInput,
+        net: cashIn - totalCashOut,
       });
     }
 
     const totalCashIn = months.reduce((s, m) => s + m.cashIn, 0);
     const totalCashOut = months.reduce((s, m) => s + m.cashOut, 0);
+    const totalCashOutSalaries = months.reduce((s, m) => s + m.cashOutSalaries, 0);
+    const totalVatOutput = months.reduce((s, m) => s + m.vatOutput, 0);
+    const totalVatInput = months.reduce((s, m) => s + m.vatInput, 0);
+    const grandTotalCashOut = totalCashOut + totalCashOutSalaries;
 
     return {
       year,
       months,
       totalCashIn,
       totalCashOut,
-      totalNet: totalCashIn - totalCashOut,
+      totalCashOutSalaries,
+      grandTotalCashOut,
+      totalVatOutput,
+      totalVatInput,
+      totalVatNet: totalVatOutput - totalVatInput,
+      totalNet: totalCashIn - grandTotalCashOut,
     };
   }
 


### PR DESCRIPTION
- getMonthlyCashFlow: adds paid salary disbursements (fin_salaries is_paid=1,
  date_payment) and per-month VAT output/input per invoice dates as separate
  columns; grandTotalCashOut = supplier payments + salary payments
- getDashboardSummary: computes totalCashPaidOut (actual cash-basis outflow:
  supplier fin_payments + paid fin_salaries) in addition to existing accrual
  totalExpenses
- Monthly report API: appends totalVatOut, totalVatIn, netVat to totals
- Cash flow client: new Supplier Payments / Salary Payments / Total Cash Out
  columns; VAT Position summary card at the bottom
- Monthly report client: 6th KPI tile for Net VAT Position; VAT Summary card
  showing output/input/net; summary bar shows VAT payable/refundable; KpiTile
  extended with orange and emerald color variants
- Dashboard: Total Expenses tile shows "Cash paid: X" sub-line (cash-basis)
  alongside the existing accrual total

https://claude.ai/code/session_01DW7PmaL7kAayTARfojHq1G