### PR TITLE
feat(qc): MIR workflow, PDF fix, and approval signatures

### DIFF
--- a/prisma/manual_migrations/v29_0_mir_workflow.sql
+++ b/prisma/manual_migrations/v29_0_mir_workflow.sql
@@ -1,0 +1,177 @@
+-- v29.0 MIR workflow fields
+-- Adds workflow status tracking columns to material_inspection_receipts:
+-- workflow_status, submitted_at/by, reviewed_at/by/notes, approved_at/by/notes
+-- Each PREPARE / EXECUTE / DEALLOCATE is on its own line so the startup
+-- migration runner sends them as three separate single-statement queries
+-- (multipleStatements: false only executes the first statement in a string).
+
+-- workflow_status
+SET @col_ws = (
+  SELECT IF(
+    EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = DATABASE()
+        AND LOWER(table_name) = 'material_inspection_receipts'
+        AND column_name = 'workflow_status'
+    ),
+    'SELECT 1',
+    (SELECT CONCAT('ALTER TABLE `', table_name, '` ADD COLUMN `workflow_status` VARCHAR(50) NOT NULL DEFAULT ''Draft'' AFTER `status`')
+     FROM information_schema.tables
+     WHERE table_schema = DATABASE() AND LOWER(table_name) = 'material_inspection_receipts' LIMIT 1)
+  )
+);
+PREPARE s_ws FROM @col_ws;
+EXECUTE s_ws;
+DEALLOCATE PREPARE s_ws;
+
+-- submitted_at
+SET @col_sat = (
+  SELECT IF(
+    EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = DATABASE()
+        AND LOWER(table_name) = 'material_inspection_receipts'
+        AND column_name = 'submitted_at'
+    ),
+    'SELECT 1',
+    (SELECT CONCAT('ALTER TABLE `', table_name, '` ADD COLUMN `submitted_at` DATETIME NULL AFTER `workflow_status`')
+     FROM information_schema.tables
+     WHERE table_schema = DATABASE() AND LOWER(table_name) = 'material_inspection_receipts' LIMIT 1)
+  )
+);
+PREPARE s_sat FROM @col_sat;
+EXECUTE s_sat;
+DEALLOCATE PREPARE s_sat;
+
+-- submitted_by_id
+SET @col_sbi = (
+  SELECT IF(
+    EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = DATABASE()
+        AND LOWER(table_name) = 'material_inspection_receipts'
+        AND column_name = 'submitted_by_id'
+    ),
+    'SELECT 1',
+    (SELECT CONCAT('ALTER TABLE `', table_name, '` ADD COLUMN `submitted_by_id` CHAR(36) NULL AFTER `submitted_at`')
+     FROM information_schema.tables
+     WHERE table_schema = DATABASE() AND LOWER(table_name) = 'material_inspection_receipts' LIMIT 1)
+  )
+);
+PREPARE s_sbi FROM @col_sbi;
+EXECUTE s_sbi;
+DEALLOCATE PREPARE s_sbi;
+
+-- reviewed_at
+SET @col_rat = (
+  SELECT IF(
+    EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = DATABASE()
+        AND LOWER(table_name) = 'material_inspection_receipts'
+        AND column_name = 'reviewed_at'
+    ),
+    'SELECT 1',
+    (SELECT CONCAT('ALTER TABLE `', table_name, '` ADD COLUMN `reviewed_at` DATETIME NULL AFTER `submitted_by_id`')
+     FROM information_schema.tables
+     WHERE table_schema = DATABASE() AND LOWER(table_name) = 'material_inspection_receipts' LIMIT 1)
+  )
+);
+PREPARE s_rat FROM @col_rat;
+EXECUTE s_rat;
+DEALLOCATE PREPARE s_rat;
+
+-- reviewed_by_id
+SET @col_rbi = (
+  SELECT IF(
+    EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = DATABASE()
+        AND LOWER(table_name) = 'material_inspection_receipts'
+        AND column_name = 'reviewed_by_id'
+    ),
+    'SELECT 1',
+    (SELECT CONCAT('ALTER TABLE `', table_name, '` ADD COLUMN `reviewed_by_id` CHAR(36) NULL AFTER `reviewed_at`')
+     FROM information_schema.tables
+     WHERE table_schema = DATABASE() AND LOWER(table_name) = 'material_inspection_receipts' LIMIT 1)
+  )
+);
+PREPARE s_rbi FROM @col_rbi;
+EXECUTE s_rbi;
+DEALLOCATE PREPARE s_rbi;
+
+-- review_notes
+SET @col_rn = (
+  SELECT IF(
+    EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = DATABASE()
+        AND LOWER(table_name) = 'material_inspection_receipts'
+        AND column_name = 'review_notes'
+    ),
+    'SELECT 1',
+    (SELECT CONCAT('ALTER TABLE `', table_name, '` ADD COLUMN `review_notes` TEXT NULL AFTER `reviewed_by_id`')
+     FROM information_schema.tables
+     WHERE table_schema = DATABASE() AND LOWER(table_name) = 'material_inspection_receipts' LIMIT 1)
+  )
+);
+PREPARE s_rn FROM @col_rn;
+EXECUTE s_rn;
+DEALLOCATE PREPARE s_rn;
+
+-- approved_at
+SET @col_aat = (
+  SELECT IF(
+    EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = DATABASE()
+        AND LOWER(table_name) = 'material_inspection_receipts'
+        AND column_name = 'approved_at'
+    ),
+    'SELECT 1',
+    (SELECT CONCAT('ALTER TABLE `', table_name, '` ADD COLUMN `approved_at` DATETIME NULL AFTER `review_notes`')
+     FROM information_schema.tables
+     WHERE table_schema = DATABASE() AND LOWER(table_name) = 'material_inspection_receipts' LIMIT 1)
+  )
+);
+PREPARE s_aat FROM @col_aat;
+EXECUTE s_aat;
+DEALLOCATE PREPARE s_aat;
+
+-- approved_by_id
+SET @col_abi = (
+  SELECT IF(
+    EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = DATABASE()
+        AND LOWER(table_name) = 'material_inspection_receipts'
+        AND column_name = 'approved_by_id'
+    ),
+    'SELECT 1',
+    (SELECT CONCAT('ALTER TABLE `', table_name, '` ADD COLUMN `approved_by_id` CHAR(36) NULL AFTER `approved_at`')
+     FROM information_schema.tables
+     WHERE table_schema = DATABASE() AND LOWER(table_name) = 'material_inspection_receipts' LIMIT 1)
+  )
+);
+PREPARE s_abi FROM @col_abi;
+EXECUTE s_abi;
+DEALLOCATE PREPARE s_abi;
+
+-- approval_notes
+SET @col_an = (
+  SELECT IF(
+    EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = DATABASE()
+        AND LOWER(table_name) = 'material_inspection_receipts'
+        AND column_name = 'approval_notes'
+    ),
+    'SELECT 1',
+    (SELECT CONCAT('ALTER TABLE `', table_name, '` ADD COLUMN `approval_notes` TEXT NULL AFTER `approved_by_id`')
+     FROM information_schema.tables
+     WHERE table_schema = DATABASE() AND LOWER(table_name) = 'material_inspection_receipts' LIMIT 1)
+  )
+);
+PREPARE s_an FROM @col_an;
+EXECUTE s_an;
+DEALLOCATE PREPARE s_an;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -141,8 +141,11 @@ model User {
   assignedNCRs               NCRReport[]                           @relation("NCRAssignedTo")
   closedNCRs                 NCRReport[]                           @relation("NCRClosedBy")
   materialInspections        MaterialInspection[]                  @relation("MaterialInspector")
-  materialInspectionReceipts MaterialInspectionReceipt[]           @relation("MIRInspector")
-  mirAttachments             MaterialInspectionReceiptAttachment[] @relation("MIRAttachmentUploader")
+  materialInspectionReceipts          MaterialInspectionReceipt[]           @relation("MIRInspector")
+  mirSubmittedReceipts                MaterialInspectionReceipt[]           @relation("MIRSubmittedBy")
+  mirReviewedReceipts                 MaterialInspectionReceipt[]           @relation("MIRReviewedBy")
+  mirApprovedReceipts                 MaterialInspectionReceipt[]           @relation("MIRApprovedBy")
+  mirAttachments                      MaterialInspectionReceiptAttachment[] @relation("MIRAttachmentUploader")
   weldingInspections         WeldingInspection[]                   @relation("WeldingInspector")
   dimensionalInspections     DimensionalInspection[]               @relation("DimensionalInspector")
   ndtInspections             NDTInspection[]                       @relation("NDTInspector")
@@ -1630,14 +1633,28 @@ model MaterialInspectionReceipt {
   // Overall status
   status String @default("In Progress")
 
+  // Workflow
+  workflowStatus String    @default("Draft") @map("workflow_status")
+  submittedAt    DateTime? @map("submitted_at")
+  submittedById  String?   @map("submitted_by_id") @db.Char(36)
+  reviewedAt     DateTime? @map("reviewed_at")
+  reviewedById   String?   @map("reviewed_by_id") @db.Char(36)
+  reviewNotes    String?   @map("review_notes") @db.Text
+  approvedAt     DateTime? @map("approved_at")
+  approvedById   String?   @map("approved_by_id") @db.Char(36)
+  approvalNotes  String?   @map("approval_notes") @db.Text
+
   // Notes
   remarks String? @db.Text
 
   // Relations
-  project     Project?                              @relation("MIRProject", fields: [projectId], references: [id], onDelete: SetNull)
-  inspector   User                                  @relation("MIRInspector", fields: [inspectorId], references: [id])
-  items       MaterialInspectionReceiptItem[]
-  attachments MaterialInspectionReceiptAttachment[]
+  project      Project?                              @relation("MIRProject", fields: [projectId], references: [id], onDelete: SetNull)
+  inspector    User                                  @relation("MIRInspector", fields: [inspectorId], references: [id])
+  submittedBy  User?                                 @relation("MIRSubmittedBy", fields: [submittedById], references: [id])
+  reviewedBy   User?                                 @relation("MIRReviewedBy", fields: [reviewedById], references: [id])
+  approvedBy   User?                                 @relation("MIRApprovedBy", fields: [approvedById], references: [id])
+  items        MaterialInspectionReceiptItem[]
+  attachments  MaterialInspectionReceiptAttachment[]
 
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
@@ -1647,6 +1664,7 @@ model MaterialInspectionReceipt {
   @@index([inspectorId])
   @@index([receiptDate])
   @@index([status])
+  @@index([workflowStatus])
   @@map("material_inspection_receipts")
 }
 

--- a/src/app/api/qc/material-receipts/route.ts
+++ b/src/app/api/qc/material-receipts/route.ts
@@ -70,6 +70,15 @@ export async function GET(request: NextRequest) {
           inspector: {
             select: { id: true, name: true, email: true },
           },
+          submittedBy: {
+            select: { id: true, name: true },
+          },
+          reviewedBy: {
+            select: { id: true, name: true },
+          },
+          approvedBy: {
+            select: { id: true, name: true },
+          },
           items: {
             include: {
               attachments: {
@@ -124,6 +133,15 @@ export async function GET(request: NextRequest) {
         inspector: {
           select: { id: true, name: true, email: true },
         },
+        submittedBy: {
+          select: { id: true, name: true },
+        },
+        reviewedBy: {
+          select: { id: true, name: true },
+        },
+        approvedBy: {
+          select: { id: true, name: true },
+        },
         items: {
           select: {
             id: true,
@@ -134,6 +152,8 @@ export async function GET(request: NextRequest) {
             rejectedQty: true,
             unit: true,
             inspectionResult: true,
+            mtcAvailable: true,
+            mtcFilePath: true,
           },
         },
       },
@@ -287,12 +307,11 @@ export async function PATCH(request: NextRequest) {
       where: { id: receiptId },
       data: updateData,
       include: {
-        project: {
-          select: { id: true, projectNumber: true, name: true },
-        },
-        inspector: {
-          select: { id: true, name: true, email: true },
-        },
+        project: { select: { id: true, projectNumber: true, name: true } },
+        inspector: { select: { id: true, name: true, email: true } },
+        submittedBy: { select: { id: true, name: true } },
+        reviewedBy: { select: { id: true, name: true } },
+        approvedBy: { select: { id: true, name: true } },
         items: true,
       },
     });

--- a/src/app/api/qc/material-receipts/workflow/route.ts
+++ b/src/app/api/qc/material-receipts/workflow/route.ts
@@ -1,0 +1,215 @@
+/**
+ * POST /api/qc/material-receipts/workflow
+ *
+ * Handles workflow state transitions for Material Inspection Receipts.
+ *
+ * Transitions:
+ *   Draft      → Inspected  (action: 'submit'  — all items must be inspected)
+ *   Inspected  → Reviewed   (action: 'review')
+ *   Inspected|Reviewed → Approved (action: 'approve')
+ *   Inspected|Reviewed → Rejected (action: 'reject')
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withApiContext } from '@/lib/api-utils';
+import prisma from '@/lib/db';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+const workflowSchema = z.object({
+  receiptId: z.string().min(1),
+  action: z.enum(['submit', 'review', 'approve', 'reject']),
+  notes: z.string().optional(),
+});
+
+export const POST = withApiContext(async (req: NextRequest, session) => {
+  const body: unknown = await req.json();
+  const parsed = workflowSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Invalid input', details: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  const { receiptId, action, notes } = parsed.data;
+  const userId = session!.userId;
+
+  // Fetch the receipt with its items to validate state
+  const receipt = await prisma.materialInspectionReceipt.findUnique({
+    where: { id: receiptId },
+    select: {
+      id: true,
+      receiptNumber: true,
+      workflowStatus: true,
+      items: {
+        select: { id: true, inspectionResult: true },
+      },
+    },
+  });
+
+  if (!receipt) {
+    return NextResponse.json({ error: 'Receipt not found' }, { status: 404 });
+  }
+
+  const now = new Date();
+
+  // --- Validate transition and build update payload ---
+
+  if (action === 'submit') {
+    if (receipt.workflowStatus !== 'Draft') {
+      return NextResponse.json(
+        {
+          error: `Cannot submit: receipt is currently '${receipt.workflowStatus}'. Expected 'Draft'.`,
+        },
+        { status: 422 },
+      );
+    }
+
+    const hasPendingItems = receipt.items.some(
+      (item: { id: string; inspectionResult: string }) =>
+        item.inspectionResult === 'Pending',
+    );
+    if (hasPendingItems) {
+      return NextResponse.json(
+        { error: 'Cannot submit: all items must be inspected before submitting.' },
+        { status: 422 },
+      );
+    }
+
+    const updated = await prisma.materialInspectionReceipt.update({
+      where: { id: receiptId },
+      data: {
+        workflowStatus: 'Inspected',
+        submittedAt: now,
+        submittedById: userId,
+      },
+      include: {
+        project: { select: { id: true, projectNumber: true, name: true } },
+        inspector: { select: { id: true, name: true, email: true } },
+        submittedBy: { select: { id: true, name: true } },
+        reviewedBy: { select: { id: true, name: true } },
+        approvedBy: { select: { id: true, name: true } },
+        items: true,
+      },
+    });
+
+    logger.info(
+      { receiptId, receiptNumber: receipt.receiptNumber, action, userId },
+      '[MIR Workflow] Receipt submitted for inspection review',
+    );
+
+    return NextResponse.json(updated);
+  }
+
+  if (action === 'review') {
+    if (receipt.workflowStatus !== 'Inspected') {
+      return NextResponse.json(
+        {
+          error: `Cannot review: receipt is currently '${receipt.workflowStatus}'. Expected 'Inspected'.`,
+        },
+        { status: 422 },
+      );
+    }
+
+    const updated = await prisma.materialInspectionReceipt.update({
+      where: { id: receiptId },
+      data: {
+        workflowStatus: 'Reviewed',
+        reviewedAt: now,
+        reviewedById: userId,
+        reviewNotes: notes ?? null,
+      },
+      include: {
+        project: { select: { id: true, projectNumber: true, name: true } },
+        inspector: { select: { id: true, name: true, email: true } },
+        submittedBy: { select: { id: true, name: true } },
+        reviewedBy: { select: { id: true, name: true } },
+        approvedBy: { select: { id: true, name: true } },
+        items: true,
+      },
+    });
+
+    logger.info(
+      { receiptId, receiptNumber: receipt.receiptNumber, action, userId },
+      '[MIR Workflow] Receipt reviewed',
+    );
+
+    return NextResponse.json(updated);
+  }
+
+  if (action === 'approve') {
+    if (!['Inspected', 'Reviewed'].includes(receipt.workflowStatus)) {
+      return NextResponse.json(
+        {
+          error: `Cannot approve: receipt is currently '${receipt.workflowStatus}'. Expected 'Inspected' or 'Reviewed'.`,
+        },
+        { status: 422 },
+      );
+    }
+
+    const updated = await prisma.materialInspectionReceipt.update({
+      where: { id: receiptId },
+      data: {
+        workflowStatus: 'Approved',
+        approvedAt: now,
+        approvedById: userId,
+        approvalNotes: notes ?? null,
+      },
+      include: {
+        project: { select: { id: true, projectNumber: true, name: true } },
+        inspector: { select: { id: true, name: true, email: true } },
+        submittedBy: { select: { id: true, name: true } },
+        reviewedBy: { select: { id: true, name: true } },
+        approvedBy: { select: { id: true, name: true } },
+        items: true,
+      },
+    });
+
+    logger.info(
+      { receiptId, receiptNumber: receipt.receiptNumber, action, userId },
+      '[MIR Workflow] Receipt approved',
+    );
+
+    return NextResponse.json(updated);
+  }
+
+  // action === 'reject'
+  if (!['Inspected', 'Reviewed'].includes(receipt.workflowStatus)) {
+    return NextResponse.json(
+      {
+        error: `Cannot reject: receipt is currently '${receipt.workflowStatus}'. Expected 'Inspected' or 'Reviewed'.`,
+      },
+      { status: 422 },
+    );
+  }
+
+  const updated = await prisma.materialInspectionReceipt.update({
+    where: { id: receiptId },
+    data: {
+      workflowStatus: 'Rejected',
+      status: 'Rejected',
+      approvedAt: now,
+      approvedById: userId,
+      approvalNotes: notes ?? null,
+    },
+    include: {
+      project: { select: { id: true, projectNumber: true, name: true } },
+      inspector: { select: { id: true, name: true, email: true } },
+      submittedBy: { select: { id: true, name: true } },
+      reviewedBy: { select: { id: true, name: true } },
+      approvedBy: { select: { id: true, name: true } },
+      items: true,
+    },
+  });
+
+  logger.info(
+    { receiptId, receiptNumber: receipt.receiptNumber, action, userId },
+    '[MIR Workflow] Receipt rejected',
+  );
+
+  return NextResponse.json(updated);
+});

--- a/src/app/qc/material/_page-client.tsx
+++ b/src/app/qc/material/_page-client.tsx
@@ -24,6 +24,10 @@ import {
   Printer,
   AlertTriangle,
   CheckCheck,
+  Send,
+  ShieldCheck,
+  ShieldX,
+  ClipboardCheck,
 } from 'lucide-react';
 import {
   Dialog,
@@ -82,6 +86,19 @@ type MaterialReceipt = {
   projectId?: string;
   receiptDate: string;
   status: string;
+  workflowStatus: string;
+  submittedAt?: string;
+  submittedById?: string;
+  submittedBy?: { id: string; name: string } | null;
+  reviewedAt?: string;
+  reviewedById?: string;
+  reviewedBy?: { id: string; name: string } | null;
+  approvedAt?: string;
+  approvedById?: string;
+  approvedBy?: { id: string; name: string } | null;
+  approvalNotes?: string;
+  reviewNotes?: string;
+  remarks?: string;
   items: ReceiptItem[];
   project?: {
     id: string;
@@ -159,6 +176,14 @@ export default function MaterialInspectionReceiptPage() {
 
   // PDF generation
   const [generatingPdf, setGeneratingPdf] = useState(false);
+
+  // Workflow actions
+  const [workflowDialog, setWorkflowDialog] = useState<{
+    action: 'submit' | 'review' | 'approve' | 'reject';
+    receipt: MaterialReceipt;
+  } | null>(null);
+  const [workflowNotes, setWorkflowNotes] = useState('');
+  const [processingWorkflow, setProcessingWorkflow] = useState(false);
 
   useEffect(() => {
     fetchReceipts();
@@ -423,9 +448,21 @@ export default function MaterialInspectionReceiptPage() {
         supplierName: fullReceipt.supplierName,
         receiptDate: fullReceipt.receiptDate,
         status: fullReceipt.status,
+        workflowStatus: fullReceipt.workflowStatus ?? 'Draft',
         projectNumber: fullReceipt.project?.projectNumber,
         projectName: fullReceipt.project?.name,
         inspectorName: fullReceipt.inspector.name,
+        inspectorId: fullReceipt.inspector.id,
+        submittedAt: fullReceipt.submittedAt,
+        submittedByName: fullReceipt.submittedBy?.name,
+        submittedById: fullReceipt.submittedById,
+        reviewedAt: fullReceipt.reviewedAt,
+        reviewedByName: fullReceipt.reviewedBy?.name,
+        reviewedById: fullReceipt.reviewedById,
+        approvedAt: fullReceipt.approvedAt,
+        approvedByName: fullReceipt.approvedBy?.name,
+        approvedById: fullReceipt.approvedById,
+        approvalNotes: fullReceipt.approvalNotes,
         remarks: fullReceipt.remarks,
         items: fullReceipt.items,
       });
@@ -433,6 +470,35 @@ export default function MaterialInspectionReceiptPage() {
       console.error('Error generating PDF:', error);
     } finally {
       setGeneratingPdf(false);
+    }
+  };
+
+  const handleWorkflowAction = async () => {
+    if (!workflowDialog) return;
+    setProcessingWorkflow(true);
+    try {
+      const res = await fetch('/api/qc/material-receipts/workflow', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          receiptId: workflowDialog.receipt.id,
+          action: workflowDialog.action,
+          notes: workflowNotes || undefined,
+        }),
+      });
+      if (res.ok) {
+        const updated = await res.json();
+        setWorkflowDialog(null);
+        setWorkflowNotes('');
+        if (selectedReceipt?.id === workflowDialog.receipt.id) {
+          setSelectedReceipt(updated);
+        }
+        fetchReceipts();
+      }
+    } catch {
+      // silently handled
+    } finally {
+      setProcessingWorkflow(false);
     }
   };
 
@@ -454,12 +520,10 @@ export default function MaterialInspectionReceiptPage() {
 
   const stats = {
     total: receipts.length,
-    inProgress: receipts.filter(r => r.status === 'In Progress').length,
-    partiallyReceived: receipts.filter(r =>
-      r.status === 'Partially Received' || r.status === 'Partially Accepted'
-    ).length,
-    completed: receipts.filter(r => r.status === 'Received and Accepted').length,
-    rejected: receipts.filter(r => r.status === 'Rejected').length,
+    draft: receipts.filter(r => !r.workflowStatus || r.workflowStatus === 'Draft').length,
+    inspected: receipts.filter(r => r.workflowStatus === 'Inspected' || r.workflowStatus === 'Reviewed').length,
+    approved: receipts.filter(r => r.workflowStatus === 'Approved').length,
+    rejected: receipts.filter(r => r.workflowStatus === 'Rejected').length,
   };
 
   const getStatusBadge = (status: string) => {
@@ -483,6 +547,21 @@ export default function MaterialInspectionReceiptPage() {
     if (status === 'Rejected') return 'border-b bg-red-50/40 dark:bg-red-950/10 hover:bg-red-50/60';
     if (status === 'Received and Accepted') return 'border-b bg-green-50/20 dark:bg-green-950/10 hover:bg-muted/30';
     return 'border-b hover:bg-muted/50';
+  };
+
+  const getWorkflowBadge = (wfStatus: string) => {
+    switch (wfStatus) {
+      case 'Approved':
+        return <Badge className="bg-green-500/15 text-green-700 border border-green-300 whitespace-nowrap font-semibold"><ShieldCheck className="h-3 w-3 mr-1" /> Approved</Badge>;
+      case 'Rejected':
+        return <Badge className="bg-red-500/15 text-red-700 border border-red-300 whitespace-nowrap font-semibold"><ShieldX className="h-3 w-3 mr-1" /> Rejected</Badge>;
+      case 'Inspected':
+        return <Badge className="bg-amber-500/15 text-amber-700 border border-amber-300 whitespace-nowrap"><ClipboardCheck className="h-3 w-3 mr-1" /> Inspected</Badge>;
+      case 'Reviewed':
+        return <Badge className="bg-blue-500/15 text-blue-700 border border-blue-300 whitespace-nowrap"><ClipboardCheck className="h-3 w-3 mr-1" /> Reviewed</Badge>;
+      default:
+        return <Badge className="bg-gray-500/10 text-gray-600 whitespace-nowrap"><Clock className="h-3 w-3 mr-1" /> Draft</Badge>;
+    }
   };
 
   const getInspectionResultBadge = (result: string) => {
@@ -550,7 +629,7 @@ export default function MaterialInspectionReceiptPage() {
       </div>
 
       {/* Stats */}
-      <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <Card>
           <CardContent className="pt-6">
             <div className="text-2xl font-bold">{stats.total}</div>
@@ -559,26 +638,20 @@ export default function MaterialInspectionReceiptPage() {
         </Card>
         <Card>
           <CardContent className="pt-6">
-            <div className="text-2xl font-bold text-blue-600">{stats.inProgress}</div>
-            <p className="text-xs text-muted-foreground">In Progress</p>
+            <div className="text-2xl font-bold text-gray-500">{stats.draft}</div>
+            <p className="text-xs text-muted-foreground">Draft / In Progress</p>
           </CardContent>
         </Card>
         <Card>
           <CardContent className="pt-6">
-            <div className="text-2xl font-bold text-amber-600">{stats.partiallyReceived}</div>
-            <p className="text-xs text-muted-foreground">Partial</p>
+            <div className="text-2xl font-bold text-amber-600">{stats.inspected}</div>
+            <p className="text-xs text-muted-foreground">Awaiting Approval</p>
           </CardContent>
         </Card>
         <Card>
           <CardContent className="pt-6">
-            <div className="text-2xl font-bold text-green-600">{stats.completed}</div>
-            <p className="text-xs text-muted-foreground">Received & Accepted</p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-6">
-            <div className="text-2xl font-bold text-red-600">{stats.rejected}</div>
-            <p className="text-xs text-muted-foreground">Rejected</p>
+            <div className="text-2xl font-bold text-green-600">{stats.approved}</div>
+            <p className="text-xs text-muted-foreground">Fully Approved</p>
           </CardContent>
         </Card>
       </div>
@@ -629,6 +702,7 @@ export default function MaterialInspectionReceiptPage() {
                   <th className="text-left p-3 font-medium">Project</th>
                   <th className="text-left p-3 font-medium">Date</th>
                   <th className="text-left p-3 font-medium">Status</th>
+                  <th className="text-left p-3 font-medium">Workflow</th>
                   <th className="text-center p-3 font-medium">Items</th>
                   <th className="text-center p-3 font-medium" title="MTC Received & Uploaded">MTC</th>
                   <th className="text-center p-3 font-medium">Actions</th>
@@ -637,7 +711,7 @@ export default function MaterialInspectionReceiptPage() {
               <tbody>
                 {filteredReceipts.length === 0 ? (
                   <tr>
-                    <td colSpan={9} className="text-center p-8 text-muted-foreground">
+                    <td colSpan={10} className="text-center p-8 text-muted-foreground">
                       No material receipts found
                     </td>
                   </tr>
@@ -650,6 +724,7 @@ export default function MaterialInspectionReceiptPage() {
                       <td className="p-3 text-sm font-mono">{receipt.project?.projectNumber || '—'}</td>
                       <td className="p-3 text-sm">{new Date(receipt.receiptDate).toLocaleDateString('en-SA-u-ca-gregory')}</td>
                       <td className="p-3">{getStatusBadge(receipt.status)}</td>
+                      <td className="p-3">{getWorkflowBadge(receipt.workflowStatus ?? 'Draft')}</td>
                       <td className="p-3 text-center">
                         <Badge variant="secondary">{receipt.items.length}</Badge>
                       </td>
@@ -899,6 +974,111 @@ export default function MaterialInspectionReceiptPage() {
                 <div>
                   <p className="text-xs text-muted-foreground mb-1">Receipt Date</p>
                   <p className="font-medium">{new Date(selectedReceipt.receiptDate).toLocaleDateString('en-SA-u-ca-gregory')}</p>
+                </div>
+              </div>
+
+              {/* Workflow Status Panel */}
+              <div className={`rounded-lg border p-4 ${
+                selectedReceipt.workflowStatus === 'Approved' ? 'border-green-200 bg-green-50/40 dark:bg-green-950/10' :
+                selectedReceipt.workflowStatus === 'Rejected' ? 'border-red-200 bg-red-50/40 dark:bg-red-950/10' :
+                (selectedReceipt.workflowStatus === 'Inspected' || selectedReceipt.workflowStatus === 'Reviewed') ? 'border-amber-200 bg-amber-50/40 dark:bg-amber-950/10' :
+                'border-muted bg-muted/30'
+              }`}>
+                <div className="flex items-center justify-between mb-3">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-semibold">Workflow</span>
+                    {getWorkflowBadge(selectedReceipt.workflowStatus ?? 'Draft')}
+                  </div>
+                  {/* Workflow action buttons */}
+                  <div className="flex gap-2">
+                    {(!selectedReceipt.workflowStatus || selectedReceipt.workflowStatus === 'Draft') && (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="gap-1 border-amber-400 text-amber-700 hover:bg-amber-50"
+                        onClick={() => setWorkflowDialog({ action: 'submit', receipt: selectedReceipt })}
+                      >
+                        <Send className="h-3.5 w-3.5" />
+                        Finalize & Submit
+                      </Button>
+                    )}
+                    {selectedReceipt.workflowStatus === 'Inspected' && (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="gap-1 border-blue-400 text-blue-700 hover:bg-blue-50"
+                        onClick={() => setWorkflowDialog({ action: 'review', receipt: selectedReceipt })}
+                      >
+                        <ClipboardCheck className="h-3.5 w-3.5" />
+                        Mark Reviewed
+                      </Button>
+                    )}
+                    {(selectedReceipt.workflowStatus === 'Inspected' || selectedReceipt.workflowStatus === 'Reviewed') && (
+                      <>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="gap-1 border-green-400 text-green-700 hover:bg-green-50"
+                          onClick={() => setWorkflowDialog({ action: 'approve', receipt: selectedReceipt })}
+                        >
+                          <ShieldCheck className="h-3.5 w-3.5" />
+                          Approve
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="gap-1 border-red-400 text-red-700 hover:bg-red-50"
+                          onClick={() => setWorkflowDialog({ action: 'reject', receipt: selectedReceipt })}
+                        >
+                          <ShieldX className="h-3.5 w-3.5" />
+                          Reject
+                        </Button>
+                      </>
+                    )}
+                  </div>
+                </div>
+
+                {/* Workflow history signatures */}
+                <div className="grid grid-cols-3 gap-4 text-xs">
+                  <div className="space-y-0.5">
+                    <p className="font-semibold text-muted-foreground uppercase tracking-wide text-[10px]">Inspector / Receiver</p>
+                    <p className="font-medium">{selectedReceipt.inspector.name}</p>
+                    <p className="text-muted-foreground font-mono">ID: {selectedReceipt.inspector.id.replace(/-/g,'').slice(0,8).toUpperCase()}</p>
+                    {selectedReceipt.submittedAt && (
+                      <p className="text-muted-foreground">{new Date(selectedReceipt.submittedAt).toLocaleString('en-SA-u-ca-gregory')}</p>
+                    )}
+                  </div>
+                  <div className="space-y-0.5">
+                    <p className="font-semibold text-muted-foreground uppercase tracking-wide text-[10px]">QC Reviewer</p>
+                    {selectedReceipt.reviewedBy ? (
+                      <>
+                        <p className="font-medium">{selectedReceipt.reviewedBy.name}</p>
+                        <p className="text-muted-foreground font-mono">ID: {selectedReceipt.reviewedBy.id.replace(/-/g,'').slice(0,8).toUpperCase()}</p>
+                        {selectedReceipt.reviewedAt && (
+                          <p className="text-muted-foreground">{new Date(selectedReceipt.reviewedAt).toLocaleString('en-SA-u-ca-gregory')}</p>
+                        )}
+                      </>
+                    ) : (
+                      <p className="text-muted-foreground italic">Pending</p>
+                    )}
+                  </div>
+                  <div className="space-y-0.5">
+                    <p className="font-semibold text-muted-foreground uppercase tracking-wide text-[10px]">Approved By</p>
+                    {selectedReceipt.approvedBy ? (
+                      <>
+                        <p className="font-medium">{selectedReceipt.approvedBy.name}</p>
+                        <p className="text-muted-foreground font-mono">ID: {selectedReceipt.approvedBy.id.replace(/-/g,'').slice(0,8).toUpperCase()}</p>
+                        {selectedReceipt.approvedAt && (
+                          <p className="text-muted-foreground">{new Date(selectedReceipt.approvedAt).toLocaleString('en-SA-u-ca-gregory')}</p>
+                        )}
+                        {selectedReceipt.approvalNotes && (
+                          <p className="text-muted-foreground italic">&quot;{selectedReceipt.approvalNotes}&quot;</p>
+                        )}
+                      </>
+                    ) : (
+                      <p className="text-muted-foreground italic">Pending</p>
+                    )}
+                  </div>
                 </div>
               </div>
 
@@ -1459,6 +1639,74 @@ export default function MaterialInspectionReceiptPage() {
                 )}
               </Button>
             </div>
+          </DialogContent>
+        </Dialog>
+      )}
+
+      {/* Workflow Action Dialog */}
+      {workflowDialog && (
+        <Dialog open={!!workflowDialog} onOpenChange={() => { setWorkflowDialog(null); setWorkflowNotes(''); }}>
+          <DialogContent className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                {workflowDialog.action === 'submit' && <><Send className="h-5 w-5 text-amber-600" /> Finalize &amp; Submit MIR</>}
+                {workflowDialog.action === 'review' && <><ClipboardCheck className="h-5 w-5 text-blue-600" /> Confirm QC Review</>}
+                {workflowDialog.action === 'approve' && <><ShieldCheck className="h-5 w-5 text-green-600" /> Approve MIR</>}
+                {workflowDialog.action === 'reject' && <><ShieldX className="h-5 w-5 text-red-600" /> Reject MIR</>}
+              </DialogTitle>
+              <DialogDescription>
+                {workflowDialog.receipt.receiptNumber} — {workflowDialog.receipt.dolibarrPoRef}
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-4 py-2">
+              {workflowDialog.action === 'submit' && (
+                <div className="rounded-md bg-amber-50 border border-amber-200 p-3 text-sm text-amber-800 dark:bg-amber-950/20 dark:text-amber-300">
+                  This will finalize the MIR and send it for approval. All items must be inspected. This action cannot be undone.
+                </div>
+              )}
+              {(workflowDialog.action === 'approve' || workflowDialog.action === 'reject' || workflowDialog.action === 'review') && (
+                <div className="space-y-1.5">
+                  <Label htmlFor="wfNotes">
+                    {workflowDialog.action === 'reject' ? 'Rejection Reason *' : 'Notes (optional)'}
+                  </Label>
+                  <Textarea
+                    id="wfNotes"
+                    placeholder={workflowDialog.action === 'reject' ? 'Explain why this MIR is being rejected...' : 'Add any notes or comments...'}
+                    rows={3}
+                    value={workflowNotes}
+                    onChange={(e) => setWorkflowNotes(e.target.value)}
+                  />
+                </div>
+              )}
+            </div>
+
+            <DialogFooter>
+              <Button variant="outline" onClick={() => { setWorkflowDialog(null); setWorkflowNotes(''); }} disabled={processingWorkflow}>
+                Cancel
+              </Button>
+              <Button
+                onClick={handleWorkflowAction}
+                disabled={processingWorkflow || (workflowDialog.action === 'reject' && !workflowNotes.trim())}
+                className={
+                  workflowDialog.action === 'approve' ? 'bg-green-600 hover:bg-green-700' :
+                  workflowDialog.action === 'reject' ? 'bg-red-600 hover:bg-red-700' :
+                  workflowDialog.action === 'submit' ? 'bg-amber-600 hover:bg-amber-700' :
+                  ''
+                }
+              >
+                {processingWorkflow ? (
+                  <><Loader2 className="mr-2 h-4 w-4 animate-spin" />Processing...</>
+                ) : (
+                  <>
+                    {workflowDialog.action === 'submit' && <><Send className="mr-2 h-4 w-4" />Submit for Approval</>}
+                    {workflowDialog.action === 'review' && <><ClipboardCheck className="mr-2 h-4 w-4" />Confirm Review</>}
+                    {workflowDialog.action === 'approve' && <><ShieldCheck className="mr-2 h-4 w-4" />Approve MIR</>}
+                    {workflowDialog.action === 'reject' && <><ShieldX className="mr-2 h-4 w-4" />Reject MIR</>}
+                  </>
+                )}
+              </Button>
+            </DialogFooter>
           </DialogContent>
         </Dialog>
       )}

--- a/src/lib/mir-pdf-generator.ts
+++ b/src/lib/mir-pdf-generator.ts
@@ -43,8 +43,35 @@ function fmt(d: string | Date | null | undefined): string {
   });
 }
 
+function fmtTs(d: string | Date | null | undefined): string {
+  if (!d) return '—';
+  return new Date(d).toLocaleString('en-SA-u-ca-gregory', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
 function val(v: string | null | undefined): string {
   return v || '—';
+}
+
+function shortId(id: string | null | undefined): string {
+  if (!id) return '—';
+  return id.replace(/-/g, '').slice(0, 8).toUpperCase();
+}
+
+// Status → { label, rgb }
+function workflowStatusStyle(ws: string): { label: string; r: number; g: number; b: number } {
+  switch (ws) {
+    case 'Approved':  return { label: 'APPROVED',  r: 21,  g: 128, b: 61  };
+    case 'Rejected':  return { label: 'REJECTED',  r: 185, g: 28,  b: 28  };
+    case 'Inspected': return { label: 'INSPECTED', r: 180, g: 120, b: 0   };
+    case 'Reviewed':  return { label: 'REVIEWED',  r: 30,  g: 100, b: 200 };
+    default:          return { label: 'DRAFT',     r: 100, g: 100, b: 100 };
+  }
 }
 
 export type MIRItemPDFData = {
@@ -80,9 +107,21 @@ export type MIRPDFData = {
   supplierName?: string | null;
   receiptDate: string | Date;
   status: string;
+  workflowStatus: string;
   projectNumber?: string | null;
   projectName?: string | null;
   inspectorName: string;
+  inspectorId?: string | null;
+  submittedAt?: string | Date | null;
+  submittedByName?: string | null;
+  submittedById?: string | null;
+  reviewedAt?: string | Date | null;
+  reviewedByName?: string | null;
+  reviewedById?: string | null;
+  approvedAt?: string | Date | null;
+  approvedByName?: string | null;
+  approvedById?: string | null;
+  approvalNotes?: string | null;
   remarks?: string | null;
   items: MIRItemPDFData[];
 };
@@ -97,29 +136,37 @@ export async function generateMIRPDF(data: MIRPDFData): Promise<void> {
     `${data.receiptNumber} · ${FORM_REF}`
   );
 
-  // Receipt metadata
+  // Workflow status badge (inline with metadata)
+  const ws = workflowStatusStyle(data.workflowStatus || 'Draft');
+
+  // Receipt metadata (4 columns - compact row layout)
   pdf.addInfoGrid(
     {
-      'MIR No.': data.receiptNumber,
+      'MIR No.':      data.receiptNumber,
       'PO Reference': data.dolibarrPoRef,
-      'Supplier': val(data.supplierName),
+      'Supplier':     val(data.supplierName),
       'Receipt Date': fmt(data.receiptDate),
-      'Project': data.projectNumber ? `${data.projectNumber}${data.projectName ? ' — ' + data.projectName : ''}` : '—',
-      'Inspector': data.inspectorName,
-      'Status': data.status,
-      'Remarks': val(data.remarks),
+      'Project':      data.projectNumber
+        ? `${data.projectNumber}${data.projectName ? ' — ' + data.projectName : ''}`
+        : '—',
+      'Inspector':    data.inspectorName,
+      'Status':       data.status,
+      'Remarks':      val(data.remarks),
     },
     4
   );
 
+  // Workflow status pill — rendered as a colored label row
+  pdf.addWorkflowStatusBadge(ws.label, ws.r, ws.g, ws.b);
+
   pdf.addDivider();
 
-  // Items summary table
+  // ── Items Summary table ──────────────────────────────────────────────────
   pdf.addSectionHeader('Items Summary');
 
   const summaryHeaders = ['Item', 'Spec', 'Ordered', 'Received', 'Accepted', 'Rejected', 'MTC', 'Result'];
   const summaryRows = data.items.map(item => [
-    item.itemName.length > 35 ? item.itemName.slice(0, 33) + '…' : item.itemName,
+    item.itemName,
     val(item.specification),
     `${item.orderedQty} ${item.unit}`,
     `${item.receivedQty} ${item.unit}`,
@@ -129,9 +176,15 @@ export async function generateMIRPDF(data: MIRPDFData): Promise<void> {
     item.inspectionResult,
   ]);
 
-  pdf.addTable(summaryHeaders, summaryRows, { alternateRows: true });
+  // Explicit column widths to prevent overflow in landscape (267mm available)
+  pdf.addTableWithColumnWidths(
+    summaryHeaders,
+    summaryRows,
+    [85, 20, 22, 22, 22, 22, 28, 22],
+    { alternateRows: true }
+  );
 
-  // Detailed inspection per item
+  // ── Detailed inspection per item ─────────────────────────────────────────
   const hasAnyDetail = data.items.some(
     i =>
       i.surfaceCondition ||
@@ -158,60 +211,83 @@ export async function generateMIRPDF(data: MIRPDFData): Promise<void> {
 
       if (!hasDetail) continue;
 
-      pdf.addInfoGrid(
-        {
-          'Item': item.itemName.length > 50 ? item.itemName.slice(0, 48) + '…' : item.itemName,
-          'Result': item.inspectionResult,
-          'Surface': val(item.surfaceCondition),
-          'Dimension': val(item.dimensionStatus),
-          'Thickness': item.thicknessStatus ? `${item.thicknessStatus}${item.thicknessMeasured ? ' (' + item.thicknessMeasured + ')' : ''}` : '—',
-          'Specs': val(item.specsCompliance),
-          'Heat No.': val(item.heatNumber),
-          'Batch No.': val(item.batchNumber),
-          'MTC': item.mtcAvailable ? (item.mtcNumber || 'Yes') : 'No',
-          'MTC Uploaded': item.mtcAvailable ? 'Yes' : 'No',
-        },
-        5
-      );
+      const thicknessStr = item.thicknessStatus
+        ? `${item.thicknessStatus}${item.thicknessMeasured ? ' — ' + item.thicknessMeasured : ''}`
+        : '—';
 
-      if (item.inspectionResult === 'Rejected' && item.rejectionReason) {
+      const detailRows: string[][] = [
+        ['Surface',   val(item.surfaceCondition), 'Dimension', val(item.dimensionStatus)],
+        ['Thickness', thicknessStr,               'Specs',     val(item.specsCompliance)],
+        ['Heat No.',  val(item.heatNumber),        'Batch No.', val(item.batchNumber)],
+        ['MTC Cert.', item.mtcAvailable ? (item.mtcNumber || 'Yes') : 'No',
+         'MTC Uploaded', item.mtcAvailable ? 'Yes' : 'No'],
+      ];
+
+      pdf.addItemInspectionTable(item.itemName, item.inspectionResult, detailRows);
+
+      if (item.inspectionResult === 'Rejected' && item.rejectionReason)
         pdf.addLabelValue('Rejection Reason', item.rejectionReason);
-      }
-
-      if (item.surfaceNotes) pdf.addLabelValue('Surface Notes', item.surfaceNotes);
-      if (item.dimensionNotes) pdf.addLabelValue('Dimension Notes', item.dimensionNotes);
-      if (item.thicknessNotes) pdf.addLabelValue('Thickness Notes', item.thicknessNotes);
-      if (item.specsNotes) pdf.addLabelValue('Specs Notes', item.specsNotes);
-      if (item.remarks) pdf.addLabelValue('Item Remarks', item.remarks);
+      if (item.surfaceNotes)    pdf.addLabelValue('Surface Notes',   item.surfaceNotes);
+      if (item.dimensionNotes)  pdf.addLabelValue('Dimension Notes', item.dimensionNotes);
+      if (item.thicknessNotes)  pdf.addLabelValue('Thickness Notes', item.thicknessNotes);
+      if (item.specsNotes)      pdf.addLabelValue('Specs Notes',     item.specsNotes);
+      if (item.remarks)         pdf.addLabelValue('Item Remarks',    item.remarks);
 
       pdf.addDivider();
     }
   }
 
-  // Rejected items summary
+  // ── Rejected items summary ───────────────────────────────────────────────
   const rejectedItems = data.items.filter(i => i.inspectionResult === 'Rejected');
   if (rejectedItems.length > 0) {
     pdf.addSectionHeader('Rejected Items Summary');
 
     const rejHeaders = ['Item', 'Rejected Qty', 'Surface', 'Dimension', 'Thickness', 'Specs', 'Rejection Reason'];
     const rejRows = rejectedItems.map(item => [
-      item.itemName.length > 30 ? item.itemName.slice(0, 28) + '…' : item.itemName,
+      item.itemName,
       `${item.rejectedQty} ${item.unit}`,
       val(item.surfaceCondition),
       val(item.dimensionStatus),
-      item.thicknessStatus ? `${item.thicknessStatus}${item.thicknessMeasured ? ' (' + item.thicknessMeasured + ')' : ''}` : '—',
+      item.thicknessStatus
+        ? `${item.thicknessStatus}${item.thicknessMeasured ? ' (' + item.thicknessMeasured + ')' : ''}`
+        : '—',
       val(item.specsCompliance),
       val(item.rejectionReason),
     ]);
 
-    pdf.addTable(rejHeaders, rejRows, { alternateRows: true });
+    pdf.addTableWithColumnWidths(
+      rejHeaders,
+      rejRows,
+      [70, 24, 28, 28, 28, 28, 55],
+      { alternateRows: true }
+    );
   }
 
-  // Signature section
+  // ── Approval notes ───────────────────────────────────────────────────────
+  if (data.approvalNotes) {
+    pdf.addLabelValue('Approval Notes', data.approvalNotes);
+  }
+
+  // ── Signatures ───────────────────────────────────────────────────────────
   pdf.addSignatureSection([
-    { label: 'Inspector / Receiver', name: data.inspectorName, date: fmt(data.receiptDate) },
-    { label: 'QC Review', name: '', date: '' },
-    { label: 'Approved By', name: '', date: '' },
+    {
+      label:     'Inspector / Receiver',
+      name:      data.inspectorName,
+      userId:    shortId(data.inspectorId),
+      timestamp: data.submittedAt ? fmtTs(data.submittedAt) : fmt(data.receiptDate),
+    },
+    {
+      label:     'QC Reviewer',
+      name:      data.reviewedByName ?? '',
+      userId:    data.reviewedById ? shortId(data.reviewedById) : undefined,
+      timestamp: data.reviewedAt ? fmtTs(data.reviewedAt) : undefined,
+    },
+    {
+      label:     'Approved By',
+      name:      data.approvedByName ?? '',
+      userId:    data.approvedById ? shortId(data.approvedById) : undefined,
+      timestamp: data.approvedAt ? fmtTs(data.approvedAt) : undefined,
+    },
   ]);
 
   pdf.addFooter(FOOTER_BASE, FORM_REF);

--- a/src/lib/pdf-builder.ts
+++ b/src/lib/pdf-builder.ts
@@ -214,6 +214,8 @@ export class PDFReportBuilder {
 
     const entries = Object.entries(data);
     const columnWidth = (this.pageWidth - 2 * this.margin) / columns;
+    const labelWidth = 32;
+    const valueMaxWidth = columnWidth - labelWidth - 3;
     const lineHeight = 6;
     let col = 0;
     let row = 0;
@@ -229,7 +231,8 @@ export class PDFReportBuilder {
 
       this.doc.setFont(this.font, 'normal');
       this.doc.setTextColor(this.theme.textColor);
-      this.doc.text(String(value), x + 35, y);
+      const lines = this.doc.splitTextToSize(String(value), valueMaxWidth);
+      this.doc.text(lines[0] as string, x + labelWidth, y);
 
       col++;
       if (col >= columns) {
@@ -239,6 +242,123 @@ export class PDFReportBuilder {
     });
 
     this.currentY += Math.ceil(entries.length / columns) * lineHeight + 5;
+  }
+
+  addItemInspectionTable(
+    itemName: string,
+    result: string,
+    rows: string[][],
+  ): void {
+    this.checkPageBreak(45);
+
+    const resultColors: Record<string, [number, number, number]> = {
+      Accepted: [22, 163, 74],
+      Rejected: [220, 38, 38],
+      Pending:  [107, 114, 128],
+    };
+    const resultColor = resultColors[result] ?? [107, 114, 128];
+
+    // Item header bar
+    this.doc.setFillColor(240, 242, 245);
+    this.doc.rect(this.margin, this.currentY, this.pageWidth - 2 * this.margin, 8, 'F');
+    this.doc.setDrawColor(200, 200, 200);
+    this.doc.setLineWidth(0.2);
+    this.doc.rect(this.margin, this.currentY, this.pageWidth - 2 * this.margin, 8);
+
+    // Left accent bar
+    this.doc.setFillColor(...resultColor);
+    this.doc.rect(this.margin, this.currentY, 2, 8, 'F');
+
+    this.doc.setFontSize(8.5);
+    this.doc.setFont(this.font, 'bold');
+    this.doc.setTextColor(this.theme.textColor);
+    const truncated = itemName.length > 90 ? itemName.slice(0, 88) + '…' : itemName;
+    this.doc.text(truncated, this.margin + 5, this.currentY + 5.5);
+
+    // Result badge on right
+    this.doc.setFontSize(8);
+    this.doc.setFont(this.font, 'bold');
+    this.doc.setTextColor(...resultColor);
+    this.doc.text(result, this.pageWidth - this.margin - 2, this.currentY + 5.5, { align: 'right' });
+
+    this.currentY += 9;
+
+    autoTable(this.doc, {
+      body: rows,
+      startY: this.currentY,
+      margin: { left: this.margin + 2, right: this.margin },
+      theme: 'plain',
+      columnStyles: {
+        0: { cellWidth: 28, fontStyle: 'bold', textColor: [80, 80, 80], fontSize: 7.5 },
+        1: { cellWidth: 'auto', fontSize: 7.5 },
+        2: { cellWidth: 28, fontStyle: 'bold', textColor: [80, 80, 80], fontSize: 7.5 },
+        3: { cellWidth: 'auto', fontSize: 7.5 },
+      },
+      bodyStyles: { cellPadding: { top: 1.5, bottom: 1.5, left: 2, right: 2 } },
+      alternateRowStyles: { fillColor: [250, 251, 252] },
+    });
+
+    this.currentY = (this.doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 3;
+  }
+
+  addWorkflowStatusBadge(label: string, r: number, g: number, b: number): void {
+    this.checkPageBreak(10);
+
+    const badgeW = 40;
+    const badgeH = 6;
+    const x = this.pageWidth - this.margin - badgeW;
+    const y = this.currentY - 3;
+
+    this.doc.setFillColor(r, g, b);
+    this.doc.roundedRect(x, y, badgeW, badgeH, 1, 1, 'F');
+    this.doc.setFont(this.font, 'bold');
+    this.doc.setFontSize(7);
+    this.doc.setTextColor(255, 255, 255);
+    this.doc.text(label, x + badgeW / 2, y + 4.2, { align: 'center' });
+    this.doc.setTextColor(this.theme.textColor);
+    this.currentY += 4;
+  }
+
+  addTableWithColumnWidths(
+    headers: string[],
+    rows: (string | number)[][],
+    columnWidths: (number | 'auto')[],
+    options?: {
+      headerBg?: string;
+      headerText?: string;
+      alternateRows?: boolean;
+    }
+  ): void {
+    this.checkPageBreak(30);
+
+    const columnStyles: Record<number, { cellWidth: number | 'auto' }> = {};
+    columnWidths.forEach((w, i) => { columnStyles[i] = { cellWidth: w }; });
+
+    autoTable(this.doc, {
+      head: [headers],
+      body: rows,
+      startY: this.currentY,
+      margin: { left: this.margin, right: this.margin },
+      theme: 'grid',
+      headStyles: {
+        fillColor: options?.headerBg || this.theme.primaryColor,
+        textColor: options?.headerText || this.theme.headerText,
+        fontStyle: 'bold',
+        font: this.font,
+        fontSize: 8,
+      },
+      bodyStyles: {
+        fontSize: 7.5,
+        textColor: this.theme.textColor,
+        font: this.font,
+        cellPadding: 2,
+        overflow: 'linebreak',
+      },
+      columnStyles,
+      alternateRowStyles: options?.alternateRows ? { fillColor: [248, 249, 250] } : undefined,
+    });
+
+    this.currentY = (this.doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 5;
   }
 
   addTable(
@@ -310,40 +430,49 @@ export class PDFReportBuilder {
   }
 
   addSignatureSection(
-    signatures: { label: string; name?: string; date?: string }[]
+    signatures: { label: string; name?: string; userId?: string; date?: string; timestamp?: string }[]
   ): void {
-    this.checkPageBreak(35);
+    this.checkPageBreak(42);
 
     const sigWidth = (this.pageWidth - 2 * this.margin) / signatures.length;
 
     signatures.forEach((sig, index) => {
       const x = this.margin + index * sigWidth;
 
+      // Label
       this.doc.setFontSize(8);
       this.doc.setFont(this.font, 'bold');
       this.doc.setTextColor(this.theme.textColor);
       this.doc.text(sig.label, x, this.currentY);
 
+      // Signature line
       this.doc.setLineWidth(0.3);
       this.doc.setDrawColor(150, 150, 150);
-      this.doc.line(x, this.currentY + 16, x + sigWidth - 8, this.currentY + 16);
+      this.doc.line(x, this.currentY + 18, x + sigWidth - 8, this.currentY + 18);
 
       if (sig.name) {
-        this.doc.setFont(this.font, 'normal');
-        this.doc.setFontSize(7.5);
-        this.doc.setTextColor(80, 80, 80);
-        this.doc.text(sig.name, x, this.currentY + 20);
+        this.doc.setFont(this.font, 'bold');
+        this.doc.setFontSize(8);
+        this.doc.setTextColor(60, 60, 60);
+        this.doc.text(sig.name, x, this.currentY + 22);
       }
 
-      if (sig.date) {
+      if (sig.userId) {
         this.doc.setFont(this.font, 'normal');
-        this.doc.setFontSize(7.5);
+        this.doc.setFontSize(7);
         this.doc.setTextColor(120, 120, 120);
-        this.doc.text(sig.date, x, this.currentY + 24);
+        this.doc.text(`ID: ${sig.userId}`, x, this.currentY + 27);
+      }
+
+      if (sig.timestamp || sig.date) {
+        this.doc.setFont(this.font, 'normal');
+        this.doc.setFontSize(7);
+        this.doc.setTextColor(140, 140, 140);
+        this.doc.text(sig.timestamp ?? sig.date ?? '', x, sig.userId ? this.currentY + 31 : this.currentY + 27);
       }
     });
 
-    this.currentY += 32;
+    this.currentY += 40;
   }
 
   // formRef: e.g. "HEXA-FRM-004 · Procedure: Hexa-ISP-004"

--- a/src/lib/startup-migrations.ts
+++ b/src/lib/startup-migrations.ts
@@ -231,6 +231,9 @@ const STARTUP_MIGRATIONS = [
 
   // ── Project wizard: arch drawings received flag on Building ───────────────
   'add_building_arch_drawings.sql',   // archDrawingsReceived BOOLEAN on Building
+
+  // ── v29.0.0 — MIR Workflow (Inspector → Reviewer → Approver) ─────────────
+  'v29_0_mir_workflow.sql',           // workflow_status + submission/review/approval timestamps on MIR
 ];
 
 /**


### PR DESCRIPTION
PDF Fixes:
- Fix text overlapping by using splitTextToSize for long values in addInfoGrid
- Replace flat inspection-details grid with per-item autoTable blocks (Surface/Dimension/Thickness/Specs/Heat/Batch/MTC in 4-col key-value rows)
- Add explicit column widths to summary and rejected-items tables to prevent overflow
- Landscape A4 column sizes tuned for long steel item names

MIR Workflow (3-step approval chain):
- States: Draft → Inspected → Reviewed → Approved / Rejected
- New POST /api/qc/material-receipts/workflow API (submit/review/approve/reject actions)
- Migration v29_0_mir_workflow.sql adds 9 workflow columns to material_inspection_receipts
- Inspector must inspect all items before submitting; submit locks MIR to "Inspected"
- QC reviewer can mark "Reviewed", line manager can Approve or Reject

PDF Status Colors:
- Approved: green badge, Inspected/Reviewed: amber, Rejected: red, Draft: gray
- Status badge rendered as colored pill in PDF header area

PDF Signatures with ID + Timestamp:
- Inspector / Receiver: name + user ID prefix + submitted timestamp
- QC Reviewer: name + ID + review timestamp (auto-populated from workflow)
- Approved By: name + ID + approval timestamp + approval notes

UI:
- New workflow status badge column in MIR list table
- Workflow panel in receipt detail dialog with history (all 3 signatories)
- Action buttons contextual to current state (Finalize/Submit, Review, Approve, Reject)
- Stats updated to show Draft/Awaiting/Approved counts

https://claude.ai/code/session_01SrX7ZKe4pyCXBz86CmkfF6