### PR TITLE
fix: Dolibarr redirect URL, User deletedAt error, bank/VAT migration, subcontractor search

### DIFF
--- a/src/app/api/permissions/request/route.ts
+++ b/src/app/api/permissions/request/route.ts
@@ -30,7 +30,6 @@ export const POST = withApiContext(async (req, session) => {
         { role: { name: 'Admin' } },
       ],
       status: 'active',
-      deletedAt: null,
     },
     select: { id: true },
   });

--- a/src/app/supply-chain/purchase-orders/_page-client.tsx
+++ b/src/app/supply-chain/purchase-orders/_page-client.tsx
@@ -198,7 +198,7 @@ function PoDetailSheet({ order, open, onClose }: { order: PurchaseOrder | null; 
 
           {/* Open in Dolibarr */}
           <a
-            href={`https://ots.hexasteel.sa/dolibarr/index.php?id=${order.id}&module=fournisseur&action=view&mainmenu=fournisseur&leftmenu=orders_suppliers`}
+            href={`https://erp.hexametals.com/erp/fourn/commande/card.php?id=${order.id}`}
             target="_blank" rel="noopener noreferrer"
             className="inline-flex items-center gap-2 text-sm text-blue-600 hover:underline"
           >
@@ -339,7 +339,7 @@ export default function PurchaseOrdersPage() {
             <RefreshCw className={`size-4 mr-1 ${syncing ? 'animate-spin' : ''}`} />
             {syncing ? 'Syncing…' : 'Sync Invoices'}
           </Button>
-          <a href="https://ots.hexasteel.sa/dolibarr/index.php?mainmenu=fournisseur&leftmenu=orders_suppliers" target="_blank" rel="noopener noreferrer">
+          <a href="https://erp.hexametals.com/erp/fourn/commande/list.php?leftmenu=orders_suppliers" target="_blank" rel="noopener noreferrer">
             <Button variant="outline" size="sm">
               <ExternalLink className="size-4 mr-1" /> Open in Dolibarr
             </Button>

--- a/src/app/supply-chain/subcontractors/new/_page-client.tsx
+++ b/src/app/supply-chain/subcontractors/new/_page-client.tsx
@@ -341,7 +341,10 @@ export default function NewSubcontractorContractPage() {
                     </Button>
                   </PopoverTrigger>
                   <PopoverContent className="w-full p-0" style={{ minWidth: 'var(--radix-popover-trigger-width)' }}>
-                    <Command>
+                    <Command filter={(value, search) => {
+                      if (!search) return 1;
+                      return value.toLowerCase().includes(search.toLowerCase()) ? 1 : 0;
+                    }}>
                       <CommandInput placeholder="Search subcontractors…" />
                       <CommandList>
                         <CommandEmpty>No subcontractors found.</CommandEmpty>

--- a/src/lib/startup-migrations.ts
+++ b/src/lib/startup-migrations.ts
@@ -217,6 +217,9 @@ const STARTUP_MIGRATIONS = [
 
   // ── v24.7.0 — VAT payment records ────────────────────────────────────────
   'v24_7_fin_vat_payments.sql',          // fin_vat_payments table for ZATCA settlement tracking
+
+  // ── v25.1.0 — Bank transactions + VAT sync columns ───────────────────────
+  'v25_1_fin_bank_transactions_and_vat_sync.sql', // fin_bank_transactions table; dolibarr_id/source/sync_hash on fin_vat_payments
 ];
 
 /**


### PR DESCRIPTION
- Purchase orders "Open in Dolibarr" now links directly to erp.hexametals.com
  (list: /fourn/commande/list.php, individual PO card: /fourn/commande/card.php?id=)
- Remove invalid `deletedAt: null` filter from prisma.user query in
  permissions/request route (User model has no deletedAt field)
- Register v25_1_fin_bank_transactions_and_vat_sync.sql in startup-migrations
  so fin_bank_transactions table and VAT sync columns are created on boot
- Fix subcontractor search hallucination: replace cmdk fuzzy matching with
  strict case-insensitive substring filter on the Command component

https://claude.ai/code/session_01SJ6uMbCVFdB34zdrSpUNfm