### PR TITLE
Fix table names in MIR status backfill migration

### DIFF
--- a/prisma/manual_migrations/v28_0_mir_status_backfill.sql
+++ b/prisma/manual_migrations/v28_0_mir_status_backfill.sql
@@ -1,7 +1,7 @@
 -- Backfill MaterialInspectionReceipt status based on item inspection results
 -- Logic mirrors computeReceiptStatus() in items/route.ts
 
-UPDATE MaterialInspectionReceipt r
+UPDATE material_inspection_receipts r
 SET status = (
   SELECT
     CASE
@@ -18,7 +18,7 @@ SET status = (
         THEN 'Partially Received'
       ELSE 'In Progress'
     END
-  FROM MaterialInspectionReceiptItem i
+  FROM material_inspection_receipt_items i
   WHERE i.receiptId = r.id
 )
 WHERE r.deletedAt IS NULL OR r.deletedAt IS NOT NULL;


### PR DESCRIPTION
## Summary
Corrects table name references in the MaterialInspectionReceipt status backfill migration to use snake_case naming convention consistent with the database schema.

## Changes
- Updated `MaterialInspectionReceipt` to `material_inspection_receipts` in UPDATE clause
- Updated `MaterialInspectionReceiptItem` to `material_inspection_receipt_items` in FROM clause

## Details
The migration was using PascalCase table names which don't match the actual MySQL schema. This fix ensures the backfill query executes correctly against the properly-named tables. The logic itself (mirroring `computeReceiptStatus()` from items/route.ts) remains unchanged.

https://claude.ai/code/session_01MrED7kUV1ahSNNEHMn5Vni