### PR TITLE
Add archDrawingsReceived flag to Building table

### DIFF
--- a/src/lib/startup-migrations.ts
+++ b/src/lib/startup-migrations.ts
@@ -228,6 +228,9 @@ const STARTUP_MIGRATIONS = [
 
   // ── v27.0.0 — Verification step notes & per-party status ────────────────
   'v27_0_validation_step_notes.sql',  // stepNotes + status columns on ProjectValidation
+
+  // ── Project wizard: arch drawings received flag on Building ───────────────
+  'add_building_arch_drawings.sql',   // archDrawingsReceived BOOLEAN on Building
 ];
 
 /**


### PR DESCRIPTION
## Summary
Adds a new database migration to support the project wizard feature by introducing an `archDrawingsReceived` boolean column to the `Building` table.

## Changes
- Added `add_building_arch_drawings.sql` migration to the startup migrations queue
- This migration adds the `archDrawingsReceived` BOOLEAN column to the Building table, enabling tracking of whether architectural drawings have been received as part of the project wizard workflow

## Implementation Details
- Migration follows the standard pattern in `src/lib/startup-migrations.ts`
- Registered in the v27.0.0 migration batch
- Will execute automatically on server startup via the existing migration system

https://claude.ai/code/session_01Pa9SeeF2Lnwuw6ZKED9j16