### PR TITLE
Fix migration statement separation and add meetings redirect

### DIFF
--- a/prisma/manual_migrations/v25_1_fin_bank_transactions_and_vat_sync.sql
+++ b/prisma/manual_migrations/v25_1_fin_bank_transactions_and_vat_sync.sql
@@ -14,7 +14,9 @@ SET @col1 = (
     'ALTER TABLE fin_vat_payments ADD COLUMN dolibarr_id INT NULL AFTER id'
   )
 );
-PREPARE s1 FROM @col1; EXECUTE s1; DEALLOCATE PREPARE s1;
+PREPARE s1 FROM @col1;
+EXECUTE s1;
+DEALLOCATE PREPARE s1;
 
 SET @col2 = (
   SELECT IF(
@@ -28,7 +30,9 @@ SET @col2 = (
     "ALTER TABLE fin_vat_payments ADD COLUMN source ENUM('manual','dolibarr') NOT NULL DEFAULT 'manual' AFTER notes"
   )
 );
-PREPARE s2 FROM @col2; EXECUTE s2; DEALLOCATE PREPARE s2;
+PREPARE s2 FROM @col2;
+EXECUTE s2;
+DEALLOCATE PREPARE s2;
 
 SET @col3 = (
   SELECT IF(
@@ -42,7 +46,9 @@ SET @col3 = (
     'ALTER TABLE fin_vat_payments ADD COLUMN sync_hash VARCHAR(32) NULL'
   )
 );
-PREPARE s3 FROM @col3; EXECUTE s3; DEALLOCATE PREPARE s3;
+PREPARE s3 FROM @col3;
+EXECUTE s3;
+DEALLOCATE PREPARE s3;
 
 SET @idx1 = (
   SELECT IF(
@@ -56,7 +62,9 @@ SET @idx1 = (
     'ALTER TABLE fin_vat_payments ADD UNIQUE INDEX idx_dolibarr_id (dolibarr_id)'
   )
 );
-PREPARE si1 FROM @idx1; EXECUTE si1; DEALLOCATE PREPARE si1;
+PREPARE si1 FROM @idx1;
+EXECUTE si1;
+DEALLOCATE PREPARE si1;
 
 -- 2. Create fin_bank_transactions table
 SET @sql2 = (
@@ -86,4 +94,6 @@ SET @sql2 = (
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci'
   )
 );
-PREPARE s4 FROM @sql2; EXECUTE s4; DEALLOCATE PREPARE s4;
+PREPARE s4 FROM @sql2;
+EXECUTE s4;
+DEALLOCATE PREPARE s4;

--- a/prisma/manual_migrations/v26_0_project_validation.sql
+++ b/prisma/manual_migrations/v26_0_project_validation.sql
@@ -13,7 +13,9 @@ SET @col1 = (
      WHERE table_schema = DATABASE() AND LOWER(table_name) = 'project' LIMIT 1)
   )
 );
-PREPARE s1 FROM @col1; EXECUTE s1; DEALLOCATE PREPARE s1;
+PREPARE s1 FROM @col1;
+EXECUTE s1;
+DEALLOCATE PREPARE s1;
 
 -- Add FK index for operationsManagerId
 SET @idx1 = (
@@ -30,7 +32,9 @@ SET @idx1 = (
      WHERE table_schema = DATABASE() AND LOWER(table_name) = 'project' LIMIT 1)
   )
 );
-PREPARE si1 FROM @idx1; EXECUTE si1; DEALLOCATE PREPARE si1;
+PREPARE si1 FROM @idx1;
+EXECUTE si1;
+DEALLOCATE PREPARE si1;
 
 -- Create ProjectValidation table (only if it doesn't exist)
 SET @tbl_exists = (
@@ -66,7 +70,9 @@ SET @create_tbl = IF(
   ),
   'SELECT 1'
 );
-PREPARE stbl FROM @create_tbl; EXECUTE stbl; DEALLOCATE PREPARE stbl;
+PREPARE stbl FROM @create_tbl;
+EXECUTE stbl;
+DEALLOCATE PREPARE stbl;
 
 -- Add PROJECT_VALIDATION_REQUIRED to Notification.type enum (case-insensitive table lookup)
 SET @notif_table = (
@@ -93,7 +99,9 @@ SET @enum_alter = IF(
   ),
   'SELECT 1'
 );
-PREPARE senum FROM @enum_alter; EXECUTE senum; DEALLOCATE PREPARE senum;
+PREPARE senum FROM @enum_alter;
+EXECUTE senum;
+DEALLOCATE PREPARE senum;
 
 -- Add PROJECT_VALIDATION_REQUIRED to NotificationPreference.notificationType enum
 SET @pref_table = (
@@ -120,4 +128,6 @@ SET @enum_alter2 = IF(
   ),
   'SELECT 1'
 );
-PREPARE senum2 FROM @enum_alter2; EXECUTE senum2; DEALLOCATE PREPARE senum2;
+PREPARE senum2 FROM @enum_alter2;
+EXECUTE senum2;
+DEALLOCATE PREPARE senum2;

--- a/prisma/manual_migrations/v27_0_validation_step_notes.sql
+++ b/prisma/manual_migrations/v27_0_validation_step_notes.sql
@@ -1,4 +1,7 @@
 -- Add step-level notes and overall status to ProjectValidation
+-- Each PREPARE / EXECUTE / DEALLOCATE is on its own line so the startup
+-- migration runner sends them as three separate single-statement queries
+-- (multipleStatements: false only executes the first statement in a string).
 
 -- salesStepNotes
 SET @col_ssn = (
@@ -15,7 +18,9 @@ SET @col_ssn = (
      WHERE table_schema = DATABASE() AND LOWER(table_name) = 'projectvalidation' LIMIT 1)
   )
 );
