### PR TITLE
fix: use snake_case column names in MIR status backfill migration

### DIFF
--- a/prisma/manual_migrations/v28_0_mir_status_backfill.sql
+++ b/prisma/manual_migrations/v28_0_mir_status_backfill.sql
@@ -6,19 +6,19 @@ SET status = (
   SELECT
     CASE
       WHEN COUNT(*) = 0 THEN 'In Progress'
-      WHEN SUM(CASE WHEN i.inspectionResult = 'Accepted' THEN 1 ELSE 0 END) = COUNT(*)
-        AND SUM(CASE WHEN i.receivedQty >= i.orderedQty THEN 1 ELSE 0 END) = COUNT(*)
+      WHEN SUM(CASE WHEN i.inspection_result = 'Accepted' THEN 1 ELSE 0 END) = COUNT(*)
+        AND SUM(CASE WHEN i.received_qty >= i.ordered_qty THEN 1 ELSE 0 END) = COUNT(*)
         THEN 'Received and Accepted'
-      WHEN SUM(CASE WHEN i.inspectionResult = 'Rejected' THEN 1 ELSE 0 END) = COUNT(*)
-        AND SUM(CASE WHEN i.receivedQty > 0 THEN 1 ELSE 0 END) > 0
+      WHEN SUM(CASE WHEN i.inspection_result = 'Rejected' THEN 1 ELSE 0 END) = COUNT(*)
+        AND SUM(CASE WHEN i.received_qty > 0 THEN 1 ELSE 0 END) > 0
         THEN 'Rejected'
-      WHEN SUM(CASE WHEN i.inspectionResult != 'Pending' THEN 1 ELSE 0 END) > 0
+      WHEN SUM(CASE WHEN i.inspection_result != 'Pending' THEN 1 ELSE 0 END) > 0
         THEN 'Partially Accepted'
-      WHEN SUM(CASE WHEN i.receivedQty > 0 THEN 1 ELSE 0 END) > 0
+      WHEN SUM(CASE WHEN i.received_qty > 0 THEN 1 ELSE 0 END) > 0
         THEN 'Partially Received'
       ELSE 'In Progress'
     END
   FROM material_inspection_receipt_items i
-  WHERE i.receiptId = r.id
+  WHERE i.receipt_id = r.id
 )
-WHERE r.deletedAt IS NULL OR r.deletedAt IS NOT NULL;
+;


### PR DESCRIPTION
Prisma @map annotations mean all camelCase field names resolve to snake_case in MySQL: inspectionResult→inspection_result, receivedQty→received_qty, orderedQty→ordered_qty, receiptId→receipt_id. Also removed the redundant WHERE clause that matched all rows unconditionally.