### PR TITLE
fix: multi-issue patch — alias 403, building hyphen, VAT sync, dashboard cleanup

### DIFF
--- a/src/app/api/projects/[id]/buildings/route.ts
+++ b/src/app/api/projects/[id]/buildings/route.ts
@@ -194,11 +194,11 @@ export async function POST(
       );
     }
 
-    // Validate designation format (2-5 uppercase letters/numbers)
-    const designationPattern = /^[A-Z0-9]{2,5}$/;
+    // Validate designation format (2-8 uppercase letters/numbers/hyphens, no leading/trailing hyphen)
+    const designationPattern = /^[A-Z0-9][A-Z0-9-]{0,6}[A-Z0-9]$|^[A-Z0-9]{2}$/;
     if (!designationPattern.test(designation)) {
       return NextResponse.json(
-        { error: 'Designation must be 2-5 uppercase letters/numbers' },
+        { error: 'Designation must be 2-8 uppercase letters, numbers, or hyphens' },
         { status: 400 }
       );
     }

--- a/src/app/api/supply-chain/lcr/aliases/route.ts
+++ b/src/app/api/supply-chain/lcr/aliases/route.ts
@@ -3,6 +3,8 @@ import { withApiContext } from '@/lib/api-utils';
 import prisma from '@/lib/db';
 import { z } from 'zod';
 import { logger } from '@/lib/logger';
+import { resolveUserPermissions } from '@/lib/services/permission-resolution.service';
+import { hasPermission } from '@/lib/permissions';
 
 const log = logger.child({ module: 'API:LcrAliases' });
 
