### PR TITLE
feat: add bank transactions + VAT payments sync from Dolibarr

### DIFF
--- a/prisma/manual_migrations/v25_1_fin_bank_transactions_and_vat_sync.sql
+++ b/prisma/manual_migrations/v25_1_fin_bank_transactions_and_vat_sync.sql
@@ -1,0 +1,89 @@
+-- Add Dolibarr sync support to fin_vat_payments
+-- and create fin_bank_transactions table for direct bank line sync
+
+-- 1. Add dolibarr_id, source, sync_hash to fin_vat_payments
+SET @col1 = (
+  SELECT IF(
+    EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = DATABASE()
+        AND table_name = 'fin_vat_payments'
+        AND column_name = 'dolibarr_id'
+    ),
+    'SELECT 1',
+    'ALTER TABLE fin_vat_payments ADD COLUMN dolibarr_id INT NULL AFTER id'
+  )
+);
+PREPARE s1 FROM @col1; EXECUTE s1; DEALLOCATE PREPARE s1;
+
+SET @col2 = (
+  SELECT IF(
+    EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = DATABASE()
+        AND table_name = 'fin_vat_payments'
+        AND column_name = 'source'
+    ),
+    'SELECT 1',
+    "ALTER TABLE fin_vat_payments ADD COLUMN source ENUM('manual','dolibarr') NOT NULL DEFAULT 'manual' AFTER notes"
+  )
+);
+PREPARE s2 FROM @col2; EXECUTE s2; DEALLOCATE PREPARE s2;
+
+SET @col3 = (
+  SELECT IF(
+    EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = DATABASE()
+        AND table_name = 'fin_vat_payments'
+        AND column_name = 'sync_hash'
+    ),
+    'SELECT 1',
+    'ALTER TABLE fin_vat_payments ADD COLUMN sync_hash VARCHAR(32) NULL'
+  )
+);
+PREPARE s3 FROM @col3; EXECUTE s3; DEALLOCATE PREPARE s3;
+
+SET @idx1 = (
+  SELECT IF(
+    EXISTS (
+      SELECT 1 FROM information_schema.statistics
+      WHERE table_schema = DATABASE()
+        AND table_name = 'fin_vat_payments'
+        AND index_name = 'idx_dolibarr_id'
+    ),
+    'SELECT 1',
+    'ALTER TABLE fin_vat_payments ADD UNIQUE INDEX idx_dolibarr_id (dolibarr_id)'
+  )
+);
+PREPARE si1 FROM @idx1; EXECUTE si1; DEALLOCATE PREPARE si1;
+
+-- 2. Create fin_bank_transactions table
+SET @sql2 = (
+  SELECT IF(
+    EXISTS (
+      SELECT 1 FROM information_schema.tables
+      WHERE table_schema = DATABASE()
+        AND table_name = 'fin_bank_transactions'
+    ),
+    'SELECT 1',
+    'CREATE TABLE fin_bank_transactions (
+      id                      INT AUTO_INCREMENT PRIMARY KEY,
+      dolibarr_id             INT NOT NULL,
+      bank_account_dolibarr_id INT NOT NULL,
+      dateo                   DATE NULL,
+      datev                   DATE NULL,
+      amount                  DECIMAL(20,2) NOT NULL,
+      label                   VARCHAR(500) NULL,
+      fk_type                 VARCHAR(50) NULL,
+      num_chq                 VARCHAR(100) NULL,
+      sync_hash               VARCHAR(32) NULL,
+      first_synced_at         DATETIME DEFAULT CURRENT_TIMESTAMP,
+      last_synced_at          DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+      UNIQUE KEY uk_dolibarr_bank (dolibarr_id, bank_account_dolibarr_id),
+      INDEX idx_bank_account (bank_account_dolibarr_id),
+      INDEX idx_dateo (dateo)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci'
+  )
+);
+PREPARE s4 FROM @sql2; EXECUTE s4; DEALLOCATE PREPARE s4;

--- a/src/app/api/financial/bank-accounts/[id]/transactions/route.ts
+++ b/src/app/api/financial/bank-accounts/[id]/transactions/route.ts
@@ -25,47 +25,86 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
     );
     if (!account.length) return NextResponse.json({ error: 'Bank account not found' }, { status: 404 });
 
