### PR TITLE
feat: supply chain & project card multi-feature update

### DIFF
--- a/src/app/api/subcontractor-contracts/[id]/route.ts
+++ b/src/app/api/subcontractor-contracts/[id]/route.ts
@@ -85,11 +85,34 @@ export const DELETE = withApiContext(async (req: NextRequest, session, context) 
   if (!id) return NextResponse.json({ error: 'Missing id' }, { status: 400 });
 
   let reason = 'Deleted by user';
+  let force = false;
   try {
-    const body = await req.json() as { reason?: string };
+    const body = await req.json() as { reason?: string; force?: boolean };
     if (body.reason) reason = body.reason;
-  } catch { /* reason stays default */ }
+    if (body.force) force = true;
+  } catch { /* defaults stay */ }
 
+  // Hard delete — admin/CEO only
+  if (force) {
+    if (!['admin', 'ceo'].includes(session.role?.toLowerCase() ?? '')) {
+      return NextResponse.json({ error: 'Forbidden: only admin or CEO can force-delete contracts' }, { status: 403 });
+    }
+    if (!reason) {
+      return NextResponse.json({ error: 'Reason is required for force delete' }, { status: 422 });
+    }
+    try {
+      const existing = await prisma.subcontractorContract.findFirst({ where: { id } });
+      if (!existing) return NextResponse.json({ error: 'Contract not found' }, { status: 404 });
+      await prisma.subcontractorContract.delete({ where: { id } });
+      logger.info({ id, reason, userId: session.userId }, '[SC Contracts] Force-deleted contract');
+      return NextResponse.json({ success: true });
+    } catch (error) {
+      logger.error({ error, id }, '[SC Contracts] Failed to force-delete contract');
+      return NextResponse.json({ error: 'Failed to force-delete contract' }, { status: 500 });
+    }
+  }
+
+  // Soft delete
   try {
     const existing = await prisma.subcontractorContract.findUnique({ where: { id, deletedAt: null } });
     if (!existing) return NextResponse.json({ error: 'Contract not found' }, { status: 404 });

--- a/src/app/api/supply-chain/purchase-orders/sync-invoice-links/route.ts
+++ b/src/app/api/supply-chain/purchase-orders/sync-invoice-links/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from 'next/server';
+import { withApiContext } from '@/lib/api-utils';
+import { createDolibarrClient } from '@/lib/dolibarr/dolibarr-client';
+import prisma from '@/lib/db';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+export const POST = withApiContext(async (_req, session) => {
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  try {
+    const client = createDolibarrClient();
+    let updated = 0;
+    let page = 0;
+    const batchSize = 200;
+    let hasMore = true;
+
+    while (hasMore) {
+      const invoices = await client.getSupplierInvoices({ limit: batchSize, page, sortfield: 't.rowid', sortorder: 'ASC' });
+      if (!invoices.length) break;
+      hasMore = invoices.length >= batchSize;
+
+      for (const inv of invoices) {
+        const invId = Number(inv.id);
+        if (!invId) continue;
+
+        let poId: number | null = null;
+
+        // Strategy A: origin-based link
+        if ((inv as Record<string, unknown>).origin_type === 'order_supplier') {
+          const originId = Number((inv as Record<string, unknown>).origin_id);
+          if (originId > 0) poId = originId;
+        }
+
+        // Strategy B: fetch full record and check linked_objects
+        if (!poId) {
+          try {
+            const full = await client.getSupplierInvoiceById(invId);
+            if (full) {
+              const linked = (full as Record<string, unknown>).linked_objects as Record<string, unknown> | undefined;
+              if (linked) {
+                const orderSupplier = linked['order_supplier'] as Record<string, unknown> | undefined;
+                if (orderSupplier) {
+                  const firstId = Object.keys(orderSupplier)[0];
+                  if (firstId) poId = Number(firstId);
+                }
+              }
+            }
+          } catch { /* non-fatal */ }
+        }
+
+        if (poId && poId > 0) {
+          await prisma.$executeRawUnsafe(
+            `UPDATE fin_supplier_invoices SET linked_po_dolibarr_id = ? WHERE dolibarr_id = ? AND (linked_po_dolibarr_id IS NULL OR linked_po_dolibarr_id != ?)`,
+            poId, invId, poId,
+          );
+          updated++;
+        }
+      }
+
+      page++;
+    }
+
+    logger.info({ updated, userId: session.userId }, '[PO] Synced invoice links');
+    return NextResponse.json({ success: true, updated });
+  } catch (error) {
+    logger.error({ error }, '[PO] Failed to sync invoice links');
+    return NextResponse.json({ error: 'Sync failed' }, { status: 500 });
+  }
+});

--- a/src/app/api/supply-chain/suppliers/[id]/subcontracts/route.ts
+++ b/src/app/api/supply-chain/suppliers/[id]/subcontracts/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withApiContext } from '@/lib/api-utils';
+import prisma from '@/lib/db';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+export const GET = withApiContext(async (_req: NextRequest, session, context) => {
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const supplierId = Number(context?.params.id);
+  if (!supplierId || isNaN(supplierId)) {
+    return NextResponse.json({ error: 'Invalid supplier id' }, { status: 400 });
+  }
+
+  try {
+    const contracts = await prisma.subcontractorContract.findMany({
+      where: {
+        deletedAt: null,
+        supplier: { dolibarrId: supplierId },
+      },
+      select: {
+        id: true,
+        contractNumber: true,
+        name: true,
+        status: true,
+        contractValue: true,
+        currency: true,
+        scopeTypes: true,
+        createdAt: true,
+        project: { select: { id: true, projectNumber: true, name: true } },
+        building: { select: { id: true, designation: true, name: true } },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    return NextResponse.json({
+      contracts: contracts.map(c => ({
+        ...c,
+        contractValue: Number(c.contractValue),
+      })),
+    });
+  } catch (error) {
+    logger.error({ error, supplierId }, '[Suppliers] Failed to fetch subcontracts');
+    return NextResponse.json({ error: 'Failed to fetch subcontracts' }, { status: 500 });
+  }
+});

--- a/src/app/api/supply-chain/suppliers/route.ts
+++ b/src/app/api/supply-chain/suppliers/route.ts
@@ -6,9 +6,11 @@ import { getSupplierList } from '@/lib/services/supply-chain/supplier-portal.ser
 export const dynamic = 'force-dynamic';
 
 const querySchema = z.object({
-  search: z.string().optional(),
-  page:  z.coerce.number().min(1).default(1),
-  limit: z.coerce.number().min(1).max(200).default(50),
+  search:  z.string().optional(),
+  page:    z.coerce.number().min(1).default(1),
+  limit:   z.coerce.number().min(1).max(200).default(50),
+  sortKey: z.enum(['name', 'approval_status', 'approval_rating', 'credit_limit', 'net_days']).default('name'),
+  sortDir: z.enum(['asc', 'desc']).default('asc'),
 });
 
 export const GET = withApiContext(async (req, session) => {
@@ -18,7 +20,7 @@ export const GET = withApiContext(async (req, session) => {
   const parsed = querySchema.safeParse(Object.fromEntries(searchParams));
   if (!parsed.success) return NextResponse.json({ error: 'Invalid params' }, { status: 400 });
 
-  const { search, page, limit } = parsed.data;
-  const result = await getSupplierList(search ?? null, page, limit);
+  const { search, page, limit, sortKey, sortDir } = parsed.data;
+  const result = await getSupplierList(search ?? null, page, limit, sortKey, sortDir);
   return NextResponse.json(result);
 });

--- a/src/app/supply-chain/purchase-orders/_page-client.tsx
+++ b/src/app/supply-chain/purchase-orders/_page-client.tsx
@@ -8,7 +8,7 @@ import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
-import { ShoppingCart, ChevronLeft, ChevronRight, ExternalLink, FileText, X, Search } from 'lucide-react';
+import { ShoppingCart, ChevronLeft, ChevronRight, ExternalLink, FileText, X, Search, RefreshCw } from 'lucide-react';
 
 interface LinkedInvoice {
   dolibarr_id: number;
@@ -222,6 +222,8 @@ export default function PurchaseOrdersPage() {
   const [pageSize, setPageSize] = useState(50);
   const [page, setPage] = useState(0);
   const [selected, setSelected] = useState<PurchaseOrder | null>(null);
+  const [syncing, setSyncing] = useState(false);
+  const [syncResult, setSyncResult] = useState<string | null>(null);
   const searchTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const fetchOrders = useCallback(async () => {
@@ -241,6 +243,25 @@ export default function PurchaseOrdersPage() {
   }, [page, pageSize, search]);
 
   useEffect(() => { fetchOrders(); }, [fetchOrders]);
+
+  async function syncInvoiceLinks() {
+    setSyncing(true);
+    setSyncResult(null);
+    try {
+      const res = await fetch('/api/supply-chain/purchase-orders/sync-invoice-links', { method: 'POST' });
+      if (res.ok) {
+        const data = await res.json() as { updated: number };
+        setSyncResult(`${data.updated} invoice link(s) synced`);
+        fetchOrders();
+      } else {
+        setSyncResult('Sync failed');
+      }
+    } catch {
+      setSyncResult('Sync failed');
+    } finally {
+      setSyncing(false);
+    }
+  }
 
   // Debounce search input so we don't fire on every keystroke
   function handleSearchChange(val: string) {
@@ -314,6 +335,10 @@ export default function PurchaseOrdersPage() {
               </SelectContent>
             </Select>
           </div>
+          <Button variant="outline" size="sm" onClick={syncInvoiceLinks} disabled={syncing || loading} title="Re-sync invoice links from Dolibarr">
+            <RefreshCw className={`size-4 mr-1 ${syncing ? 'animate-spin' : ''}`} />
+            {syncing ? 'Syncing…' : 'Sync Invoices'}
+          </Button>
           <a href="https://ots.hexasteel.sa/dolibarr/index.php?mainmenu=fournisseur&leftmenu=orders_suppliers" target="_blank" rel="noopener noreferrer">
             <Button variant="outline" size="sm">
               <ExternalLink className="size-4 mr-1" /> Open in Dolibarr
@@ -321,6 +346,9 @@ export default function PurchaseOrdersPage() {
           </a>
         </div>
       </div>
+      {syncResult && (
+        <p className="text-xs text-muted-foreground">{syncResult}</p>
+      )}
 
       {/* Table */}
       <Card>

--- a/src/app/supply-chain/subcontractors/_page-client.tsx
+++ b/src/app/supply-chain/subcontractors/_page-client.tsx
@@ -97,16 +97,17 @@ interface Props {
   canEdit: boolean;
   canDelete: boolean;
   canApprove: boolean;
+  canHardDelete: boolean;
 }
 
-export default function SubcontractorsPage({ canCreate, canEdit, canDelete, canApprove }: Props) {
+export default function SubcontractorsPage({ canCreate, canEdit, canDelete, canApprove, canHardDelete }: Props) {
   const router = useRouter();
   const [contracts, setContracts] = useState<Contract[]>([]);
   const [stats, setStats] = useState<DashStats | null>(null);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState('ALL');
-  const [deleteTarget, setDeleteTarget] = useState<{ id: string; contractNumber: string } | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<{ id: string; contractNumber: string; force?: boolean } | null>(null);
   const [deleteReason, setDeleteReason] = useState('');
   const [deleting, setDeleting] = useState(false);
 
@@ -154,7 +155,7 @@ export default function SubcontractorsPage({ canCreate, canEdit, canDelete, canA
       const res = await fetch(`/api/subcontractor-contracts/${deleteTarget.id}`, {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ reason: deleteReason }),
+        body: JSON.stringify({ reason: deleteReason, force: deleteTarget.force ?? false }),
       });
       if (res.ok) {
         setDeleteTarget(null);
@@ -377,9 +378,17 @@ export default function SubcontractorsPage({ canCreate, canEdit, canDelete, canA
                                 {canDelete && ['DRAFT', 'CANCELLED'].includes(c.status) && (
                                   <DropdownMenuItem
                                     className="text-rose-600 focus:text-rose-600 focus:bg-rose-50"
-                                    onClick={() => { setDeleteTarget({ id: c.id, contractNumber: c.contractNumber }); setDeleteReason(''); }}
+                                    onClick={() => { setDeleteTarget({ id: c.id, contractNumber: c.contractNumber, force: false }); setDeleteReason(''); }}
                                   >
                                     <Trash2 className="size-4 mr-2" /> Delete
+                                  </DropdownMenuItem>
+                                )}
+                                {canHardDelete && (
+                                  <DropdownMenuItem
+                                    className="text-red-700 focus:text-red-700 focus:bg-red-50 font-medium"
+                                    onClick={() => { setDeleteTarget({ id: c.id, contractNumber: c.contractNumber, force: true }); setDeleteReason(''); }}
+                                  >
+                                    <Trash2 className="size-4 mr-2" /> Force Delete
                                   </DropdownMenuItem>
                                 )}
                               </DropdownMenuContent>
@@ -425,14 +434,19 @@ export default function SubcontractorsPage({ canCreate, canEdit, canDelete, canA
       <Dialog open={!!deleteTarget} onOpenChange={open => { if (!open) setDeleteTarget(null); }}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Delete Contract</DialogTitle>
+            <DialogTitle>{deleteTarget?.force ? 'Force Delete Contract' : 'Delete Contract'}</DialogTitle>
           </DialogHeader>
           <div className="space-y-3 py-2">
+            {deleteTarget?.force && (
+              <div className="rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-800 font-medium">
+                ⚠ This will permanently destroy the contract and all related data (certificates, variations, deductions). This cannot be undone.
+              </div>
+            )}
             <p className="text-sm text-muted-foreground">
-              Are you sure you want to delete <span className="font-semibold text-foreground">{deleteTarget?.contractNumber}</span>? This action cannot be undone.
+              Are you sure you want to {deleteTarget?.force ? 'permanently delete' : 'delete'} <span className="font-semibold text-foreground">{deleteTarget?.contractNumber}</span>?
             </p>
             <div className="space-y-1.5">
-              <Label htmlFor="del-reason">Reason (optional)</Label>
+              <Label htmlFor="del-reason">Reason {deleteTarget?.force ? '*' : '(optional)'}</Label>
               <Textarea
                 id="del-reason"
                 placeholder="Reason for deletion…"
@@ -444,8 +458,8 @@ export default function SubcontractorsPage({ canCreate, canEdit, canDelete, canA
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setDeleteTarget(null)} disabled={deleting}>Cancel</Button>
-            <Button variant="destructive" onClick={handleDelete} disabled={deleting}>
-              {deleting ? 'Deleting…' : 'Delete'}
+            <Button variant="destructive" onClick={handleDelete} disabled={deleting || (deleteTarget?.force && !deleteReason)}>
+              {deleting ? 'Deleting…' : deleteTarget?.force ? 'Permanently Delete' : 'Delete'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/app/supply-chain/subcontractors/new/_page-client.tsx
+++ b/src/app/supply-chain/subcontractors/new/_page-client.tsx
@@ -9,10 +9,13 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command';
 import {
   Handshake, ChevronLeft, ChevronRight, Plus, Trash2, Loader2,
-  FileText, CheckCircle2, AlertCircle,
+  FileText, CheckCircle2, AlertCircle, ChevronsUpDown, Check,
 } from 'lucide-react';
+import { cn } from '@/lib/utils';
 import { getDefaultTerms, SCOPE_LABELS, TEMPLATE_LABELS } from '@/lib/services/subcontractor-contract.constants';
 
 type Project = { id: string; projectNumber: string; name: string };
@@ -44,12 +47,15 @@ export default function NewSubcontractorContractPage() {
   const [selectedProject, setSelectedProject] = useState('');
   const [selectedSupplier, setSelectedSupplier] = useState('');
   const [scopeLevel, setScopeLevel] = useState<'project' | 'building' | 'scope'>('building');
+  const [projectOpen, setProjectOpen] = useState(false);
+  const [supplierOpen, setSupplierOpen] = useState(false);
 
   // Step 2
   const [buildings, setBuildings] = useState<Building[]>([]);
   const [selectedBuilding, setSelectedBuilding] = useState('');
   const [selectedScopeTypes, setSelectedScopeTypes] = useState<string[]>(['steel']);
   const [scopeItems, setScopeItems] = useState<ScopeItem[]>([]);
+  const [projectScopeTypes, setProjectScopeTypes] = useState<string[]>([]);
 
   // Step 3
   const [retentionPct, setRetentionPct] = useState(10);
@@ -88,6 +94,24 @@ export default function NewSubcontractorContractPage() {
 
   useEffect(() => { fetchProjects(); fetchSuppliers(); }, [fetchProjects, fetchSuppliers]);
   useEffect(() => { if (selectedProject) fetchBuildings(); }, [selectedProject, fetchBuildings]);
+
+  useEffect(() => {
+    if (!selectedProject) { setProjectScopeTypes([]); return; }
+    fetch(`/api/scope-of-work?projectId=${selectedProject}`)
+      .then(r => r.ok ? r.json() : [])
+      .then((scopes: { scopeType: string }[]) => {
+        const types = [...new Set(scopes.map(s => s.scopeType))];
+        setProjectScopeTypes(types);
+        // Reset selected scope types to only those valid for this project
+        if (types.length > 0) {
+          setSelectedScopeTypes(prev => {
+            const valid = prev.filter(t => types.includes(t));
+            return valid.length > 0 ? valid : types.slice(0, 1);
+          });
+        }
+      })
+      .catch(() => setProjectScopeTypes([]));
+  }, [selectedProject]);
 
   useEffect(() => {
     setTermsAndConditions(getDefaultTerms(templateType));
@@ -271,38 +295,74 @@ export default function NewSubcontractorContractPage() {
             </CardHeader>
             <CardContent className="space-y-5">
               <div className="space-y-2">
-                <Label htmlFor="project">Project <span className="text-destructive">*</span></Label>
-                <Select value={selectedProject} onValueChange={setSelectedProject}>
-                  <SelectTrigger id="project">
-                    <SelectValue placeholder="Select a project…" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {projects.map(p => (
-                      <SelectItem key={p.id} value={p.id}>
-                        <span className="font-mono mr-2 text-primary">{p.projectNumber}</span>
-                        {p.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <Label>Project <span className="text-destructive">*</span></Label>
+                <Popover open={projectOpen} onOpenChange={setProjectOpen}>
+                  <PopoverTrigger asChild>
+                    <Button variant="outline" role="combobox" aria-expanded={projectOpen} className="w-full justify-between font-normal">
+                      {selectedProject
+                        ? (() => { const p = projects.find(x => x.id === selectedProject); return p ? `${p.projectNumber} — ${p.name}` : 'Select a project…'; })()
+                        : 'Select a project…'}
+                      <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-full p-0" style={{ minWidth: 'var(--radix-popover-trigger-width)' }}>
+                    <Command>
+                      <CommandInput placeholder="Search projects…" />
+                      <CommandList>
+                        <CommandEmpty>No projects found.</CommandEmpty>
+                        <CommandGroup>
+                          {projects.map(p => (
+                            <CommandItem
+                              key={p.id}
+                              value={`${p.projectNumber} ${p.name}`}
+                              onSelect={() => { setSelectedProject(p.id); setProjectOpen(false); }}
+                            >
+                              <Check className={cn('mr-2 h-4 w-4', selectedProject === p.id ? 'opacity-100' : 'opacity-0')} />
+                              <span className="font-mono text-primary mr-2 text-sm">{p.projectNumber}</span>
+                              {p.name}
+                            </CommandItem>
+                          ))}
+                        </CommandGroup>
+                      </CommandList>
+                    </Command>
+                  </PopoverContent>
+                </Popover>
               </div>
 
               <div className="space-y-2">
-                <Label htmlFor="supplier">Subcontractor <span className="text-destructive">*</span></Label>
-                <Select value={selectedSupplier} onValueChange={setSelectedSupplier}>
-                  <SelectTrigger id="supplier">
-                    <SelectValue placeholder="Select a subcontractor…" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {suppliers.map(s => (
-                      <SelectItem key={s.dolibarr_id} value={String(s.dolibarr_id)}>
-                        <span className="font-mono mr-2 text-muted-foreground text-xs">{s.code_supplier ?? '—'}</span>
-                        {s.name}
-                        {s.approval_rating && <Badge variant="outline" className="ml-2 text-xs">{s.approval_rating}</Badge>}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <Label>Subcontractor <span className="text-destructive">*</span></Label>
+                <Popover open={supplierOpen} onOpenChange={setSupplierOpen}>
+                  <PopoverTrigger asChild>
+                    <Button variant="outline" role="combobox" aria-expanded={supplierOpen} className="w-full justify-between font-normal">
+                      {selectedSupplier
+                        ? (() => { const s = suppliers.find(x => String(x.dolibarr_id) === selectedSupplier); return s ? s.name : 'Select a subcontractor…'; })()
+                        : 'Select a subcontractor…'}
+                      <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-full p-0" style={{ minWidth: 'var(--radix-popover-trigger-width)' }}>
+                    <Command>
+                      <CommandInput placeholder="Search subcontractors…" />
+                      <CommandList>
+                        <CommandEmpty>No subcontractors found.</CommandEmpty>
+                        <CommandGroup>
+                          {suppliers.map(s => (
+                            <CommandItem
+                              key={s.dolibarr_id}
+                              value={`${s.code_supplier ?? ''} ${s.name}`}
+                              onSelect={() => { setSelectedSupplier(String(s.dolibarr_id)); setSupplierOpen(false); }}
+                            >
+                              <Check className={cn('mr-2 h-4 w-4', String(s.dolibarr_id) === selectedSupplier ? 'opacity-100' : 'opacity-0')} />
+                              <span className="font-mono text-muted-foreground text-xs mr-2">{s.code_supplier ?? '—'}</span>
+                              {s.name}
+                              {s.approval_rating && <Badge variant="outline" className="ml-2 text-xs">{s.approval_rating}</Badge>}
+                            </CommandItem>
+                          ))}
+                        </CommandGroup>
+                      </CommandList>
+                    </Command>
+                  </PopoverContent>
+                </Popover>
               </div>
 
               <div className="space-y-2">
@@ -371,8 +431,11 @@ export default function NewSubcontractorContractPage() {
 
               <div className="space-y-2">
                 <Label>Scope Types <span className="text-destructive">*</span></Label>
+                {projectScopeTypes.length > 0 && (
+                  <p className="text-xs text-muted-foreground">Showing scopes available in the selected project</p>
+                )}
                 <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
-                  {SCOPE_TYPES.map(st => (
+                  {(projectScopeTypes.length > 0 ? SCOPE_TYPES.filter(st => projectScopeTypes.includes(st)) : SCOPE_TYPES).map(st => (
                     <button
                       key={st}
                       type="button"

--- a/src/app/supply-chain/subcontractors/page.tsx
+++ b/src/app/supply-chain/subcontractors/page.tsx
@@ -23,12 +23,15 @@ export default async function SubcontractorContractsPage() {
 
   if (!canView) redirect('/unauthorized?from=/supply-chain/subcontractors');
 
+  const canHardDelete = ['admin', 'ceo'].includes(session.role?.toLowerCase() ?? '');
+
   return (
     <SubcontractorsPage
       canCreate={canCreate}
       canEdit={canEdit}
       canDelete={canDelete}
       canApprove={canApprove}
+      canHardDelete={canHardDelete}
     />
   );
 }

--- a/src/app/supply-chain/suppliers/[id]/_page-client.tsx
+++ b/src/app/supply-chain/suppliers/[id]/_page-client.tsx
@@ -6,7 +6,7 @@ import {
   Factory, ArrowLeft, Mail, Phone, MapPin, Building2, ChevronRight,
   ShieldCheck, ShieldAlert, ShieldOff, Shield, ClipboardList, CreditCard,
   FileText, ShoppingCart, Banknote, BarChart3, Plus, ClipboardCheck,
-  AlertTriangle, Users,
+  AlertTriangle, Users, Handshake,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
@@ -171,11 +171,19 @@ const fmtDate = (d: string | null | undefined) => {
 export function SupplierDetailClient({ supplierId }: { supplierId: number }) {
   const [overview, setOverview] = useState<SupplierOverview | null>(null);
   const [loading, setLoading] = useState(true);
+  const [subcontractsCount, setSubcontractsCount] = useState(0);
 
   const fetchOverview = useCallback(async () => {
     setLoading(true);
-    const res = await fetch(`/api/supply-chain/suppliers/${supplierId}`);
-    if (res.ok) setOverview(await res.json());
+    const [overviewRes, scRes] = await Promise.all([
+      fetch(`/api/supply-chain/suppliers/${supplierId}`),
+      fetch(`/api/supply-chain/suppliers/${supplierId}/subcontracts`),
+    ]);
+    if (overviewRes.ok) setOverview(await overviewRes.json());
+    if (scRes.ok) {
+      const scData = await scRes.json() as { contracts: unknown[] };
+      setSubcontractsCount(scData.contracts?.length ?? 0);
+    }
     setLoading(false);
   }, [supplierId]);
 
@@ -274,6 +282,12 @@ export function SupplierDetailClient({ supplierId }: { supplierId: number }) {
             <TabsTrigger value="soa"><BarChart3 className="h-4 w-4 mr-1.5" />Statement</TabsTrigger>
             <TabsTrigger value="evaluations"><ClipboardCheck className="h-4 w-4 mr-1.5" />Evaluations</TabsTrigger>
             <TabsTrigger value="coa"><ClipboardList className="h-4 w-4 mr-1.5" />CoA & COGS</TabsTrigger>
+            {subcontractsCount > 0 && (
+              <TabsTrigger value="subcontracts">
+                <Handshake className="h-4 w-4 mr-1.5" />Subcontracts
+                <span className="ml-1.5 text-xs bg-orange-100 text-orange-700 px-1.5 py-0.5 rounded-full font-medium">{subcontractsCount}</span>
+              </TabsTrigger>
+            )}
           </TabsList>
 
           <TabsContent value="overview">
@@ -304,6 +318,11 @@ export function SupplierDetailClient({ supplierId }: { supplierId: number }) {
           <TabsContent value="coa">
             <CoaTab supplierId={supplierId} initial={overview} onSaved={fetchOverview} />
           </TabsContent>
+          {subcontractsCount > 0 && (
+            <TabsContent value="subcontracts">
+              <SupplierSubcontractsTab supplierId={supplierId} />
+            </TabsContent>
+          )}
         </Tabs>
       </div>
     </div>
@@ -407,17 +426,30 @@ function OverviewTab({ overview }: { overview: SupplierOverview }) {
   );
 }
 
-// ─── Credit & Terms Tab (merged Payment Terms + Credit Limit) ────────────────
+// ─── Credit & Terms Tab ───────────────────────────────────────────────────────
+
+const TODAY = new Date().toISOString().slice(0, 10);
 
 function CreditAndTermsTab({ supplierId }: { supplierId: number }) {
   const [terms, setTerms] = useState<PaymentTermsRow[]>([]);
   const [history, setHistory] = useState<CreditLimitRow[]>([]);
   const [loading, setLoading] = useState(true);
-  const [termsDialog, setTermsDialog] = useState(false);
-  const [creditDialog, setCreditDialog] = useState(false);
   const [saving, setSaving] = useState(false);
-  const [termsForm, setTermsForm] = useState({ net_days: '30', discount_days: '', discount_percentage: '', valid_from: new Date().toISOString().slice(0, 10), notes: '' });
-  const [creditForm, setCreditForm] = useState({ credit_limit: '', valid_from: new Date().toISOString().slice(0, 10), notes: '' });
+
+  // Unified dialog (credit + terms together)
+  const [unifiedDialog, setUnifiedDialog] = useState(false);
+  const [unifiedForm, setUnifiedForm] = useState({
+    credit_limit: '', net_days: '30', valid_from: TODAY,
+    discount_days: '', discount_percentage: '', notes: '',
+  });
+
+  // Standalone credit-only dialog
+  const [creditDialog, setCreditDialog] = useState(false);
+  const [creditForm, setCreditForm] = useState({ credit_limit: '', valid_from: TODAY, notes: '' });
+
+  // Standalone terms-only dialog
+  const [termsDialog, setTermsDialog] = useState(false);
+  const [termsForm, setTermsForm] = useState({ net_days: '30', discount_days: '', discount_percentage: '', valid_from: TODAY, notes: '' });
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -432,11 +464,53 @@ function CreditAndTermsTab({ supplierId }: { supplierId: number }) {
 
   useEffect(() => { load(); }, [load]);
 
-  async function saveTerms() {
+  async function saveUnified() {
+    if (!unifiedForm.credit_limit || !unifiedForm.net_days || !unifiedForm.valid_from) return;
     setSaving(true);
-    const res = await fetch(`/api/supply-chain/suppliers/${supplierId}/payment-terms`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+    await Promise.all([
+      fetch(`/api/supply-chain/suppliers/${supplierId}/credit-limit`, {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          credit_limit: parseFloat(unifiedForm.credit_limit),
+          valid_from: unifiedForm.valid_from,
+          notes: unifiedForm.notes || null,
+        }),
+      }),
+      fetch(`/api/supply-chain/suppliers/${supplierId}/payment-terms`, {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          net_days: parseInt(unifiedForm.net_days),
+          discount_days: unifiedForm.discount_days ? parseInt(unifiedForm.discount_days) : null,
+          discount_percentage: unifiedForm.discount_percentage ? parseFloat(unifiedForm.discount_percentage) : null,
+          valid_from: unifiedForm.valid_from,
+          notes: unifiedForm.notes || null,
+        }),
+      }),
+    ]);
+    setSaving(false);
+    setUnifiedDialog(false);
+    setUnifiedForm({ credit_limit: '', net_days: '30', valid_from: TODAY, discount_days: '', discount_percentage: '', notes: '' });
+    load();
+  }
+
+  async function saveCredit() {
+    if (!creditForm.credit_limit || !creditForm.valid_from) return;
+    setSaving(true);
+    await fetch(`/api/supply-chain/suppliers/${supplierId}/credit-limit`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ credit_limit: parseFloat(creditForm.credit_limit), valid_from: creditForm.valid_from, notes: creditForm.notes || null }),
+    });
+    setSaving(false);
+    setCreditDialog(false);
+    setCreditForm({ credit_limit: '', valid_from: TODAY, notes: '' });
+    load();
+  }
+
+  async function saveTerms() {
+    if (!termsForm.net_days || !termsForm.valid_from) return;
+    setSaving(true);
+    await fetch(`/api/supply-chain/suppliers/${supplierId}/payment-terms`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         net_days: parseInt(termsForm.net_days),
         discount_days: termsForm.discount_days ? parseInt(termsForm.discount_days) : null,
@@ -446,82 +520,119 @@ function CreditAndTermsTab({ supplierId }: { supplierId: number }) {
       }),
     });
     setSaving(false);
-    if (res.ok) { setTermsDialog(false); load(); }
+    setTermsDialog(false);
+    load();
   }
 
-  async function saveCredit() {
-    if (!creditForm.credit_limit || !creditForm.valid_from) return;
-    setSaving(true);
-    const res = await fetch(`/api/supply-chain/suppliers/${supplierId}/credit-limit`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        credit_limit: parseFloat(creditForm.credit_limit),
-        valid_from: creditForm.valid_from,
-        notes: creditForm.notes || null,
-      }),
-    });
-    setSaving(false);
-    if (res.ok) { setCreditDialog(false); setCreditForm({ credit_limit: '', valid_from: new Date().toISOString().slice(0, 10), notes: '' }); load(); }
-  }
-
-  const skeletons = <div className="space-y-2">{[1,2].map(i => <div key={i} className="h-14 bg-muted animate-pulse rounded-lg" />)}</div>;
+  const skeletons = <div className="space-y-2">{[1, 2].map(i => <div key={i} className="h-14 bg-muted animate-pulse rounded-lg" />)}</div>;
 
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-      {/* ── Credit Limit ── */}
-      <div className="space-y-4">
-        <div className="flex items-center justify-between">
+    <div className="space-y-8">
+      {/* ── Action bar ── */}
+      <div className="flex flex-wrap gap-2">
+        <Button onClick={() => setUnifiedDialog(true)}>
+          <Plus className="h-4 w-4 mr-1.5" />Set Credit &amp; Terms
+        </Button>
+        <Button size="sm" variant="outline" onClick={() => setCreditDialog(true)}>
+          <Banknote className="h-4 w-4 mr-1.5" />Credit Limit Only
+        </Button>
+        <Button size="sm" variant="outline" onClick={() => setTermsDialog(true)}>
+          <CreditCard className="h-4 w-4 mr-1.5" />Payment Terms Only
+        </Button>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+        {/* ── Credit Limit history ── */}
+        <div className="space-y-4">
           <h3 className="font-semibold flex items-center gap-2"><Banknote className="h-4 w-4" />Credit Limit History</h3>
-          <Button size="sm" onClick={() => setCreditDialog(true)}><Plus className="h-4 w-4 mr-1.5" />Set Credit Limit</Button>
+          {loading ? skeletons : history.length === 0 ? (
+            <div className="text-center py-10 text-muted-foreground rounded-xl border text-sm">No credit limit on record.</div>
+          ) : (
+            <div className="space-y-3">
+              {history.map(r => (
+                <div key={r.id} className={`rounded-xl border px-5 py-4 flex flex-wrap items-center justify-between gap-3 ${!r.valid_to ? 'border-emerald-200 bg-emerald-50/50' : ''}`}>
+                  <div className="flex items-center gap-3">
+                    {!r.valid_to && <span className="text-xs font-semibold text-emerald-700 bg-emerald-100 px-2 py-0.5 rounded-full">Current</span>}
+                    <span className="font-bold text-base">{fmt(r.credit_limit)}</span>
+                  </div>
+                  <div className="flex items-center gap-4 text-sm text-muted-foreground">
+                    <span>{fmtDate(r.valid_from)} → {r.valid_to ? fmtDate(r.valid_to) : 'Present'}</span>
+                    {r.notes && <span className="text-xs bg-muted px-2 py-0.5 rounded max-w-xs truncate">{r.notes}</span>}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
-        {loading ? skeletons : history.length === 0 ? (
-          <div className="text-center py-10 text-muted-foreground rounded-xl border text-sm">No credit limit on record.</div>
-        ) : (
-          <div className="space-y-3">
-            {history.map(r => (
-              <div key={r.id} className={`rounded-xl border px-5 py-4 flex flex-wrap items-center justify-between gap-3 ${!r.valid_to ? 'border-emerald-200 bg-emerald-50/50' : ''}`}>
-                <div className="flex items-center gap-3">
-                  {!r.valid_to && <span className="text-xs font-semibold text-emerald-700 bg-emerald-100 px-2 py-0.5 rounded-full">Current</span>}
-                  <span className="font-bold text-base">{fmt(r.credit_limit)}</span>
-                </div>
-                <div className="flex items-center gap-4 text-sm text-muted-foreground">
-                  <span>{fmtDate(r.valid_from)} → {r.valid_to ? fmtDate(r.valid_to) : 'Present'}</span>
-                  {r.notes && <span className="text-xs bg-muted px-2 py-0.5 rounded max-w-xs truncate">{r.notes}</span>}
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
 
-      {/* ── Payment Terms ── */}
-      <div className="space-y-4">
-        <div className="flex items-center justify-between">
+        {/* ── Payment Terms history ── */}
+        <div className="space-y-4">
           <h3 className="font-semibold flex items-center gap-2"><CreditCard className="h-4 w-4" />Payment Terms History</h3>
-          <Button size="sm" onClick={() => setTermsDialog(true)}><Plus className="h-4 w-4 mr-1.5" />Add Terms</Button>
+          {loading ? skeletons : terms.length === 0 ? (
+            <div className="text-center py-10 text-muted-foreground rounded-xl border text-sm">No payment terms on record.</div>
+          ) : (
+            <div className="space-y-3">
+              {terms.map(t => (
+                <div key={t.id} className={`rounded-xl border px-5 py-4 flex flex-wrap items-center justify-between gap-3 ${!t.valid_to ? 'border-blue-200 bg-blue-50/50' : ''}`}>
+                  <div className="flex items-center gap-3">
+                    {!t.valid_to && <span className="text-xs font-semibold text-blue-700 bg-blue-100 px-2 py-0.5 rounded-full">Current</span>}
+                    <PaymentTermsBadge netDays={t.net_days} discountDays={t.discount_days} discountPercentage={t.discount_percentage} />
+                  </div>
+                  <div className="flex items-center gap-4 text-sm text-muted-foreground">
+                    <span>{fmtDate(t.valid_from)} → {t.valid_to ? fmtDate(t.valid_to) : 'Present'}</span>
+                    {t.notes && <span className="text-xs bg-muted px-2 py-0.5 rounded max-w-xs truncate">{t.notes}</span>}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
-        {loading ? skeletons : terms.length === 0 ? (
-          <div className="text-center py-10 text-muted-foreground rounded-xl border text-sm">No payment terms on record.</div>
-        ) : (
-          <div className="space-y-3">
-            {terms.map(t => (
-              <div key={t.id} className={`rounded-xl border px-5 py-4 flex flex-wrap items-center justify-between gap-3 ${!t.valid_to ? 'border-blue-200 bg-blue-50/50' : ''}`}>
-                <div className="flex items-center gap-3">
-                  {!t.valid_to && <span className="text-xs font-semibold text-blue-700 bg-blue-100 px-2 py-0.5 rounded-full">Current</span>}
-                  <PaymentTermsBadge netDays={t.net_days} discountDays={t.discount_days} discountPercentage={t.discount_percentage} />
-                </div>
-                <div className="flex items-center gap-4 text-sm text-muted-foreground">
-                  <span>{fmtDate(t.valid_from)} → {t.valid_to ? fmtDate(t.valid_to) : 'Present'}</span>
-                  {t.notes && <span className="text-xs bg-muted px-2 py-0.5 rounded max-w-xs truncate">{t.notes}</span>}
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
       </div>
 
-      {/* ── Dialogs ── */}
+      {/* ── Unified dialog ── */}
+      <Dialog open={unifiedDialog} onOpenChange={setUnifiedDialog}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader><DialogTitle>Set Credit &amp; Payment Terms</DialogTitle></DialogHeader>
+          <div className="space-y-4 py-2">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-1.5">
+                <Label>Credit Limit (SAR) *</Label>
+                <Input type="number" min="0" step="1000" placeholder="e.g. 500000" value={unifiedForm.credit_limit} onChange={e => setUnifiedForm(f => ({ ...f, credit_limit: e.target.value }))} />
+              </div>
+              <div className="space-y-1.5">
+                <Label>Net Days *</Label>
+                <Input type="number" min="0" max="365" placeholder="e.g. 30" value={unifiedForm.net_days} onChange={e => setUnifiedForm(f => ({ ...f, net_days: e.target.value }))} />
+              </div>
+            </div>
+            <div className="space-y-1.5">
+              <Label>Effective From *</Label>
+              <Input type="date" value={unifiedForm.valid_from} onChange={e => setUnifiedForm(f => ({ ...f, valid_from: e.target.value }))} />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-1.5">
+                <Label>Discount Days <span className="text-muted-foreground text-xs">(optional)</span></Label>
+                <Input type="number" min="0" placeholder="e.g. 10" value={unifiedForm.discount_days} onChange={e => setUnifiedForm(f => ({ ...f, discount_days: e.target.value }))} />
+              </div>
+              <div className="space-y-1.5">
+                <Label>Discount % <span className="text-muted-foreground text-xs">(optional)</span></Label>
+                <Input type="number" min="0" step="0.5" placeholder="e.g. 2" value={unifiedForm.discount_percentage} onChange={e => setUnifiedForm(f => ({ ...f, discount_percentage: e.target.value }))} />
+              </div>
+            </div>
+            <div className="space-y-1.5">
+              <Label>Notes <span className="text-muted-foreground text-xs">(optional)</span></Label>
+              <Textarea rows={2} value={unifiedForm.notes} onChange={e => setUnifiedForm(f => ({ ...f, notes: e.target.value }))} placeholder="Reason for change…" />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setUnifiedDialog(false)}>Cancel</Button>
+            <Button onClick={saveUnified} disabled={saving || !unifiedForm.credit_limit || !unifiedForm.net_days || !unifiedForm.valid_from}>
+              {saving ? 'Saving…' : 'Save Credit & Terms'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* ── Credit-only dialog ── */}
       <Dialog open={creditDialog} onOpenChange={setCreditDialog}>
         <DialogContent className="max-w-md">
           <DialogHeader><DialogTitle>Set Credit Limit</DialogTitle></DialogHeader>
@@ -548,6 +659,7 @@ function CreditAndTermsTab({ supplierId }: { supplierId: number }) {
         </DialogContent>
       </Dialog>
 
+      {/* ── Terms-only dialog ── */}
       <Dialog open={termsDialog} onOpenChange={setTermsDialog}>
         <DialogContent className="max-w-md">
           <DialogHeader><DialogTitle>Add Payment Terms</DialogTitle></DialogHeader>
@@ -1014,6 +1126,104 @@ function CoaTab({ supplierId, initial, onSaved }: { supplierId: number; initial:
         <Textarea rows={2} value={notes} onChange={e => setNotes(e.target.value)} placeholder="Optional mapping notes…" />
       </div>
       <Button onClick={save} disabled={saving}>{saving ? 'Saving…' : saved ? '✓ Saved' : 'Save Mapping'}</Button>
+    </div>
+  );
+}
+
+// ─── Supplier Subcontracts Tab ────────────────────────────────────────────────
+
+interface SupplierSubcontract {
+  id: string;
+  contractNumber: string;
+  name: string;
+  status: string;
+  contractValue: number;
+  currency: string;
+  scopeTypes: string[];
+  createdAt: string;
+  project: { id: string; projectNumber: string; name: string };
+  building: { id: string; designation: string; name: string } | null;
+}
+
+const SC_STATUS_STYLE: Record<string, string> = {
+  DRAFT:     'bg-slate-100 text-slate-700',
+  SUBMITTED: 'bg-amber-100 text-amber-700',
+  APPROVED:  'bg-blue-100 text-blue-700',
+  ACTIVE:    'bg-emerald-100 text-emerald-700',
+  SUSPENDED: 'bg-orange-100 text-orange-700',
+  COMPLETED: 'bg-teal-100 text-teal-700',
+  CANCELLED: 'bg-rose-100 text-rose-700',
+};
+
+function SupplierSubcontractsTab({ supplierId }: { supplierId: number }) {
+  const [contracts, setContracts] = useState<SupplierSubcontract[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch(`/api/supply-chain/suppliers/${supplierId}/subcontracts`)
+      .then(r => r.json())
+      .then((j: { contracts: SupplierSubcontract[] }) => setContracts(j.contracts ?? []))
+      .finally(() => setLoading(false));
+  }, [supplierId]);
+
+  return (
+    <div className="space-y-4">
+      <h3 className="font-semibold flex items-center gap-2">
+        <Handshake className="h-4 w-4" />Subcontract Contracts
+        <span className="text-muted-foreground font-normal text-sm">({contracts.length})</span>
+      </h3>
+      <div className="rounded-xl border overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b bg-muted/50">
+              <th className="px-4 py-2.5 text-left font-medium">Contract #</th>
+              <th className="px-4 py-2.5 text-left font-medium">Project</th>
+              <th className="px-4 py-2.5 text-left font-medium">Building</th>
+              <th className="px-4 py-2.5 text-left font-medium">Scope</th>
+              <th className="px-4 py-2.5 text-right font-medium">Value</th>
+              <th className="px-4 py-2.5 text-center font-medium">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading ? (
+              <tr><td colSpan={6} className="px-4 py-8 text-center"><div className="h-4 w-24 bg-muted animate-pulse rounded mx-auto" /></td></tr>
+            ) : contracts.length === 0 ? (
+              <tr><td colSpan={6} className="px-4 py-8 text-center text-muted-foreground">No subcontract contracts found.</td></tr>
+            ) : contracts.map(c => (
+              <tr key={c.id} className="border-b last:border-0 hover:bg-muted/30">
+                <td className="px-4 py-2.5">
+                  <Link href={`/supply-chain/subcontractors/${c.id}`} className="font-mono text-xs font-semibold text-primary hover:underline">
+                    {c.contractNumber}
+                  </Link>
+                  <p className="text-xs text-muted-foreground truncate max-w-[160px]">{c.name}</p>
+                </td>
+                <td className="px-4 py-2.5">
+                  <p className="font-medium text-xs">{c.project.projectNumber}</p>
+                  <p className="text-xs text-muted-foreground truncate max-w-[140px]">{c.project.name}</p>
+                </td>
+                <td className="px-4 py-2.5 text-xs text-muted-foreground">
+                  {c.building ? `${c.building.designation} ${c.building.name}` : '—'}
+                </td>
+                <td className="px-4 py-2.5">
+                  <div className="flex flex-wrap gap-1">
+                    {(c.scopeTypes as string[]).map(st => (
+                      <span key={st} className="text-xs bg-muted px-1.5 py-0.5 rounded capitalize">{st.replace(/_/g, ' ')}</span>
+                    ))}
+                  </div>
+                </td>
+                <td className="px-4 py-2.5 text-right tabular-nums font-medium text-sm">
+                  {fmt(c.contractValue)}
+                </td>
+                <td className="px-4 py-2.5 text-center">
+                  <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${SC_STATUS_STYLE[c.status] ?? 'bg-slate-100 text-slate-700'}`}>
+                    {c.status}
+                  </span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/src/app/supply-chain/suppliers/_page-client.tsx
+++ b/src/app/supply-chain/suppliers/_page-client.tsx
@@ -65,7 +65,7 @@ export function SupplierListClient() {
 
   const fetchData = useCallback(async () => {
     setLoading(true);
-    const params = new URLSearchParams({ page: String(page), limit: String(limit) });
+    const params = new URLSearchParams({ page: String(page), limit: String(limit), sortKey, sortDir });
     if (search) params.set('search', search);
     const res = await fetch(`/api/supply-chain/suppliers?${params}`);
     if (res.ok) {
@@ -74,7 +74,7 @@ export function SupplierListClient() {
       setTotal(j.total ?? 0);
     }
     setLoading(false);
-  }, [search, page]);
+  }, [search, page, sortKey, sortDir]);
 
   const syncAndRefresh = useCallback(async () => {
     setSyncing(true);
@@ -96,20 +96,8 @@ export function SupplierListClient() {
       setSortKey(key);
       setSortDir('asc');
     }
+    setPage(1);
   }
-
-  const sorted = [...suppliers].sort((a, b) => {
-    let av: string | number | null, bv: string | number | null;
-    if (sortKey === 'name') { av = a.name; bv = b.name; }
-    else if (sortKey === 'approval_status') { av = a.approval_status ?? ''; bv = b.approval_status ?? ''; }
-    else if (sortKey === 'approval_rating') { av = a.approval_rating ?? 'Z'; bv = b.approval_rating ?? 'Z'; }
-    else if (sortKey === 'credit_limit') { av = a.credit_limit ?? -1; bv = b.credit_limit ?? -1; }
-    else { av = a.net_days ?? -1; bv = b.net_days ?? -1; }
-
-    if (av === bv) return 0;
-    const cmp = av < bv ? -1 : 1;
-    return sortDir === 'asc' ? cmp : -cmp;
-  });
 
   const kpi = {
     total,
@@ -190,12 +178,11 @@ export function SupplierListClient() {
                 <tr className="border-b bg-muted/50 text-muted-foreground">
                   <Th col="name" label="Supplier" />
                   <th className="px-4 py-3 text-left font-medium whitespace-nowrap hidden sm:table-cell">Code</th>
-                  <th className="px-4 py-3 text-left font-medium whitespace-nowrap hidden md:table-cell">Location</th>
                   <th className="px-4 py-3 text-left font-medium whitespace-nowrap hidden lg:table-cell">Category</th>
                   <Th col="approval_status" label="Status" />
                   <Th col="approval_rating" label="Rating" className="hidden sm:table-cell" />
-                  <Th col="credit_limit" label="Credit Limit" className="hidden xl:table-cell" />
-                  <Th col="net_days" label="Pay. Terms" className="hidden xl:table-cell" />
+                  <Th col="credit_limit" label="Credit Limit" className="hidden md:table-cell" />
+                  <Th col="net_days" label="Pay. Terms" className="hidden md:table-cell" />
                   <th className="px-4 py-3" />
                 </tr>
               </thead>
@@ -203,18 +190,18 @@ export function SupplierListClient() {
                 {loading ? (
                   Array.from({ length: 8 }).map((_, i) => (
                     <tr key={i} className="border-b">
-                      <td colSpan={9} className="px-4 py-3">
+                      <td colSpan={8} className="px-4 py-3">
                         <div className="h-4 bg-muted animate-pulse rounded w-3/4" />
                       </td>
                     </tr>
                   ))
-                ) : sorted.length === 0 ? (
+                ) : suppliers.length === 0 ? (
                   <tr>
-                    <td colSpan={9} className="px-4 py-10 text-center text-muted-foreground">
+                    <td colSpan={8} className="px-4 py-10 text-center text-muted-foreground">
                       No suppliers found{search ? ` matching "${search}"` : ''}.
                     </td>
                   </tr>
-                ) : sorted.map(s => (
+                ) : suppliers.map(s => (
                   <tr key={s.dolibarr_id} className="border-b last:border-0 hover:bg-muted/30 transition-colors">
                     <td className="px-4 py-3">
                       <Link href={`/supply-chain/suppliers/${s.dolibarr_id}`} className="hover:underline">
@@ -226,9 +213,6 @@ export function SupplierListClient() {
                       {s.code_supplier
                         ? <span className="font-mono text-xs bg-muted px-2 py-0.5 rounded">{s.code_supplier}</span>
                         : <span className="text-muted-foreground text-xs">—</span>}
-                    </td>
-                    <td className="px-4 py-3 text-muted-foreground hidden md:table-cell">
-                      {[s.town, s.country_code].filter(Boolean).join(', ') || '—'}
                     </td>
                     <td className="px-4 py-3 hidden lg:table-cell">
                       {s.cost_category
@@ -254,10 +238,10 @@ export function SupplierListClient() {
                         </span>
                       ) : <span className="text-muted-foreground">—</span>}
                     </td>
-                    <td className="px-4 py-3 hidden xl:table-cell tabular-nums text-sm">
+                    <td className="px-4 py-3 hidden md:table-cell tabular-nums text-sm">
                       {s.credit_limit != null ? fmtSAR(s.credit_limit) : <span className="text-muted-foreground">—</span>}
                     </td>
-                    <td className="px-4 py-3 hidden xl:table-cell text-sm">
+                    <td className="px-4 py-3 hidden md:table-cell text-sm">
                       {s.net_days != null
                         ? <span className="text-xs bg-blue-50 text-blue-700 border border-blue-200 px-2 py-0.5 rounded-full font-medium">Net {s.net_days}d</span>
                         : <span className="text-muted-foreground">—</span>}

--- a/src/components/project-details.tsx
+++ b/src/components/project-details.tsx
@@ -339,157 +339,128 @@ export function ProjectDetails({ project, restrictedModules = [] }: ProjectDetai
   };
 
   return (
-    <main className="min-h-screen bg-gradient-to-br from-background via-background to-muted/20">
-      <div className="container mx-auto p-6 lg:p-8 space-y-8 max-lg:pt-20">
-        {/* Header */}
-        <div className="flex items-start justify-between gap-4">
-          <div className="flex items-center gap-4">
-            <div className="flex items-center gap-1">
-              <Link href="/projects">
-                <Button variant="ghost" size="icon" title="Back to list">
-                  <ArrowLeft className="size-5" />
-                </Button>
-              </Link>
-              <div className="h-6 w-px bg-border mx-1" />
-              <Link href={navigation.previousId ? `/projects/${navigation.previousId}` : '#'}>
-                <Button 
-                  variant="ghost" 
-                  size="icon" 
-                  disabled={!navigation.previousId || isLoadingNav}
-                  title="Previous project"
-                >
-                  <ChevronLeft className="size-5" />
-                </Button>
-              </Link>
-              <Link href={navigation.nextId ? `/projects/${navigation.nextId}` : '#'}>
-                <Button 
-                  variant="ghost" 
-                  size="icon" 
-                  disabled={!navigation.nextId || isLoadingNav}
-                  title="Next project"
-                >
-                  <ChevronRightIcon className="size-5" />
-                </Button>
-              </Link>
-            </div>
-            <div>
-              <div className="flex items-center gap-2 mb-2">
-                <Badge variant="outline" className="font-mono">
-                  {project.projectNumber}
-                </Badge>
-                <Badge
-                  variant="outline"
-                  className={cn('border', statusColors[project.status as keyof typeof statusColors])}
-                >
-                  {project.status}
-                </Badge>
+    <main className="min-h-screen bg-background">
+      {/* ── Hero Banner ── */}
+      <div className="relative overflow-hidden bg-gradient-to-br from-slate-900 via-slate-800 to-blue-900 text-white">
+        <div className="absolute inset-0 opacity-5"
+          style={{ backgroundImage: 'repeating-linear-gradient(45deg,#fff 0,#fff 1px,transparent 0,transparent 50%)', backgroundSize: '20px 20px' }} />
+        <div className="absolute -top-10 -right-10 w-64 h-64 bg-blue-500/10 rounded-full blur-3xl" />
+        <div className="absolute bottom-0 left-1/4 w-48 h-48 bg-white/5 rounded-full blur-3xl" />
+        <div className="relative container mx-auto px-6 lg:px-8 pt-6 pb-8 max-lg:pt-20">
+          {/* Nav row */}
+          <div className="flex items-center gap-2 mb-5">
+            <Link href="/projects">
+              <Button variant="ghost" size="sm" className="text-slate-300 hover:text-white hover:bg-white/10 gap-1">
+                <ArrowLeft className="size-4" /> Projects
+              </Button>
+            </Link>
+            <div className="h-4 w-px bg-white/20 mx-1" />
+            <Link href={navigation.previousId ? `/projects/${navigation.previousId}` : '#'}>
+              <Button variant="ghost" size="icon" className="text-slate-300 hover:text-white hover:bg-white/10 h-8 w-8" disabled={!navigation.previousId || isLoadingNav} title="Previous project">
+                <ChevronLeft className="size-4" />
+              </Button>
+            </Link>
+            <Link href={navigation.nextId ? `/projects/${navigation.nextId}` : '#'}>
+              <Button variant="ghost" size="icon" className="text-slate-300 hover:text-white hover:bg-white/10 h-8 w-8" disabled={!navigation.nextId || isLoadingNav} title="Next project">
+                <ChevronRightIcon className="size-4" />
+              </Button>
+            </Link>
+          </div>
+
+          {/* Title row */}
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div className="flex items-start gap-4">
+              <div className="p-3 rounded-2xl bg-white/10 backdrop-blur-sm border border-white/20 hidden sm:flex">
+                <Building2 className="size-8 text-blue-300" />
               </div>
-              <h1 className="text-3xl font-bold tracking-tight">{project.name}</h1>
-              <p className="text-muted-foreground mt-1">
-                {project.client.name} • {project.projectManager.name}
-              </p>
+              <div>
+                <div className="flex flex-wrap items-center gap-2 mb-2">
+                  <span className="font-mono text-sm bg-white/15 border border-white/20 px-2.5 py-0.5 rounded text-slate-200">
+                    {project.projectNumber}
+                  </span>
+                  <span className={cn('text-xs font-semibold px-2.5 py-1 rounded-full border', statusColors[project.status as keyof typeof statusColors])}>
+                    {project.status}
+                  </span>
+                  {project.projectNature && (
+                    <span className="text-xs bg-white/10 border border-white/15 px-2 py-0.5 rounded text-slate-300">{project.projectNature}</span>
+                  )}
+                </div>
+                <h1 className="text-2xl sm:text-3xl font-bold tracking-tight">{project.name}</h1>
+                <p className="text-slate-400 mt-1 text-sm">
+                  {project.client.name} <span className="text-slate-600 mx-1">·</span> {project.projectManager.name}
+                  {project.projectLocation ? <><span className="text-slate-600 mx-1">·</span> {project.projectLocation}</> : null}
+                </p>
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Link href={`/projects/${project.id}/timeline`}>
+                <Button variant="outline" size="sm" className="bg-white/10 border-white/20 text-white hover:bg-white/20 hover:text-white">
+                  <Clock className="size-4 mr-1" /> Timeline
+                </Button>
+              </Link>
+              <Link href={`/projects/${project.id}/scope`}>
+                <Button variant="outline" size="sm" className="bg-white/10 border-white/20 text-white hover:bg-white/20 hover:text-white">
+                  <FileText className="size-4 mr-1" /> Scope
+                </Button>
+              </Link>
+              <Link href={`/projects/${project.id}/edit`}>
+                <Button size="sm" className="bg-blue-500 hover:bg-blue-400 text-white border-0">
+                  <Edit className="size-4 mr-1" /> Edit
+                </Button>
+              </Link>
+              <Button size="sm" variant="destructive" onClick={() => setShowDeleteDialog(true)} disabled={isDeleting}>
+                <Trash2 className="size-4" />
+              </Button>
             </div>
           </div>
-          
-          <div className="flex items-center gap-2">
-            <Link href={`/projects/${project.id}/timeline`}>
-              <Button variant="outline">
-                <Clock className="size-4" />
-                Timeline
-              </Button>
-            </Link>
-            <Link href={`/projects/${project.id}/scope`}>
-              <Button variant="outline">
-                <FileText className="size-4" />
-                Scope Summary
-              </Button>
-            </Link>
-            <Link href={`/projects/${project.id}/edit`}>
-              <Button>
-                <Edit className="size-4" />
-                Edit Project
-              </Button>
-            </Link>
-            <Button 
-              variant="destructive"
-              onClick={() => setShowDeleteDialog(true)}
-              disabled={isDeleting}
-            >
-              <Trash2 className="size-4" />
-              Delete
-            </Button>
+
+          {/* KPI chips */}
+          <div className="mt-6 flex flex-wrap gap-3">
+            <div className="flex items-center gap-2 bg-white/10 backdrop-blur-sm border border-white/15 rounded-xl px-4 py-2">
+              <Building2 className="size-4 text-blue-300" />
+              <span className="text-xs text-slate-400">Buildings</span>
+              <span className="text-sm font-bold">{project._count.buildings}</span>
+            </div>
+            <div className="flex items-center gap-2 bg-white/10 backdrop-blur-sm border border-white/15 rounded-xl px-4 py-2">
+              <FileText className="size-4 text-slate-400" />
+              <span className="text-xs text-slate-400">Tasks</span>
+              <span className="text-sm font-bold">{project._count.tasks}</span>
+            </div>
+            {(project.contractualTonnage || project.engineeringTonnage) && (
+              <div className="flex items-center gap-2 bg-white/10 backdrop-blur-sm border border-white/15 rounded-xl px-4 py-2">
+                <Settings className="size-4 text-amber-400" />
+                <span className="text-xs text-slate-400">Tonnage</span>
+                <span className="text-sm font-bold">
+                  {project.contractualTonnage ?? project.engineeringTonnage} t
+                </span>
+              </div>
+            )}
+            {project.contractValue && !hideFinancialData && (
+              <div className="flex items-center gap-2 bg-white/10 backdrop-blur-sm border border-white/15 rounded-xl px-4 py-2">
+                <DollarSign className="size-4 text-emerald-400" />
+                <span className="text-xs text-slate-400">Contract Value</span>
+                <span className="text-sm font-bold">{formatCurrency(project.contractValue)}</span>
+              </div>
+            )}
+            {project.plannedStartDate && (
+              <div className="flex items-center gap-2 bg-white/10 backdrop-blur-sm border border-white/15 rounded-xl px-4 py-2">
+                <Calendar className="size-4 text-slate-400" />
+                <span className="text-xs text-slate-400">Start</span>
+                <span className="text-sm font-bold">{formatDate(project.plannedStartDate)}</span>
+              </div>
+            )}
+            {project.plannedEndDate && (
+              <div className="flex items-center gap-2 bg-white/10 backdrop-blur-sm border border-white/15 rounded-xl px-4 py-2">
+                <Calendar className="size-4 text-slate-400" />
+                <span className="text-xs text-slate-400">End</span>
+                <span className="text-sm font-bold">{formatDate(project.plannedEndDate)}</span>
+              </div>
+            )}
           </div>
         </div>
+      </div>
 
-        {/* Quick Stats */}
-        <div className="grid gap-4 md:grid-cols-4">
-          <Link href={`/projects/${project.id}/buildings`}>
-            <Card className="cursor-pointer hover:bg-muted/50 transition-colors">
-              <CardContent className="pt-6">
-                <div className="flex items-center gap-2 text-muted-foreground mb-1">
-                  <Building2 className="size-4" />
-                  <span className="text-sm">Buildings</span>
-                </div>
-                <p className="text-2xl font-bold">{project._count.buildings}</p>
-              </CardContent>
-            </Card>
-          </Link>
-          
-          <Link href={`/tasks?project=${project.id}`}>
-            <Card className="cursor-pointer hover:bg-muted/50 transition-colors">
-              <CardContent className="pt-6">
-                <div className="flex items-center gap-2 text-muted-foreground mb-1">
-                  <FileText className="size-4" />
-                  <span className="text-sm">Tasks</span>
-                </div>
-                <p className="text-2xl font-bold">{project._count.tasks}</p>
-              </CardContent>
-            </Card>
-          </Link>
-
-          {project.contractValue && !hideFinancialData && (
-            <Card>
-              <CardContent className="pt-6">
-                <div className="flex items-center gap-2 text-muted-foreground mb-1">
-                  <DollarSign className="size-4" />
-                  <span className="text-sm">Contract Value</span>
-                </div>
-                <p className="text-2xl font-bold">{formatCurrency(project.contractValue)}</p>
-              </CardContent>
-            </Card>
-          )}
-
-          {(project.contractualTonnage || project.engineeringTonnage) && (
-            <Card>
-              <CardContent className="pt-6">
-                <div className="flex items-center gap-2 text-muted-foreground mb-1">
-                  <Settings className="size-4" />
-                  <span className="text-sm">Tonnage</span>
-                </div>
-                <div className="space-y-1">
-                  {project.contractualTonnage && (
-                    <p className="text-lg font-semibold">{project.contractualTonnage} tons (Contractual)</p>
-                  )}
-                  {project.engineeringTonnage && (
-                    <p className="text-sm text-muted-foreground">{project.engineeringTonnage} tons (Engineering)</p>
-                  )}
-                </div>
-              </CardContent>
-            </Card>
-          )}
-
-          {project.plannedStartDate && (
-            <Card>
-              <CardContent className="pt-6">
-                <div className="flex items-center gap-2 text-muted-foreground mb-1">
-                  <Calendar className="size-4" />
-                  <span className="text-sm">Start Date</span>
-                </div>
-                <p className="text-lg font-semibold">{formatDate(project.plannedStartDate)}</p>
-              </CardContent>
-            </Card>
-          )}
-        </div>
+      <div className="container mx-auto p-6 lg:p-8 space-y-6 max-lg:pt-6">
 
         {/* Collapsible Sections */}
         <div className="space-y-4">

--- a/src/lib/services/supply-chain/supplier-portal.service.ts
+++ b/src/lib/services/supply-chain/supplier-portal.service.ts
@@ -185,14 +185,27 @@ export function ratingToOutcome(rating: string): string {
 // Supplier List
 // ---------------------------------------------------------------------------
 
+const SORT_COL_MAP: Record<string, string> = {
+  name:            'dt.name',
+  approval_status: 'sas.approvalStatus',
+  approval_rating: 'sas.rating',
+  credit_limit:    'cl.credit_limit',
+  net_days:        'pt.net_days',
+};
+
 export async function getSupplierList(
   search: string | null,
   page: number,
   limit: number,
+  sortKey: string = 'name',
+  sortDir: 'asc' | 'desc' = 'asc',
 ): Promise<{ suppliers: SupplierListRow[]; total: number }> {
   const offset = (page - 1) * limit;
   const searchFilter = search ? `AND dt.name LIKE ?` : '';
   const searchArgs = search ? [`%${search}%`] : [];
+  const col = SORT_COL_MAP[sortKey] ?? 'dt.name';
+  const dir = sortDir === 'desc' ? 'DESC' : 'ASC';
+  const orderClause = `ORDER BY ${col} ${dir} NULLS LAST, dt.name ASC`;
 
   const rows = await prisma.$queryRawUnsafe<SupplierListRow[]>(`
     SELECT
@@ -230,7 +243,7 @@ export async function getSupplierList(
         )
       )
       ${searchFilter}
-    ORDER BY dt.name ASC
+    ${orderClause}
     LIMIT ? OFFSET ?
   `, ...searchArgs, limit, offset);
 


### PR DESCRIPTION
- PO page: add Sync Invoice Links button + endpoint to re-establish
  linked_po_dolibarr_id for all invoices via origin/linked_objects strategies

- Suppliers list: server-side sorting (SQL ORDER BY) so all pages sort
  correctly; remove Location column; show Credit Limit + Pay. Terms at md breakpoint

- Supplier detail: unified "Set Credit & Terms" dialog (credit limit +
  payment terms in one form); add Subcontracts tab for suppliers who have contracts

- Subcontracts list: Force Delete (hard delete) option in 3-dots menu
  visible for admin/CEO only, with API enforcement; API supports force=true
  to bypass soft-delete status restrictions

- New Subcontract form: combobox (Popover + Command) for Project and
  Supplier fields enabling text search + keyboard arrow navigation;
  scope type buttons filtered to scopes present in the selected project

- Project card: rich hero banner (gradient, icon badge, project tags,
  action buttons, KPI chips) replacing the plain flat header