@@ -83,8 +85,9 @@ export const POST = withApiContext<any>(async (req, session) => {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  if (session.role !== 'Admin' && session.role !== 'CEO') {
-    return NextResponse.json({ error: 'Forbidden: admin only' }, { status: 403 });
+  const permissions = await resolveUserPermissions(session.userId);
+  if (!hasPermission(permissions, 'supply_chain.alias')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
 
   const body = await req.json();
@@ -174,8 +177,9 @@ export const DELETE = withApiContext<any>(async (req, session) => {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  if (session.role !== 'Admin' && session.role !== 'CEO') {
-    return NextResponse.json({ error: 'Forbidden: admin only' }, { status: 403 });
+  const permissions = await resolveUserPermissions(session.userId);
+  if (!hasPermission(permissions, 'supply_chain.alias')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
 
   const url = new URL(req.url);

--- a/src/app/financial/_page-client.tsx
+++ b/src/app/financial/_page-client.tsx
@@ -289,22 +289,8 @@ export default function FinancialDashboardPage() {
         </Link>
       </div>
 
-      {/* Row 3: VAT Summary & Account Mapping */}
+      {/* Row 3: VAT Summary */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-        <Link href="/financial/account-mapping">
-          <Card className="border-amber-200 dark:border-amber-900/50 hover:border-amber-400 transition-colors cursor-pointer h-full">
-            <CardContent className="pt-5 pb-4">
-              <div className="flex items-center justify-between mb-1">
-                <span className="text-xs text-muted-foreground">Account Mapping</span>
-                <ArrowUpDown className="h-3.5 w-3.5 text-amber-500" />
-              </div>
-              <div className="text-lg font-bold text-amber-600">Manage</div>
-              <div className="text-[10px] text-muted-foreground">Map Dolibarr codes to categories</div>
-              <div className="text-[10px] text-primary mt-1 flex items-center">Configure <ArrowRight className="h-3 w-3 ml-1" /></div>
-            </CardContent>
-          </Card>
-        </Link>
-
         <Link href="/financial/reports/vat">
           <Card className="border-orange-200 dark:border-orange-900/50 hover:border-orange-400 transition-colors cursor-pointer h-full">
             <CardContent className="pt-5 pb-4">
@@ -602,42 +588,6 @@ export default function FinancialDashboardPage() {
               <div>
                 <h3 className="font-semibold">Chart of Accounts</h3>
                 <p className="text-xs text-muted-foreground">Manage account codes and categories</p>
-              </div>
-              <ArrowRight className="h-4 w-4 ml-auto text-muted-foreground" />
-            </CardContent>
-          </Card>
-        </Link>
-        <Link href="/financial/account-mapping">
-          <Card className="hover:border-primary/50 transition-colors cursor-pointer">
-            <CardContent className="pt-6 flex items-center gap-3">
-              <ArrowUpDown className="h-5 w-5 text-muted-foreground" />
-              <div>
-                <h3 className="font-semibold">Account Mapping</h3>
-                <p className="text-xs text-muted-foreground">Map Dolibarr account codes to cost categories</p>
-              </div>
-              <ArrowRight className="h-4 w-4 ml-auto text-muted-foreground" />
-            </CardContent>
-          </Card>
-        </Link>
-        <Link href="/financial/product-categories">
-          <Card className="hover:border-primary/50 transition-colors cursor-pointer">
-            <CardContent className="pt-6 flex items-center gap-3">
-              <Package className="h-5 w-5 text-muted-foreground" />
-              <div>
-                <h3 className="font-semibold">Product Categories</h3>
-                <p className="text-xs text-muted-foreground">Define categories and map invoice products</p>
-              </div>
-              <ArrowRight className="h-4 w-4 ml-auto text-muted-foreground" />
-            </CardContent>
-          </Card>
-        </Link>
-        <Link href="/financial/supplier-classification">
-          <Card className="hover:border-primary/50 transition-colors cursor-pointer">
-            <CardContent className="pt-6 flex items-center gap-3">
-              <Building2 className="h-5 w-5 text-muted-foreground" />
-              <div>
-                <h3 className="font-semibold">Supplier Classification</h3>
-                <p className="text-xs text-muted-foreground">Assign default cost categories to suppliers</p>
               </div>
               <ArrowRight className="h-4 w-4 ml-auto text-muted-foreground" />
             </CardContent>

--- a/src/app/supply-chain/suppliers/[id]/_page-client.tsx
+++ b/src/app/supply-chain/suppliers/[id]/_page-client.tsx
@@ -1091,8 +1091,20 @@ function EvaluationDialog({ open, onOpenChange, supplierName, form, setForm, onS
 
 // ─── CoA & COGS Tab ───────────────────────────────────────────────────────────
 
+const COST_CATEGORIES = [
+  'Raw Materials (Steel)',
+  'Subcontracting',
+  'Direct Labor',
+  'Manufacturing Overhead',
+  'Services',
+  'Transport & Logistics',
+  'Equipment & Machinery',
+  'General & Administrative',
+  'Other / Unclassified',
+];
+
 function CoaTab({ supplierId, initial, onSaved }: { supplierId: number; initial: SupplierOverview; onSaved: () => void }) {
-  const [accounts, setAccounts] = useState<{account_code: string; account_name: string}[]>([]);
+  const [accounts, setAccounts] = useState<{account_code: string; account_name: string; account_category: string | null}[]>([]);
   const [ap, setAp] = useState(initial.coa_ap_account?.account_code ?? '');
   const [cogs, setCogs] = useState(initial.coa_cogs_account?.account_code ?? '');
   const [category, setCategory] = useState(initial.cost_category ?? '');
@@ -1103,8 +1115,16 @@ function CoaTab({ supplierId, initial, onSaved }: { supplierId: number; initial:
   useEffect(() => {
     fetch('/api/financial/chart-of-accounts')
       .then(r => r.json())
-      .then(j => setAccounts((j.accounts ?? j) as {account_code: string; account_name: string}[]));
+      .then(j => setAccounts((j.accounts ?? j) as {account_code: string; account_name: string; account_category: string | null}[]));
   }, []);
+
+  function handleCogsChange(code: string) {
+    setCogs(code);
+    if (code) {
+      const acct = accounts.find(a => a.account_code === code);
+      if (acct?.account_category) setCategory(acct.account_category);
+    }
+  }
 
   async function save() {
     setSaving(true);
@@ -1136,14 +1156,30 @@ function CoaTab({ supplierId, initial, onSaved }: { supplierId: number; initial:
     </div>
   );
 
+  const allCategories = [...new Set([
+    ...COST_CATEGORIES,
+    ...(category && !COST_CATEGORIES.includes(category) ? [category] : []),
+  ])];
+
   return (
     <div className="max-w-xl space-y-5">
       <h3 className="font-semibold">Chart of Accounts Mapping</h3>
       <AccountSelect value={ap} onChange={setAp} label="AP Account (Accounts Payable)" placeholder="Select AP account…" />
-      <AccountSelect value={cogs} onChange={setCogs} label="COGS / Expense Account" placeholder="Select COGS account…" />
+      <AccountSelect value={cogs} onChange={handleCogsChange} label="COGS / Expense Account" placeholder="Select COGS account…" />
       <div className="space-y-1.5">
         <Label>Cost Category</Label>
-        <Input value={category} onChange={e => setCategory(e.target.value)} placeholder="e.g. Raw Materials, Services, Subcontracting" />
+        <Select value={category || '__none__'} onValueChange={v => setCategory(v === '__none__' ? '' : v)}>
+          <SelectTrigger>
+            <SelectValue placeholder="Select or inherit from COGS account…" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__none__">— Not set —</SelectItem>
+            {allCategories.map(c => (
+              <SelectItem key={c} value={c}>{c}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">Auto-populated from COGS account when selected</p>
       </div>
       <div className="space-y-1.5">
         <Label>Notes</Label>

--- a/src/components/building-dialog.tsx
+++ b/src/components/building-dialog.tsx
@@ -142,15 +142,15 @@ export function BuildingDialog({ projectId, building, open, onOpenChange, onSave
               <Input
                 id="designation"
                 name="designation"
-                placeholder="e.g., BLD1, WH, MAIN1"
+                placeholder="e.g., BLD1, WH, MAIN-1, Z8T"
                 defaultValue={building?.designation || ''}
                 required
                 disabled={loading || !!building}
-                maxLength={5}
+                maxLength={8}
                 className="uppercase"
               />
               <p className="text-xs text-muted-foreground">
-                2-5 uppercase letters/numbers (e.g., BLD1, WH, MAIN1)
+                2-8 uppercase letters/numbers/hyphens (e.g., BLD1, WH, MAIN-1)
               </p>
             </div>
 

--- a/src/components/buildings-client.tsx
+++ b/src/components/buildings-client.tsx
@@ -610,14 +610,14 @@ export function BuildingsClient({ initialBuildings }: BuildingsClientProps) {
                 <Input
                   id="designation"
                   name="designation"
-                  placeholder="e.g., BLD1, WH, MAIN"
+                  placeholder="e.g., BLD1, WH, MAIN-1"
                   required
                   disabled={isCreating}
-                  maxLength={5}
+                  maxLength={8}
                   className="uppercase"
                 />
                 <p className="text-xs text-muted-foreground">
-                  2-5 uppercase letters/numbers (e.g., BLD1, WH, MAIN1)
+                  2-8 uppercase letters/numbers/hyphens (e.g., BLD1, WH, MAIN-1)
                 </p>
               </div>
 

--- a/src/lib/dolibarr/dolibarr-client.ts
+++ b/src/lib/dolibarr/dolibarr-client.ts
@@ -383,9 +383,11 @@ export interface DolibarrBankLine {
 
 export interface DolibarrVatPayment {
   id: number | string;
-  datep: number | string | null;
+  datep: number | string | null;   // payment date (paymentsvatreturns)
+  datev: number | string | null;   // VAT period date (tva declarations)
   amount: number | string;
   ref_num: string | null;
+  label: string | null;
   note: string | null;
   fk_typepayment: number | string | null;
   fk_account: number | string | null;
@@ -986,21 +988,29 @@ export class DolibarrClient {
   }
 
   /**
-   * Fetch VAT payment records from Dolibarr (compta/tva — paymentsvatreturns)
+   * Fetch VAT records from Dolibarr (compta/tva).
+   * Tries TVA declarations first (`tva` endpoint), then falls back to payment records (`paymentsvatreturns`).
+   * TVA declarations (llx_tva) use `datev`; payment records (llx_payment_vat) use `datep`.
    */
   async getVatPayments(params?: DolibarrPaginationParams): Promise<DolibarrVatPayment[]> {
-    try {
-      const result = await this.request<DolibarrVatPayment[]>('paymentsvatreturns', {
-        limit: params?.limit ?? 500,
-        page: params?.page ?? 0,
-        sortfield: params?.sortfield ?? 't.rowid',
-        sortorder: params?.sortorder ?? 'ASC',
-      });
-      return Array.isArray(result) ? result : [];
-    } catch (error: any) {
-      if (error.message?.includes('404')) return [];
-      throw error;
+    const commonParams = {
+      limit: params?.limit ?? 500,
+      page: params?.page ?? 0,
+      sortfield: params?.sortfield ?? 't.rowid',
+      sortorder: params?.sortorder ?? 'ASC',
+    };
+
+    // Try TVA declarations endpoint first (matches compta/tva/list.php)
+    for (const endpoint of ['tva', 'paymentsvatreturns']) {
+      try {
+        const result = await this.request<DolibarrVatPayment[]>(endpoint, commonParams);
+        if (Array.isArray(result) && result.length > 0) return result;
+        if (Array.isArray(result) && result.length === 0 && endpoint === 'paymentsvatreturns') return [];
+      } catch (error: any) {
+        if (!error.message?.includes('404') && !error.message?.includes('403')) throw error;
+      }
     }
+    return [];
   }
 
   /**

--- a/src/lib/dolibarr/financial-sync-service.ts
+++ b/src/lib/dolibarr/financial-sync-service.ts
@@ -21,6 +21,9 @@ import {
   createDolibarrClient,
 } from './dolibarr-client';
 import { systemEventService } from '@/services/system-events.service';
+import { logger } from '@/lib/logger';
+
+const log = logger.child({ module: 'FinancialSync' });
 
 // ============================================
 // TYPES
@@ -1060,14 +1063,19 @@ export class FinancialSyncService {
           const dolibarrId = pi(vp.id);
           if (!dolibarrId) continue;
 
-          const paymentDate = formatDate(parseDolibarrDate(vp.datep));
+          // Support both datep (payment records) and datev (TVA declaration records)
+          const rawDate = vp.datep || vp.datev;
+          const paymentDate = formatDate(parseDolibarrDate(rawDate as number | string | null));
           if (!paymentDate) continue;
+
+          const ref = (vp.ref_num || vp.label || null) as string | null;
+          const note = (vp.note || null) as string | null;
 
           const hashFields = {
             amount: vp.amount,
-            datep: vp.datep,
-            ref_num: vp.ref_num,
-            note: vp.note,
+            date: rawDate,
+            ref,
+            note,
           };
           const newHash = computeHash(hashFields);
 
@@ -1080,7 +1088,7 @@ export class FinancialSyncService {
             await prisma.$executeRawUnsafe(
               `UPDATE fin_vat_payments SET amount=?, payment_date=?, reference=?, notes=?, sync_hash=?, source='dolibarr', updated_at=NOW()
                WHERE dolibarr_id=?`,
-              pf(vp.amount), paymentDate, vp.ref_num || null, vp.note || null, newHash, dolibarrId
+              pf(vp.amount), paymentDate, ref, note, newHash, dolibarrId
             );
             updated++;
           } else {
@@ -1095,7 +1103,7 @@ export class FinancialSyncService {
               `INSERT INTO fin_vat_payments (dolibarr_id, period_label, period_start, period_end, payment_date, amount, reference, notes, sync_hash, source)
                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'dolibarr')`,
               dolibarrId, periodLabel, periodStart, periodEnd, paymentDate,
-              pf(vp.amount), vp.ref_num || null, vp.note || null, newHash
+              pf(vp.amount), ref, note, newHash
             );
             created++;
           }
@@ -1113,7 +1121,7 @@ export class FinancialSyncService {
       await this.logSync(result, triggeredBy);
       return result;
     } catch (error: any) {
-      console.error('[FinSync] VAT payments sync failed:', error.message);
+      log.error({ error: error.message }, 'VAT payments sync failed');
       const result: FinSyncResult = {
         entityType: 'vat_payments', status: 'error',
         created, updated, unchanged, total: 0,
@@ -1193,7 +1201,7 @@ export class FinancialSyncService {
         }
       }
 
-      console.log(`[FinSync] Bank transactions complete: ${total} total, ${created} created, ${updated} updated`);
+      log.info({ total, created, updated }, 'Bank transactions sync complete');
       const result: FinSyncResult = {
         entityType: 'bank_transactions', status: 'success',
         created, updated, unchanged, total,
@@ -1202,7 +1210,7 @@ export class FinancialSyncService {
       await this.logSync(result, triggeredBy);
       return result;
     } catch (error: any) {
-      console.error('[FinSync] Bank transactions sync failed:', error.message);
+      log.error({ error: error.message }, 'Bank transactions sync failed');
       const result: FinSyncResult = {
         entityType: 'bank_transactions', status: 'error',
         created, updated, unchanged, total: 0,


### PR DESCRIPTION
- LCR alias route: replace hardcoded Admin/CEO role check with supply_chain.alias
  permission check so supply chain managers can manage aliases as intended
- Building designation: allow hyphens, expand to 2-8 chars (was 2-5, no hyphens)
  in both API validation and all frontend forms
- Financial dashboard: remove dead links to /financial/account-mapping,
  /financial/product-categories, /financial/supplier-classification (pages removed,
  caused Next.js RSC 404 prefetch errors)
- Supplier CoA tab: change cost_category from free-text Input to Select dropdown
  with predefined categories; auto-populates from selected COGS account's
  account_category when a COGS account is chosen
- VAT sync: try Dolibarr `tva` endpoint first (matches compta/tva/list.php) before
  falling back to `paymentsvatreturns`; support datev as fallback when datep is null;
  add logger import; fix console.error calls in VAT + bank transaction sync handlers