-    const rows: any[] = await prisma.$queryRawUnsafe(
-      `SELECT
-         fp.id,
-         fp.dolibarr_ref,
-         fp.payment_type,
-         fp.invoice_dolibarr_id,
-         fp.amount,
-         fp.payment_date,
-         fp.payment_method,
-         CASE fp.payment_type
-           WHEN 'customer' THEN ci.ref
-           WHEN 'supplier' THEN si.ref
-         END AS invoice_ref,
-         CASE fp.payment_type
-           WHEN 'customer' THEN ci.ref_customer
-           WHEN 'supplier' THEN si.ref_supplier
-         END AS party_ref,
-         CASE fp.payment_type
-           WHEN 'customer' THEN dt_c.name
-           WHEN 'supplier' THEN dt_s.name
-         END AS party_name
-       FROM fin_payments fp
-       LEFT JOIN fin_customer_invoices ci
-         ON fp.payment_type = 'customer' AND ci.dolibarr_id = fp.invoice_dolibarr_id
-       LEFT JOIN dolibarr_thirdparties dt_c
-         ON fp.payment_type = 'customer' AND ci.socid = dt_c.dolibarr_id
-       LEFT JOIN fin_supplier_invoices si
-         ON fp.payment_type = 'supplier' AND si.dolibarr_id = fp.invoice_dolibarr_id
-       LEFT JOIN dolibarr_thirdparties dt_s
-         ON fp.payment_type = 'supplier' AND si.socid = dt_s.dolibarr_id
-       WHERE fp.bank_account_id = ?
-       ORDER BY fp.payment_date DESC, fp.id DESC
-       LIMIT ? OFFSET ?`,
-      bankDolibarrId, limit, offset
-    );
-
-    const countRows: any[] = await prisma.$queryRawUnsafe(
-      `SELECT COUNT(*) AS cnt FROM fin_payments WHERE bank_account_id = ?`,
+    // Check if fin_bank_transactions has records for this account
+    const btCount: any[] = await prisma.$queryRawUnsafe(
+      `SELECT COUNT(*) AS cnt FROM fin_bank_transactions WHERE bank_account_dolibarr_id = ?`,
       bankDolibarrId
     );
-    const total = Number(countRows[0]?.cnt ?? 0);
+    const hasBankTransactions = Number(btCount[0]?.cnt ?? 0) > 0;
+
+    let rows: any[];
+    let total: number;
+
+    if (hasBankTransactions) {
+      // Use fin_bank_transactions (direct bank statement lines from Dolibarr)
+      rows = await prisma.$queryRawUnsafe(
+        `SELECT
+           bt.id,
+           bt.num_chq       AS dolibarr_ref,
+           NULL             AS payment_type,
+           bt.bank_account_dolibarr_id AS bank_account_id,
+           bt.amount,
+           bt.dateo         AS payment_date,
+           bt.fk_type       AS payment_method,
+           NULL             AS invoice_ref,
+           NULL             AS party_ref,
+           bt.label         AS party_name
+         FROM fin_bank_transactions bt
+         WHERE bt.bank_account_dolibarr_id = ?
+         ORDER BY bt.dateo DESC, bt.id DESC
+         LIMIT ? OFFSET ?`,
+        bankDolibarrId, limit, offset
+      );
+
+      const countRows: any[] = await prisma.$queryRawUnsafe(
+        `SELECT COUNT(*) AS cnt FROM fin_bank_transactions WHERE bank_account_dolibarr_id = ?`,
+        bankDolibarrId
+      );
+      total = Number(countRows[0]?.cnt ?? 0);
+    } else {
+      // Fall back to fin_payments linked to invoices for this bank account
+      rows = await prisma.$queryRawUnsafe(
+        `SELECT
+           fp.id,
+           fp.dolibarr_ref,
+           fp.payment_type,
+           fp.invoice_dolibarr_id,
+           fp.amount,
+           fp.payment_date,
+           fp.payment_method,
+           CASE fp.payment_type
+             WHEN 'customer' THEN ci.ref
+             WHEN 'supplier' THEN si.ref
+           END AS invoice_ref,
+           CASE fp.payment_type
+             WHEN 'customer' THEN ci.ref_client
+             WHEN 'supplier' THEN si.ref_supplier
+           END AS party_ref,
+           CASE fp.payment_type
+             WHEN 'customer' THEN dt_c.name
+             WHEN 'supplier' THEN dt_s.name
+           END AS party_name
+         FROM fin_payments fp
+         LEFT JOIN fin_customer_invoices ci
+           ON fp.payment_type = 'customer' AND ci.dolibarr_id = fp.invoice_dolibarr_id
+         LEFT JOIN dolibarr_thirdparties dt_c
+           ON fp.payment_type = 'customer' AND ci.socid = dt_c.dolibarr_id
+         LEFT JOIN fin_supplier_invoices si
+           ON fp.payment_type = 'supplier' AND si.dolibarr_id = fp.invoice_dolibarr_id
+         LEFT JOIN dolibarr_thirdparties dt_s
+           ON fp.payment_type = 'supplier' AND si.socid = dt_s.dolibarr_id
+         WHERE fp.bank_account_id = ?
+         ORDER BY fp.payment_date DESC, fp.id DESC
+         LIMIT ? OFFSET ?`,
+        bankDolibarrId, limit, offset
+      );
+
+      const countRows: any[] = await prisma.$queryRawUnsafe(
+        `SELECT COUNT(*) AS cnt FROM fin_payments WHERE bank_account_id = ?`,
+        bankDolibarrId
+      );
+      total = Number(countRows[0]?.cnt ?? 0);
+    }
 
     const ba = account[0];
     return NextResponse.json({
@@ -78,6 +117,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
         currency: ba.currency_code,
         isOpen: ba.is_open === 1,
       },
+      source: hasBankTransactions ? 'bank_transactions' : 'payments',
       transactions: rows.map(r => ({
         ...r,
         id: Number(r.id),

--- a/src/app/api/financial/sync/route.ts
+++ b/src/app/api/financial/sync/route.ts
@@ -6,7 +6,7 @@ import { systemEventService } from '@/services/system-events.service';
 export const dynamic = 'force-dynamic';
 export const maxDuration = 600; // 10 minutes for full sync
 
-const VALID_ENTITIES = ['bank_accounts', 'projects', 'customer_invoices', 'supplier_invoices', 'payments', 'salaries', 'journal_entries'];
+const VALID_ENTITIES = ['bank_accounts', 'projects', 'customer_invoices', 'supplier_invoices', 'payments', 'salaries', 'vat_payments', 'bank_transactions', 'journal_entries'];
 
 export async function POST(request: NextRequest) {
   const auth = await requireFinancialPermission('financial.manage');

--- a/src/app/financial/_page-client.tsx
+++ b/src/app/financial/_page-client.tsx
@@ -455,7 +455,7 @@ export default function FinancialDashboardPage() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-7 gap-4 mb-4">
+            <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-9 gap-4 mb-4">
               {[
                 { label: 'Projects', key: 'projects', syncKey: 'projects' },
                 { label: 'Customer Invoices', key: 'customerInvoices', syncKey: 'customer_invoices' },
@@ -463,6 +463,8 @@ export default function FinancialDashboardPage() {
                 { label: 'Payments', key: 'payments', syncKey: 'payments' },
                 { label: 'Salaries', key: 'salaries', syncKey: 'salaries' },
                 { label: 'Bank Accounts', key: 'bankAccounts', syncKey: 'bank_accounts' },
+                { label: 'Bank Transactions', key: 'bankTransactions', syncKey: 'bank_transactions' },
+                { label: 'VAT Payments', key: 'vatPayments', syncKey: 'vat_payments' },
                 { label: 'Journal Entries', key: 'journalEntries', syncKey: 'journal_entries', btnLabel: 'Regenerate' },
               ].map((item) => (
                 <div key={item.key} className="text-center p-3 border rounded-lg">
@@ -520,6 +522,64 @@ export default function FinancialDashboardPage() {
           </CardContent>
         </Card>
       )}
+
+      {/* Quick Sync Tiles — Bank Transactions & VAT Payments */}
+      <h2 className="text-xl font-semibold mt-2">Quick Sync</h2>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <Card className="border-blue-200 dark:border-blue-900/50">
+          <CardContent className="pt-5 pb-4">
+            <div className="flex items-center justify-between mb-1">
+              <span className="text-sm font-semibold flex items-center gap-2">
+                <Landmark className="h-4 w-4 text-blue-500" /> Bank Transactions
+              </span>
+              <span className="text-xl font-bold">{syncStatus?.counts?.bankTransactions ?? 0}</span>
+            </div>
+            <p className="text-xs text-muted-foreground mb-3">Direct bank statement lines from Dolibarr</p>
+            <Button size="sm" variant="outline" className="w-full text-xs h-8"
+              disabled={!!syncingEntity || syncing}
+              onClick={() => handlePartialSync('bank_transactions')}>
+              {syncingEntity === 'bank_transactions' ? <Loader2 className="h-3 w-3 animate-spin mr-1" /> : <RefreshCw className="h-3 w-3 mr-1" />}
+              {syncingEntity === 'bank_transactions' ? 'Syncing…' : 'Sync Bank Transactions'}
+            </Button>
+          </CardContent>
+        </Card>
+
+        <Card className="border-orange-200 dark:border-orange-900/50">
+          <CardContent className="pt-5 pb-4">
+            <div className="flex items-center justify-between mb-1">
+              <span className="text-sm font-semibold flex items-center gap-2">
+                <Receipt className="h-4 w-4 text-orange-500" /> VAT Payments
+              </span>
+              <span className="text-xl font-bold">{syncStatus?.counts?.vatPayments ?? 0}</span>
+            </div>
+            <p className="text-xs text-muted-foreground mb-3">ZATCA settlement payments from Dolibarr</p>
+            <Button size="sm" variant="outline" className="w-full text-xs h-8"
+              disabled={!!syncingEntity || syncing}
+              onClick={() => handlePartialSync('vat_payments')}>
+              {syncingEntity === 'vat_payments' ? <Loader2 className="h-3 w-3 animate-spin mr-1" /> : <RefreshCw className="h-3 w-3 mr-1" />}
+              {syncingEntity === 'vat_payments' ? 'Syncing…' : 'Sync VAT Payments'}
+            </Button>
+          </CardContent>
+        </Card>
+
+        <Card className="border-purple-200 dark:border-purple-900/50">
+          <CardContent className="pt-5 pb-4">
+            <div className="flex items-center justify-between mb-1">
+              <span className="text-sm font-semibold flex items-center gap-2">
+                <CreditCard className="h-4 w-4 text-purple-500" /> Supplier Payments
+              </span>
+              <span className="text-xl font-bold">{syncStatus?.counts?.payments ?? 0}</span>
+            </div>
+            <p className="text-xs text-muted-foreground mb-3">Customer &amp; supplier invoice payments</p>
+            <Button size="sm" variant="outline" className="w-full text-xs h-8"
+              disabled={!!syncingEntity || syncing}
+              onClick={() => handlePartialSync('payments')}>
+              {syncingEntity === 'payments' ? <Loader2 className="h-3 w-3 animate-spin mr-1" /> : <RefreshCw className="h-3 w-3 mr-1" />}
+              {syncingEntity === 'payments' ? 'Syncing…' : 'Sync Payments'}
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
 
       {/* Management Links */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/src/app/financial/bank-accounts/[id]/_page-client.tsx
+++ b/src/app/financial/bank-accounts/[id]/_page-client.tsx
@@ -100,7 +100,8 @@ export default function BankTransactionsPage({ bankId }: { bankId: number }) {
               </div>
             ) : !data?.transactions?.length ? (
               <div className="text-center py-16 text-muted-foreground">
-                No transactions found for this account.
+                <p>No transactions found for this account.</p>
+                <p className="text-xs mt-2">Sync bank transactions from the Financial Dashboard to populate this view.</p>
               </div>
             ) : (
               <>
@@ -118,29 +119,33 @@ export default function BankTransactionsPage({ bankId }: { bankId: number }) {
                       </tr>
                     </thead>
                     <tbody>
-                      {data.transactions.map((t: any) => (
-                        <tr key={t.id} className="border-b hover:bg-muted/30">
-                          <td className="p-3 whitespace-nowrap">{formatDate(t.payment_date)}</td>
-                          <td className="p-3 font-mono text-xs">{t.dolibarr_ref || '—'}</td>
-                          <td className="p-3 max-w-[200px] truncate">{t.party_name || '—'}</td>
-                          <td className="p-3 font-mono text-xs">{t.invoice_ref || t.party_ref || '—'}</td>
-                          <td className="p-3">{t.payment_method || '—'}</td>
-                          <td className="p-3">
-                            {t.payment_type === 'customer' ? (
-                              <span className="inline-flex items-center gap-1 text-green-700 bg-green-50 border border-green-200 text-xs px-2 py-0.5 rounded-full font-medium">
-                                <TrendingUp className="size-3" /> Collection
-                              </span>
-                            ) : (
-                              <span className="inline-flex items-center gap-1 text-red-700 bg-red-50 border border-red-200 text-xs px-2 py-0.5 rounded-full font-medium">
-                                <TrendingDown className="size-3" /> Payment
-                              </span>
-                            )}
-                          </td>
-                          <td className={`p-3 text-right font-semibold ${t.payment_type === 'customer' ? 'text-green-600' : 'text-red-600'}`}>
-                            {t.payment_type === 'customer' ? '+' : '-'}{formatSAR(t.amount)}
-                          </td>
-                        </tr>
-                      ))}
+                      {data.transactions.map((t: any) => {
+                        const isCredit = t.payment_type === 'customer' || (t.payment_type == null && t.amount > 0);
+                        const absAmount = Math.abs(Number(t.amount));
+                        return (
+                          <tr key={t.id} className="border-b hover:bg-muted/30">
+                            <td className="p-3 whitespace-nowrap">{formatDate(t.payment_date)}</td>
+                            <td className="p-3 font-mono text-xs">{t.dolibarr_ref || '—'}</td>
+                            <td className="p-3 max-w-[200px] truncate">{t.party_name || '—'}</td>
+                            <td className="p-3 font-mono text-xs">{t.invoice_ref || t.party_ref || '—'}</td>
+                            <td className="p-3">{t.payment_method || t.fk_type || '—'}</td>
+                            <td className="p-3">
+                              {isCredit ? (
+                                <span className="inline-flex items-center gap-1 text-green-700 bg-green-50 border border-green-200 text-xs px-2 py-0.5 rounded-full font-medium">
+                                  <TrendingUp className="size-3" /> Credit
+                                </span>
+                              ) : (
+                                <span className="inline-flex items-center gap-1 text-red-700 bg-red-50 border border-red-200 text-xs px-2 py-0.5 rounded-full font-medium">
+                                  <TrendingDown className="size-3" /> Debit
+                                </span>
+                              )}
+                            </td>
+                            <td className={`p-3 text-right font-semibold ${isCredit ? 'text-green-600' : 'text-red-600'}`}>
+                              {isCredit ? '+' : '-'}{formatSAR(absAmount)}
+                            </td>
+                          </tr>
+                        );
+                      })}
                     </tbody>
                   </table>
                 </div>

--- a/src/app/financial/vat-payments/_page-client.tsx
+++ b/src/app/financial/vat-payments/_page-client.tsx
@@ -8,7 +8,7 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Skeleton } from '@/components/ui/skeleton';
-import { ArrowLeft, Plus, Trash2, Receipt, Edit } from 'lucide-react';
+import { ArrowLeft, Plus, Trash2, Receipt, Edit, RefreshCw, Loader2 } from 'lucide-react';
 import Link from 'next/link';
 import { useAlert } from '@/hooks/useAlert';
 
@@ -37,6 +37,7 @@ export default function VatPaymentsPage() {
   const [editTarget, setEditTarget] = useState<any>(null);
   const [form, setForm] = useState({ ...EMPTY_FORM });
   const [saving, setSaving] = useState(false);
+  const [syncing, setSyncing] = useState(false);
   const { showAlert, AlertDialog } = useAlert();
 
   const load = () => {
@@ -48,6 +49,23 @@ export default function VatPaymentsPage() {
   };
 
   useEffect(() => { load(); }, []);
+
+  const handleSync = async () => {
+    setSyncing(true);
+    try {
+      const res = await fetch('/api/financial/sync?entities=vat_payments', { method: 'POST' });
+      if (res.ok) {
+        load();
+      } else {
+        const err = await res.json().catch(() => ({ error: 'Sync failed' }));
+        showAlert(err.error || 'Sync failed', { type: 'error' });
+      }
+    } catch {
+      showAlert('Sync failed', { type: 'error' });
+    } finally {
+      setSyncing(false);
+    }
+  };
 
   const openNew = () => {
     setEditTarget(null);
@@ -135,7 +153,7 @@ export default function VatPaymentsPage() {
               <p className="text-slate-400 mt-1 text-sm">ZATCA settlement payments — actual amounts paid to tax authority</p>
             </div>
           </div>
-          <div className="mt-6 flex flex-wrap gap-3">
+          <div className="mt-6 flex flex-wrap gap-3 items-center">
             <div className="flex items-center gap-2 bg-white/10 backdrop-blur-sm border border-white/15 rounded-xl px-4 py-2">
               <Receipt className="size-4 text-orange-300" />
               <span className="text-xs text-slate-400">Total Paid</span>
@@ -145,6 +163,16 @@ export default function VatPaymentsPage() {
               <span className="text-xs text-slate-400">Records</span>
               <span className="text-sm font-bold">{payments.length}</span>
             </div>
+            <Button
+              size="sm"
+              variant="outline"
+              className="bg-white/10 border-white/20 text-white hover:bg-white/20 hover:text-white gap-1.5"
+              onClick={handleSync}
+              disabled={syncing}
+            >
+              {syncing ? <Loader2 className="size-3.5 animate-spin" /> : <RefreshCw className="size-3.5" />}
+              {syncing ? 'Syncing from Dolibarr…' : 'Sync from Dolibarr'}
+            </Button>
           </div>
         </div>
       </div>

--- a/src/lib/dolibarr/dolibarr-client.ts
+++ b/src/lib/dolibarr/dolibarr-client.ts
@@ -369,6 +369,29 @@ export interface DolibarrHolidayType {
   [key: string]: unknown;
 }
 
+export interface DolibarrBankLine {
+  id: number | string;
+  dateo: number | string | null;
+  datev: number | string | null;
+  amount: number | string;
+  label: string | null;
+  fk_type: string | null;
+  num_chq: string | null;
+  fk_account: number | string | null;
+  [key: string]: unknown;
+}
+
+export interface DolibarrVatPayment {
+  id: number | string;
+  datep: number | string | null;
+  amount: number | string;
+  ref_num: string | null;
+  note: string | null;
+  fk_typepayment: number | string | null;
+  fk_account: number | string | null;
+  [key: string]: unknown;
+}
+
 export interface DolibarrConnectionInfo {
   success: boolean;
   version?: string;
@@ -942,6 +965,42 @@ export class DolibarrClient {
       sortorder: 'ASC',
     });
     return Array.isArray(result) ? result : [];
+  }
+
+  /**
+   * Fetch bank account transaction lines for a specific account
+   */
+  async getBankAccountLines(bankAccountId: number, params?: DolibarrPaginationParams): Promise<DolibarrBankLine[]> {
+    try {
+      const result = await this.request<DolibarrBankLine[]>(`bankaccounts/${bankAccountId}/lines`, {
+        limit: params?.limit ?? 500,
+        page: params?.page ?? 0,
+        sortfield: 't.rowid',
+        sortorder: 'ASC',
+      });
+      return Array.isArray(result) ? result : [];
+    } catch (error: any) {
+      if (error.message?.includes('404')) return [];
+      throw error;
+    }
+  }
+
+  /**
+   * Fetch VAT payment records from Dolibarr (compta/tva — paymentsvatreturns)
+   */
+  async getVatPayments(params?: DolibarrPaginationParams): Promise<DolibarrVatPayment[]> {
+    try {
+      const result = await this.request<DolibarrVatPayment[]>('paymentsvatreturns', {
+        limit: params?.limit ?? 500,
+        page: params?.page ?? 0,
+        sortfield: params?.sortfield ?? 't.rowid',
+        sortorder: params?.sortorder ?? 'ASC',
+      });
+      return Array.isArray(result) ? result : [];
+    } catch (error: any) {
+      if (error.message?.includes('404')) return [];
+      throw error;
+    }
   }
 
   /**

--- a/src/lib/dolibarr/financial-sync-service.ts
+++ b/src/lib/dolibarr/financial-sync-service.ts
@@ -45,6 +45,8 @@ export interface FullFinSyncResult {
   supplierInvoices?: FinSyncResult;
   supplierPayments?: FinSyncResult;
   salaries?: FinSyncResult;
+  vatPayments?: FinSyncResult;
+  bankTransactions?: FinSyncResult;
   journalEntries?: FinSyncResult;
   totalDurationMs: number;
 }
@@ -1038,6 +1040,180 @@ export class FinancialSyncService {
   }
 
   // ============================================
+  // SYNC: VAT PAYMENTS
+  // ============================================
+
+  async syncVatPayments(triggeredBy: string = 'manual'): Promise<FinSyncResult> {
+    const startTime = Date.now();
+    let created = 0, updated = 0, unchanged = 0, total = 0;
+
+    try {
+      const BATCH_SIZE = 500;
+      let page = 0;
+      let hasMore = true;
+
+      while (hasMore) {
+        const batch = await this.client.getVatPayments({ limit: BATCH_SIZE, page });
+
+        for (const vp of batch) {
+          total++;
+          const dolibarrId = pi(vp.id);
+          if (!dolibarrId) continue;
+
+          const paymentDate = formatDate(parseDolibarrDate(vp.datep));
+          if (!paymentDate) continue;
+
+          const hashFields = {
+            amount: vp.amount,
+            datep: vp.datep,
+            ref_num: vp.ref_num,
+            note: vp.note,
+          };
+          const newHash = computeHash(hashFields);
+
+          const existing: any[] = await prisma.$queryRawUnsafe(
+            `SELECT id, sync_hash FROM fin_vat_payments WHERE dolibarr_id = ?`, dolibarrId
+          );
+
+          if (existing.length > 0) {
+            if (existing[0].sync_hash === newHash) { unchanged++; continue; }
+            await prisma.$executeRawUnsafe(
+              `UPDATE fin_vat_payments SET amount=?, payment_date=?, reference=?, notes=?, sync_hash=?, source='dolibarr', updated_at=NOW()
+               WHERE dolibarr_id=?`,
+              pf(vp.amount), paymentDate, vp.ref_num || null, vp.note || null, newHash, dolibarrId
+            );
+            updated++;
+          } else {
+            const d = new Date(paymentDate);
+            const mon = String(d.getMonth() + 1).padStart(2, '0');
+            const periodLabel = `${d.getFullYear()}-${mon}`;
+            const periodStart = `${d.getFullYear()}-${mon}-01`;
+            const lastDay = new Date(d.getFullYear(), d.getMonth() + 1, 0).getDate();
+            const periodEnd = `${d.getFullYear()}-${mon}-${String(lastDay).padStart(2, '0')}`;
+
+            await prisma.$executeRawUnsafe(
+              `INSERT INTO fin_vat_payments (dolibarr_id, period_label, period_start, period_end, payment_date, amount, reference, notes, sync_hash, source)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'dolibarr')`,
+              dolibarrId, periodLabel, periodStart, periodEnd, paymentDate,
+              pf(vp.amount), vp.ref_num || null, vp.note || null, newHash
+            );
+            created++;
+          }
+        }
+
+        hasMore = batch.length >= BATCH_SIZE;
+        page++;
+      }
+
+      const result: FinSyncResult = {
+        entityType: 'vat_payments', status: 'success',
+        created, updated, unchanged, total,
+        durationMs: Date.now() - startTime,
+      };
+      await this.logSync(result, triggeredBy);
+      return result;
+    } catch (error: any) {
+      console.error('[FinSync] VAT payments sync failed:', error.message);
+      const result: FinSyncResult = {
+        entityType: 'vat_payments', status: 'error',
+        created, updated, unchanged, total: 0,
+        durationMs: Date.now() - startTime, error: error.message,
+      };
+      await this.logSync(result, triggeredBy);
+      return result;
+    }
+  }
+
+  // ============================================
+  // SYNC: BANK TRANSACTIONS
+  // ============================================
+
+  async syncBankTransactions(triggeredBy: string = 'manual'): Promise<FinSyncResult> {
+    const startTime = Date.now();
+    let created = 0, updated = 0, unchanged = 0, total = 0;
+
+    try {
+      const bankAccounts: any[] = await prisma.$queryRawUnsafe(
+        `SELECT dolibarr_id FROM fin_bank_accounts WHERE is_open = 1`
+      );
+
+      for (const account of bankAccounts) {
+        const bankId = Number(account.dolibarr_id);
+        const BATCH_SIZE = 500;
+        let page = 0;
+        let hasMore = true;
+
+        while (hasMore) {
+          const lines = await this.client.getBankAccountLines(bankId, { limit: BATCH_SIZE, page });
+
+          for (const line of lines) {
+            total++;
+            const lineId = pi(line.id);
+            if (!lineId) continue;
+
+            const dateo = formatDate(parseDolibarrDate(line.dateo));
+            const datev = formatDate(parseDolibarrDate(line.datev));
+
+            const hashFields = {
+              amount: line.amount,
+              dateo: line.dateo,
+              label: line.label,
+              fk_type: line.fk_type,
+            };
+            const newHash = computeHash(hashFields);
+
+            const existing: any[] = await prisma.$queryRawUnsafe(
+              `SELECT sync_hash FROM fin_bank_transactions WHERE dolibarr_id = ? AND bank_account_dolibarr_id = ?`,
+              lineId, bankId
+            );
+
+            if (existing.length > 0) {
+              if (existing[0].sync_hash === newHash) { unchanged++; continue; }
+              await prisma.$executeRawUnsafe(
+                `UPDATE fin_bank_transactions SET dateo=?, datev=?, amount=?, label=?, fk_type=?, num_chq=?, last_synced_at=NOW(), sync_hash=?
+                 WHERE dolibarr_id=? AND bank_account_dolibarr_id=?`,
+                dateo, datev, pf(line.amount), line.label || null,
+                line.fk_type || null, (line.num_chq as string) || null,
+                newHash, lineId, bankId
+              );
+              updated++;
+            } else {
+              await prisma.$executeRawUnsafe(
+                `INSERT INTO fin_bank_transactions (dolibarr_id, bank_account_dolibarr_id, dateo, datev, amount, label, fk_type, num_chq, first_synced_at, last_synced_at, sync_hash)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW(), ?)`,
+                lineId, bankId, dateo, datev, pf(line.amount),
+                line.label || null, line.fk_type || null, (line.num_chq as string) || null, newHash
+              );
+              created++;
+            }
+          }
+
+          hasMore = lines.length >= BATCH_SIZE;
+          page++;
+        }
+      }
+
+      console.log(`[FinSync] Bank transactions complete: ${total} total, ${created} created, ${updated} updated`);
+      const result: FinSyncResult = {
+        entityType: 'bank_transactions', status: 'success',
+        created, updated, unchanged, total,
+        durationMs: Date.now() - startTime,
+      };
+      await this.logSync(result, triggeredBy);
+      return result;
+    } catch (error: any) {
+      console.error('[FinSync] Bank transactions sync failed:', error.message);
+      const result: FinSyncResult = {
+        entityType: 'bank_transactions', status: 'error',
+        created, updated, unchanged, total: 0,
+        durationMs: Date.now() - startTime, error: error.message,
+      };
+      await this.logSync(result, triggeredBy);
+      return result;
+    }
+  }
+
+  // ============================================
   // JOURNAL ENTRY GENERATION (Batch optimized)
   // ============================================
 
@@ -1433,6 +1609,14 @@ export class FinancialSyncService {
             result.salaries = await this.syncSalaries(triggeredBy);
             console.log(`[FinSync] Salaries: ${result.salaries.created} created, ${result.salaries.updated} updated`);
             break;
+          case 'vat_payments':
+            result.vatPayments = await this.syncVatPayments(triggeredBy);
+            console.log(`[FinSync] VAT payments: ${result.vatPayments.created} created, ${result.vatPayments.updated} updated`);
+            break;
+          case 'bank_transactions':
+            result.bankTransactions = await this.syncBankTransactions(triggeredBy);
+            console.log(`[FinSync] Bank transactions: ${result.bankTransactions.created} created, ${result.bankTransactions.updated} updated`);
+            break;
           case 'journal_entries':
             result.journalEntries = await this.generateJournalEntries(triggeredBy);
             console.log(`[FinSync] Journal entries: ${result.journalEntries.created} generated`);
@@ -1470,6 +1654,8 @@ export class FinancialSyncService {
     let supplierInvoices: FinSyncResult | undefined;
     let supplierPayments: FinSyncResult | undefined;
     let salaries: FinSyncResult | undefined;
+    let vatPayments: FinSyncResult | undefined;
+    let bankTransactions: FinSyncResult | undefined;
     let journalEntries: FinSyncResult | undefined;
 
     try {
@@ -1516,6 +1702,20 @@ export class FinancialSyncService {
         console.error('[FinSync] Salary sync failed:', e.message);
       }
 
+      try {
+        vatPayments = await this.syncVatPayments(triggeredBy);
+        console.log(`[FinSync] VAT payments: ${vatPayments.created} created, ${vatPayments.updated} updated`);
+      } catch (e: any) {
+        console.error('[FinSync] VAT payments sync failed:', e.message);
+      }
+
+      try {
+        bankTransactions = await this.syncBankTransactions(triggeredBy);
+        console.log(`[FinSync] Bank transactions: ${bankTransactions.created} created, ${bankTransactions.updated} updated`);
+      } catch (e: any) {
+        console.error('[FinSync] Bank transactions sync failed:', e.message);
+      }
+
       // Always attempt journal entry generation even if some syncs failed
       // This ensures we generate entries from whatever data is available
       try {
@@ -1535,7 +1735,7 @@ export class FinancialSyncService {
 
     return {
       bankAccounts, projects, customerInvoices, customerPayments,
-      supplierInvoices, supplierPayments, salaries, journalEntries,
+      supplierInvoices, supplierPayments, salaries, vatPayments, bankTransactions, journalEntries,
       totalDurationMs,
     };
   }
@@ -1567,6 +1767,8 @@ export class FinancialSyncService {
       counts.payments = await getCount(`SELECT COUNT(*) as cnt FROM fin_payments`);
       counts.salaries = await getCount(`SELECT COUNT(*) as cnt FROM fin_salaries WHERE is_active = 1`);
       counts.bankAccounts = await getCount(`SELECT COUNT(*) as cnt FROM fin_bank_accounts`);
+      counts.vatPayments = await getCount(`SELECT COUNT(*) as cnt FROM fin_vat_payments`);
+      counts.bankTransactions = await getCount(`SELECT COUNT(*) as cnt FROM fin_bank_transactions`);
       counts.journalEntries = await getCount(`SELECT COUNT(*) as cnt FROM fin_journal_entries`);
 
       let recentLogs: any[] = [];


### PR DESCRIPTION
- Add `getBankAccountLines()` and `getVatPayments()` to DolibarrClient
  using `/bankaccounts/{id}/lines` and `/paymentsvatreturns` endpoints
- Add `syncBankTransactions()` and `syncVatPayments()` to FinancialSyncService;
  both are included in runFullSync and available as partial sync entities
- Migration v25_1: create `fin_bank_transactions` table; add `dolibarr_id`,
  `source`, `sync_hash` columns to `fin_vat_payments`
- Bank transactions API now uses `fin_bank_transactions` as primary source
  (direct bank statement lines), falls back to `fin_payments` if not yet synced
- Bank transactions page: handle positive/negative amounts from direct bank lines
  (Credit / Debit labels) and show sync hint when empty
- Financial dashboard: add "Quick Sync" section with Bank Transactions, VAT
  Payments, and Payments tiles; add both to the Sync Status grid
- VAT payments page: add "Sync from Dolibarr" button in the hero header

https://claude.ai/code/session_0154kGdfRBUfzxMsHRuBZjxV