-PREPARE s_ssn FROM @col_ssn; EXECUTE s_ssn; DEALLOCATE PREPARE s_ssn;
+PREPARE s_ssn FROM @col_ssn;
+EXECUTE s_ssn;
+DEALLOCATE PREPARE s_ssn;
 
 -- salesStatus
 SET @col_ss = (
@@ -32,7 +37,9 @@ SET @col_ss = (
      WHERE table_schema = DATABASE() AND LOWER(table_name) = 'projectvalidation' LIMIT 1)
   )
 );
-PREPARE s_ss FROM @col_ss; EXECUTE s_ss; DEALLOCATE PREPARE s_ss;
+PREPARE s_ss FROM @col_ss;
+EXECUTE s_ss;
+DEALLOCATE PREPARE s_ss;
 
 -- projectsStepNotes
 SET @col_psn = (
@@ -49,7 +56,9 @@ SET @col_psn = (
      WHERE table_schema = DATABASE() AND LOWER(table_name) = 'projectvalidation' LIMIT 1)
   )
 );
-PREPARE s_psn FROM @col_psn; EXECUTE s_psn; DEALLOCATE PREPARE s_psn;
+PREPARE s_psn FROM @col_psn;
+EXECUTE s_psn;
+DEALLOCATE PREPARE s_psn;
 
 -- projectsStatus
 SET @col_ps = (
@@ -66,7 +75,9 @@ SET @col_ps = (
      WHERE table_schema = DATABASE() AND LOWER(table_name) = 'projectvalidation' LIMIT 1)
   )
 );
-PREPARE s_ps FROM @col_ps; EXECUTE s_ps; DEALLOCATE PREPARE s_ps;
+PREPARE s_ps FROM @col_ps;
+EXECUTE s_ps;
+DEALLOCATE PREPARE s_ps;
 
 -- operationsStepNotes
 SET @col_osn = (
@@ -83,7 +94,9 @@ SET @col_osn = (
      WHERE table_schema = DATABASE() AND LOWER(table_name) = 'projectvalidation' LIMIT 1)
   )
 );
-PREPARE s_osn FROM @col_osn; EXECUTE s_osn; DEALLOCATE PREPARE s_osn;
+PREPARE s_osn FROM @col_osn;
+EXECUTE s_osn;
+DEALLOCATE PREPARE s_osn;
 
 -- operationsStatus
 SET @col_os = (
@@ -100,4 +113,6 @@ SET @col_os = (
      WHERE table_schema = DATABASE() AND LOWER(table_name) = 'projectvalidation' LIMIT 1)
   )
 );
-PREPARE s_os FROM @col_os; EXECUTE s_os; DEALLOCATE PREPARE s_os;
+PREPARE s_os FROM @col_os;
+EXECUTE s_os;
+DEALLOCATE PREPARE s_os;

--- a/src/app/meetings/_page-client.tsx
+++ b/src/app/meetings/_page-client.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
 import {
   Calendar,
   Plus,
@@ -245,10 +246,19 @@ export default function MeetingsPage() {
   const [categoryFilter, setCategoryFilter] = useState('');
   const [statusFilter, setStatusFilter] = useState('');
 
-  const [showForm, setShowForm] = useState(false);
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const [showForm, setShowForm] = useState(searchParams.get('new') === '1');
   const [selectedMeeting, setSelectedMeeting] = useState<Meeting | null>(null);
   const [editingMeeting, setEditingMeeting] = useState<Meeting | null>(null);
   const [viewMode, setViewMode] = useState<'grid' | 'table'>('grid');
+
+  useEffect(() => {
+    if (searchParams.get('new') === '1') {
+      setShowForm(true);
+      router.replace('/meetings');
+    }
+  }, [searchParams, router]);
 
   const fetchMeetings = useCallback(async () => {
     setLoading(true);

--- a/src/app/meetings/new/page.tsx
+++ b/src/app/meetings/new/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function NewMeetingPage() {
+  redirect('/meetings?new=1');
+}


### PR DESCRIPTION
## Summary
This PR addresses two issues:
1. **Migration statement separation**: Splits PREPARE/EXECUTE/DEALLOCATE statements onto separate lines in all manual migrations to ensure the startup migration runner executes them as three distinct single-statement queries (required because `multipleStatements: false`)
2. **Meetings page routing**: Adds a redirect route to support the `/meetings?new=1` query parameter for opening the new meeting form

## Key Changes

### Database Migrations
- **v27_0_validation_step_notes.sql**: Separated all 6 statement groups (salesStepNotes, salesStatus, projectsStepNotes, projectsStatus, operationsStepNotes, operationsStatus) onto individual lines
- **v25_1_fin_bank_transactions_and_vat_sync.sql**: Separated 4 statement groups (s1, s2, s3, si1, s4) onto individual lines
- **v26_0_project_validation.sql**: Separated 5 statement groups (s1, si1, stbl, senum, senum2) onto individual lines
- Added explanatory comment in v27_0 migration documenting why this formatting is necessary

### Frontend Routing
- **src/app/meetings/new/page.tsx** (new): Simple redirect page that forwards `/meetings/new` to `/meetings?new=1`
- **src/app/meetings/_page-client.tsx**: 
  - Added `useSearchParams` and `useRouter` imports
  - Initialize `showForm` state from `searchParams.get('new') === '1'`
  - Added `useEffect` hook to detect the query parameter and clean up the URL (replace with `/meetings` to remove the query string)

## Implementation Details
- The redirect pattern allows users to navigate to `/meetings/new` while the actual form state is managed via query parameter, keeping the URL clean after the form opens
- Migration statement separation ensures compatibility with the startup migration runner's single-statement execution mode

https://claude.ai/code/session_01WoKaRtNCp1vMFHgjkLszax