### PR TITLE
fix: QC MIR crashes, PO status, MIR serial numbering, task scope dropdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [23.6.0] - 2026-05-08
+## [23.6.0] - 2026-05-17
 
-### Added
-- 
+### QC Material Receipts, Task Scope, MIR Numbering
 
-### Changed
-- 
+#### Added
+- **QC: PO receipt status in lookup dialog** — When searching for a PO to create a new MIR, each result now shows whether a receipt already exists. Finalized receipts (Inspected/Approved/Rejected) show a status badge and disable the Select button ("Already Received"). In-progress receipts show an "In Progress" badge with a "Resume" button that opens the existing MIR directly.
+- **QC: Delete MIR** — Admin and CEO roles can now force-delete a Material Inspection Receipt (including all items and attachments) via a trash icon in the MIR list with a confirmation dialog.
+- **Tasks: Scope in Quick Task dialog** — The Quick Task dialog (Ctrl+Shift+T) now includes Project and Scope of Work dropdowns. Scope loads automatically when a project is selected. Both fields are passed to the API on submit and pre-filled when continuing to the full form.
+- **Tasks: Scope without building in full form** — The Scope of Work dropdown in the full task form now appears whenever a project is selected, even without selecting a building. Scopes are fetched at the project level, so all scopes across the project's buildings are available.
 
-### Fixed
-- 
+#### Changed
+- **QC: MIR numbering — global serial, no monthly reset** — MIR sequence numbers (MIR-YYMM-NNNN) are now a global, ever-increasing serial. Previously the counter reset each month; now it never resets. All existing MIR records have been renumbered sequentially by creation date (YYMM stays accurate per record).
+- **Tasks: Full form pre-fill from Quick Task** — Continuing from Quick Task to the full form now pre-fills title, priority, due date, assigned user, project, and scope.
+
+#### Fixed
+- **QC: Select.Item empty value crash** — Fixed a React runtime error (`A <Select.Item /> must have a value prop that is not an empty string`) in the MIR "Create Receipt" dialog's project dropdown. This was causing the form to crash and the page to appear to reload after selecting a PO.
 
 ---
 

--- a/prisma/manual_migrations/v30_0_mir_global_serial.sql
+++ b/prisma/manual_migrations/v30_0_mir_global_serial.sql
@@ -1,0 +1,19 @@
+-- Renumber all MIRs to use a global serial (not monthly reset)
+-- Format stays MIR-YYMM-NNNN, but NNNN is now a global sequence ordered by creation date
+
+-- Step 1: Temporarily clear receipt_number to avoid unique constraint conflicts
+UPDATE material_inspection_receipts
+SET receipt_number = CONCAT('TEMP-', id);
+
+-- Step 2: Assign new sequential numbers ordered by creation date
+-- YYMM comes from each record's own created_at date
+SET @seq = 0;
+UPDATE material_inspection_receipts r
+JOIN (
+  SELECT id,
+    (@seq := @seq + 1) AS seq_num,
+    DATE_FORMAT(created_at, '%y%m') AS yymm
+  FROM material_inspection_receipts
+  ORDER BY created_at ASC
+) AS ordered ON r.id = ordered.id
+SET r.receipt_number = CONCAT('MIR-', ordered.yymm, '-', LPAD(ordered.seq_num, 4, '0'));

--- a/src/app/api/qc/material-receipts/lookup-po/route.ts
+++ b/src/app/api/qc/material-receipts/lookup-po/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { verifySession } from '@/lib/jwt';
 import { createDolibarrClient } from '@/lib/dolibarr/dolibarr-client';
+import prisma from '@/lib/db';
 
 export const dynamic = 'force-dynamic';
 
@@ -74,8 +75,27 @@ export async function GET(request: NextRequest) {
       })
     );
 
-    console.log('[PO Lookup] Returning', enrichedOrders.length, 'enriched orders');
-    return NextResponse.json({ orders: enrichedOrders });
+    // Find existing MIRs for these POs so UI can show receipt status
+    const poIds = enrichedOrders.map((o) => o.id.toString());
+    const existingMirs = await prisma.materialInspectionReceipt.findMany({
+      where: { dolibarrPoId: { in: poIds } },
+      select: {
+        id: true,
+        dolibarrPoId: true,
+        receiptNumber: true,
+        status: true,
+        workflowStatus: true,
+      },
+    });
+    const mirByPoId = new Map(existingMirs.map((m) => [m.dolibarrPoId, m]));
+
+    const ordersWithMir = enrichedOrders.map((o) => ({
+      ...o,
+      existingMir: mirByPoId.get(o.id.toString()) ?? null,
+    }));
+
+    console.log('[PO Lookup] Returning', ordersWithMir.length, 'enriched orders');
+    return NextResponse.json({ orders: ordersWithMir });
   } catch (error: any) {
     console.error('[API] PO lookup error:', error);
     return NextResponse.json(

--- a/src/app/api/qc/material-receipts/route.ts
+++ b/src/app/api/qc/material-receipts/route.ts
@@ -6,39 +6,27 @@ import { randomUUID } from 'crypto';
 
 export const dynamic = 'force-dynamic';
 
-// Generate Material Inspection Receipt Number with retry for uniqueness
+// Generate Material Inspection Receipt Number with global serial (not monthly reset)
 async function generateReceiptNumber(retryCount = 0): Promise<string> {
   const now = new Date();
   const year = now.getFullYear().toString().slice(-2);
   const month = (now.getMonth() + 1).toString().padStart(2, '0');
-  
-  const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
-  const endOfMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0);
-  
-  const count = await prisma.materialInspectionReceipt.count({
-    where: {
-      createdAt: {
-        gte: startOfMonth,
-        lte: endOfMonth,
-      },
-    },
-  });
 
-  // Add retry offset to handle race conditions
+  const count = await prisma.materialInspectionReceipt.count();
+
+  // Global sequence — never resets
   const sequence = (count + 1 + retryCount).toString().padStart(4, '0');
   const receiptNumber = `MIR-${year}${month}-${sequence}`;
-  
-  // Check if this number already exists
+
   const existing = await prisma.materialInspectionReceipt.findUnique({
     where: { receiptNumber },
     select: { id: true },
   });
-  
+
   if (existing && retryCount < 10) {
-    // Number exists, retry with incremented count
     return generateReceiptNumber(retryCount + 1);
   }
-  
+
   return receiptNumber;
 }
 
@@ -275,6 +263,39 @@ export async function POST(request: NextRequest) {
       { error: 'Failed to create material inspection receipt' },
       { status: 500 }
     );
+  }
+}
+
+// DELETE - Force-delete a MIR (Admin and CEO only)
+export async function DELETE(request: NextRequest) {
+  try {
+    const store = await cookies();
+    const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+    const session = token ? verifySession(token) : null;
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    if (!['Admin', 'CEO'].includes(session.role)) {
+      return NextResponse.json({ error: 'Forbidden — Admin or CEO role required' }, { status: 403 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const receiptId = searchParams.get('id');
+
+    if (!receiptId) {
+      return NextResponse.json({ error: 'Missing receipt id' }, { status: 400 });
+    }
+
+    await prisma.materialInspectionReceipt.delete({
+      where: { id: receiptId },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error deleting material inspection receipt:', error);
+    return NextResponse.json({ error: 'Failed to delete receipt' }, { status: 500 });
   }
 }
 

--- a/src/app/qc/material/_page-client.tsx
+++ b/src/app/qc/material/_page-client.tsx
@@ -28,6 +28,7 @@ import {
   ShieldCheck,
   ShieldX,
   ClipboardCheck,
+  Trash2,
 } from 'lucide-react';
 import {
   Dialog,
@@ -45,6 +46,13 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 
+type ExistingMir = {
+  id: string;
+  receiptNumber: string;
+  status: string;
+  workflowStatus: string | null;
+};
+
 type PurchaseOrder = {
   id: number;
   ref: string;
@@ -57,6 +65,7 @@ type PurchaseOrder = {
   fk_projet?: number;
   project_ref?: string;
   lines: PurchaseOrderLine[];
+  existingMir?: ExistingMir | null;
 };
 
 type PurchaseOrderLine = {
@@ -160,7 +169,7 @@ export default function MaterialInspectionReceiptPage() {
   // Receipt creation
   const [showCreateReceipt, setShowCreateReceipt] = useState(false);
   const [creating, setCreating] = useState(false);
-  const [selectedProject, setSelectedProject] = useState('');
+  const [selectedProject, setSelectedProject] = useState('__none__');
 
   // Receipt detail/inspection
   const [selectedReceipt, setSelectedReceipt] = useState<MaterialReceipt | null>(null);
@@ -177,6 +186,13 @@ export default function MaterialInspectionReceiptPage() {
   // PDF generation
   const [generatingPdf, setGeneratingPdf] = useState(false);
 
+  // Current user role (for admin/CEO delete access)
+  const [currentUserRole, setCurrentUserRole] = useState('');
+
+  // Delete MIR
+  const [deletingReceiptId, setDeletingReceiptId] = useState<string | null>(null);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+
   // Workflow actions
   const [workflowDialog, setWorkflowDialog] = useState<{
     action: 'submit' | 'review' | 'approve' | 'reject';
@@ -188,6 +204,10 @@ export default function MaterialInspectionReceiptPage() {
   useEffect(() => {
     fetchReceipts();
     fetchProjects();
+    fetch('/api/auth/session')
+      .then((r) => r.ok ? r.json() : null)
+      .then((data) => { if (data?.role) setCurrentUserRole(data.role); })
+      .catch(() => {});
   }, []);
 
   // Auto-search POs as user types with debounce
@@ -282,7 +302,7 @@ export default function MaterialInspectionReceiptPage() {
           dolibarrPoId: selectedPO.id.toString(),
           dolibarrPoRef: selectedPO.ref,
           supplierName: selectedPO.supplier_name,
-          projectId: selectedProject || null,
+          projectId: (selectedProject && selectedProject !== '__none__') ? selectedProject : null,
           items,
         }),
       });
@@ -291,7 +311,7 @@ export default function MaterialInspectionReceiptPage() {
         const newReceipt = await response.json();
         setShowCreateReceipt(false);
         setSelectedPO(null);
-        setSelectedProject('');
+        setSelectedProject('__none__');
         fetchReceipts();
         setSelectedReceipt(newReceipt);
       }
@@ -499,6 +519,22 @@ export default function MaterialInspectionReceiptPage() {
       // silently handled
     } finally {
       setProcessingWorkflow(false);
+    }
+  };
+
+  const handleDeleteReceipt = async (receiptId: string) => {
+    setDeletingReceiptId(receiptId);
+    try {
+      const res = await fetch(`/api/qc/material-receipts?id=${receiptId}`, { method: 'DELETE' });
+      if (res.ok) {
+        setConfirmDeleteId(null);
+        if (selectedReceipt?.id === receiptId) setSelectedReceipt(null);
+        fetchReceipts();
+      }
+    } catch {
+      // silently handled
+    } finally {
+      setDeletingReceiptId(null);
     }
   };
 
@@ -760,6 +796,17 @@ export default function MaterialInspectionReceiptPage() {
                               <Printer className="h-4 w-4" />
                             )}
                           </Button>
+                          {['Admin', 'CEO'].includes(currentUserRole) && (
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="text-red-500 hover:text-red-700 hover:bg-red-50"
+                              onClick={() => setConfirmDeleteId(receipt.id)}
+                              title="Delete MIR"
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          )}
                         </div>
                       </td>
                     </tr>
@@ -816,26 +863,65 @@ export default function MaterialInspectionReceiptPage() {
                       <th className="text-left py-2 px-3 font-medium">Project</th>
                       <th className="text-right py-2 px-3 font-medium">Total</th>
                       <th className="text-center py-2 px-3 font-medium">Items</th>
+                      <th className="text-center py-2 px-3 font-medium">Receipt Status</th>
                       <th className="text-center py-2 px-3 font-medium">Action</th>
                     </tr>
                   </thead>
                   <tbody>
-                    {poSearchResults.map((po) => (
-                      <tr key={po.id} className="border-b hover:bg-muted/50">
-                        <td className="py-2 px-3 font-mono font-semibold">{po.ref}</td>
-                        <td className="py-2 px-3">{po.supplier_name || '—'}</td>
-                        <td className="py-2 px-3 font-mono text-xs">{po.project_ref || '—'}</td>
-                        <td className="py-2 px-3 text-right">{Number(po.total_ttc).toLocaleString()}</td>
-                        <td className="py-2 px-3 text-center">
-                          <Badge variant="secondary">{po.lines?.length || 0}</Badge>
-                        </td>
-                        <td className="py-2 px-3 text-center">
-                          <Button size="sm" onClick={() => handleSelectPO(po)}>
-                            Select
-                          </Button>
-                        </td>
-                      </tr>
-                    ))}
+                    {poSearchResults.map((po) => {
+                      const mir = po.existingMir;
+                      const isFinalized = mir && ['Inspected', 'Reviewed', 'Approved', 'Rejected'].includes(mir.workflowStatus ?? '');
+                      const isInProgress = mir && !isFinalized;
+                      return (
+                        <tr key={po.id} className="border-b hover:bg-muted/50">
+                          <td className="py-2 px-3 font-mono font-semibold">{po.ref}</td>
+                          <td className="py-2 px-3">{po.supplier_name || '—'}</td>
+                          <td className="py-2 px-3 font-mono text-xs">{po.project_ref || '—'}</td>
+                          <td className="py-2 px-3 text-right">{Number(po.total_ttc).toLocaleString()}</td>
+                          <td className="py-2 px-3 text-center">
+                            <Badge variant="secondary">{po.lines?.length || 0}</Badge>
+                          </td>
+                          <td className="py-2 px-3 text-center space-y-1">
+                            {isFinalized && (
+                              <Badge className="bg-green-500/10 text-green-700 whitespace-nowrap text-xs">
+                                <CheckCircle className="h-3 w-3 mr-1" />
+                                {mir!.workflowStatus}
+                              </Badge>
+                            )}
+                            {isInProgress && (
+                              <Badge className="bg-amber-500/10 text-amber-700 whitespace-nowrap text-xs">
+                                <Clock className="h-3 w-3 mr-1" />
+                                In Progress — {mir!.receiptNumber}
+                              </Badge>
+                            )}
+                          </td>
+                          <td className="py-2 px-3 text-center">
+                            {isFinalized ? (
+                              <Button size="sm" variant="outline" disabled className="text-xs opacity-50">
+                                Already Received
+                              </Button>
+                            ) : isInProgress ? (
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                className="text-xs border-amber-400 text-amber-700 hover:bg-amber-50"
+                                onClick={() => {
+                                  setShowPOLookup(false);
+                                  const existing = receipts.find(r => r.id === mir!.id);
+                                  if (existing) setSelectedReceipt(existing);
+                                }}
+                              >
+                                Resume
+                              </Button>
+                            ) : (
+                              <Button size="sm" onClick={() => handleSelectPO(po)}>
+                                Select
+                              </Button>
+                            )}
+                          </td>
+                        </tr>
+                      );
+                    })}
                   </tbody>
                 </table>
               </div>
@@ -875,7 +961,7 @@ export default function MaterialInspectionReceiptPage() {
                     <SelectValue placeholder="Select project (optional)" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="">— No Project —</SelectItem>
+                    <SelectItem value="__none__">— No Project —</SelectItem>
                     {projects.map((p) => (
                       <SelectItem key={p.id} value={p.id}>
                         {p.projectNumber} — {p.name}
@@ -1639,6 +1725,38 @@ export default function MaterialInspectionReceiptPage() {
                 )}
               </Button>
             </div>
+          </DialogContent>
+        </Dialog>
+      )}
+
+      {/* Delete Confirmation Dialog */}
+      {confirmDeleteId && (
+        <Dialog open={!!confirmDeleteId} onOpenChange={() => setConfirmDeleteId(null)}>
+          <DialogContent className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2 text-red-600">
+                <Trash2 className="h-5 w-5" /> Delete MIR
+              </DialogTitle>
+              <DialogDescription>
+                This will permanently delete the Material Inspection Receipt and all associated items and attachments. This action cannot be undone.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setConfirmDeleteId(null)} disabled={!!deletingReceiptId}>
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={() => handleDeleteReceipt(confirmDeleteId)}
+                disabled={!!deletingReceiptId}
+              >
+                {deletingReceiptId ? (
+                  <><Loader2 className="mr-2 h-4 w-4 animate-spin" />Deleting...</>
+                ) : (
+                  <><Trash2 className="mr-2 h-4 w-4" />Delete MIR</>
+                )}
+              </Button>
+            </DialogFooter>
           </DialogContent>
         </Dialog>
       )}

--- a/src/app/tasks/new/page.tsx
+++ b/src/app/tasks/new/page.tsx
@@ -10,7 +10,11 @@ export const metadata: Metadata = {
 };
 
 
-export default async function NewTaskPage() {
+export default async function NewTaskPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string>>;
+}) {
   const cookieName = process.env.COOKIE_NAME || 'ots_session';
   const store = await cookies();
   const token = store.get(cookieName)?.value;
@@ -26,13 +30,15 @@ export default async function NewTaskPage() {
     redirect('/tasks');
   }
 
+  const params = await searchParams;
+
   // Fetch all active users for assignment dropdown
   const users = await prisma.user.findMany({
     where: { status: 'active' },
-    select: { 
-      id: true, 
-      name: true, 
-      email: true, 
+    select: {
+      id: true,
+      name: true,
+      email: true,
       position: true,
       departmentId: true,
       department: { select: { id: true, name: true } }
@@ -59,6 +65,21 @@ export default async function NewTaskPage() {
     orderBy: { name: 'asc' },
   });
 
+  // Pre-populate from URL params (e.g., when continuing from quick task dialog)
+  const initialTask = (params.title || params.projectId || params.scopeOfWorkId || params.assignedToId)
+    ? {
+        id: '',
+        title: params.title || '',
+        description: null,
+        assignedToId: params.assignedToId || null,
+        projectId: params.projectId || null,
+        priority: params.priority || 'Medium',
+        status: 'Pending',
+        dueDate: params.dueDate || null,
+        scopeOfWorkId: params.scopeOfWorkId || null,
+      }
+    : undefined;
+
   return (
     <main className="min-h-screen bg-gradient-to-br from-background via-background to-muted/20">
       <div className="container mx-auto p-6 lg:p-8 max-w-3xl max-lg:pt-20">
@@ -69,7 +90,7 @@ export default async function NewTaskPage() {
           </p>
         </div>
 
-        <TaskForm users={users} projects={projects} buildings={buildings} departments={departments} />
+        <TaskForm users={users} projects={projects} buildings={buildings} departments={departments} task={initialTask} />
       </div>
     </main>
   );

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -23,6 +23,8 @@ interface UserPoints {
 }
 
 type UserOption = { id: string; name: string | null; email: string | null };
+type ProjectOption = { id: string; projectNumber: string; name: string };
+type ScopeOption = { id: string; scopeLabel: string };
 
 function QuickTaskDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
   const router = useRouter();
@@ -30,7 +32,11 @@ function QuickTaskDialog({ open, onClose }: { open: boolean; onClose: () => void
   const [priority, setPriority] = useState('Medium');
   const [dueDate, setDueDate] = useState('');
   const [assignedToId, setAssignedToId] = useState('');
+  const [projectId, setProjectId] = useState('');
+  const [scopeOfWorkId, setScopeOfWorkId] = useState('');
   const [users, setUsers] = useState<UserOption[]>([]);
+  const [projects, setProjects] = useState<ProjectOption[]>([]);
+  const [scopes, setScopes] = useState<ScopeOption[]>([]);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -44,10 +50,36 @@ function QuickTaskDialog({ open, onClose }: { open: boolean; onClose: () => void
     } catch { /* non-fatal */ }
   }, []);
 
-  useEffect(() => { if (open) loadUsers(); }, [open, loadUsers]);
+  const loadProjects = useCallback(async () => {
+    try {
+      const res = await fetch('/api/projects?status=Active&limit=200');
+      if (res.ok) {
+        const data = await res.json();
+        setProjects(data.projects ?? data ?? []);
+      }
+    } catch { /* non-fatal */ }
+  }, []);
+
+  useEffect(() => {
+    if (open) { loadUsers(); loadProjects(); }
+  }, [open, loadUsers, loadProjects]);
+
+  useEffect(() => {
+    if (!projectId) { setScopes([]); setScopeOfWorkId(''); return; }
+    fetch(`/api/scope-of-work?projectId=${projectId}`)
+      .then((r) => r.ok ? r.json() : { scopes: [] })
+      .then((data) => {
+        const s: ScopeOption[] = (data.scopes ?? []).map((sc: { id: string; scopeLabel: string }) => ({ id: sc.id, scopeLabel: sc.scopeLabel }));
+        setScopes(s);
+        if (s.length === 1) setScopeOfWorkId(s[0].id);
+        else setScopeOfWorkId('');
+      })
+      .catch(() => setScopes([]));
+  }, [projectId]);
 
   function reset() {
-    setTitle(''); setPriority('Medium'); setDueDate(''); setAssignedToId(''); setError(null);
+    setTitle(''); setPriority('Medium'); setDueDate(''); setAssignedToId('');
+    setProjectId(''); setScopeOfWorkId(''); setError(null);
   }
 
   async function handleSubmit(e: React.FormEvent) {
@@ -64,6 +96,8 @@ function QuickTaskDialog({ open, onClose }: { open: boolean; onClose: () => void
           priority,
           dueDate: dueDate || null,
           assignedToId: assignedToId || null,
+          projectId: projectId || null,
+          scopeOfWorkId: scopeOfWorkId || null,
           status: 'Pending',
         }),
       });
@@ -86,6 +120,8 @@ function QuickTaskDialog({ open, onClose }: { open: boolean; onClose: () => void
     if (priority) params.set('priority', priority);
     if (dueDate) params.set('dueDate', dueDate);
     if (assignedToId) params.set('assignedToId', assignedToId);
+    if (projectId) params.set('projectId', projectId);
+    if (scopeOfWorkId) params.set('scopeOfWorkId', scopeOfWorkId);
     reset();
     onClose();
     router.push(`/tasks/new?${params.toString()}`);
@@ -152,6 +188,37 @@ function QuickTaskDialog({ open, onClose }: { open: boolean; onClose: () => void
               ))}
             </select>
           </div>
+          <div>
+            <Label htmlFor="qt-project">Project <span className="text-muted-foreground text-xs">(optional)</span></Label>
+            <select
+              id="qt-project"
+              value={projectId}
+              onChange={(e) => setProjectId(e.target.value)}
+              className="w-full border rounded-md h-10 px-3 text-sm bg-white"
+            >
+              <option value="">No Project</option>
+              {projects.map((p) => (
+                <option key={p.id} value={p.id}>{p.projectNumber} — {p.name}</option>
+              ))}
+            </select>
+          </div>
+          {projectId && scopes.length > 0 && (
+            <div>
+              <Label htmlFor="qt-scope">Scope of Work</Label>
+              <select
+                id="qt-scope"
+                value={scopeOfWorkId}
+                onChange={(e) => setScopeOfWorkId(e.target.value)}
+                disabled={scopes.length === 1}
+                className="w-full border rounded-md h-10 px-3 text-sm bg-white"
+              >
+                <option value="">No Scope</option>
+                {scopes.map((s) => (
+                  <option key={s.id} value={s.id}>{s.scopeLabel}</option>
+                ))}
+              </select>
+            </div>
+          )}
           {error && (
             <p className="text-xs text-red-600 rounded border border-red-200 bg-red-50 px-3 py-2">{error}</p>
           )}

--- a/src/components/task-form.tsx
+++ b/src/components/task-form.tsx
@@ -100,14 +100,17 @@ export function TaskForm({ users, projects, buildings = [], departments = [], ta
 
   const subActivities = selectedMainActivity ? (SUB_ACTIVITIES[selectedMainActivity] ?? []) : [];
 
-  // Fetch scopes for the selected building
+  // Fetch scopes for the selected building, or project if no building selected
   useEffect(() => {
-    if (!selectedBuildingId) {
+    if (!selectedBuildingId && !selectedProjectId) {
       setAvailableScopes([]);
       setSelectedScopeId('');
       return;
     }
-    fetch(`/api/scope-of-work?buildingId=${selectedBuildingId}`)
+    const url = selectedBuildingId
+      ? `/api/scope-of-work?buildingId=${selectedBuildingId}`
+      : `/api/scope-of-work?projectId=${selectedProjectId}`;
+    fetch(url)
       .then((r) => r.ok ? r.json() : { scopes: [] })
       .then((json) => {
         const scopes: ScopeOption[] = (json.scopes ?? []).map((s: { id: string; scopeType: string; scopeLabel: string }) => ({
@@ -116,7 +119,6 @@ export function TaskForm({ users, projects, buildings = [], departments = [], ta
           scopeLabel: s.scopeLabel,
         }));
         setAvailableScopes(scopes);
-        // Auto-select steel if it's the only scope and no scope already selected
         if (scopes.length === 1) {
           setSelectedScopeId(scopes[0].id);
         } else if (!scopes.find((s) => s.id === selectedScopeId)) {
@@ -126,7 +128,7 @@ export function TaskForm({ users, projects, buildings = [], departments = [], ta
       })
       .catch(() => setAvailableScopes([]));
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedBuildingId]);
+  }, [selectedBuildingId, selectedProjectId]);
 
   const predecessorKey = selectedSubActivity ? SUB_ACTIVITY_DEPENDENCIES[selectedSubActivity] : undefined;
   const predecessorLabel = predecessorKey && selectedMainActivity
@@ -334,8 +336,8 @@ export function TaskForm({ users, projects, buildings = [], departments = [], ta
               )}
             </div>
 
-            {/* Scope of Work (shown when building is selected and scopes exist) */}
-            {selectedBuildingId && availableScopes.length > 0 && (
+            {/* Scope of Work (shown when project or building is selected and scopes exist) */}
+            {(selectedBuildingId || selectedProjectId) && availableScopes.length > 0 && (
               <div className="space-y-2">
                 <Label htmlFor="scopeOfWorkId">Scope of Work</Label>
                 <select


### PR DESCRIPTION
- Fix Select.Item empty-value crash in MIR create-receipt dialog
  (value="" caused React runtime error, crashing the form on PO select)
- PO lookup: show existing MIR receipt status next to each PO result;
  finalized POs (Inspected/Approved/Rejected) disable re-receipt;
  in-progress POs show a Resume button that opens the existing MIR
- Add DELETE /api/qc/material-receipts?id= (Admin & CEO only) with
  cascade delete; trash icon shown in MIR list for privileged roles
- MIR serial number: change to global non-resetting sequence
  (MIR-YYMM-NNNN format kept, but NNNN no longer resets each month);
  migration v30_0_mir_global_serial.sql renumbers all existing MIRs
  by creation date order
- Task full form: scope dropdown now appears when any project is selected
  (no longer requires building selection first)
- Task quick dialog: add Project + Scope of Work dropdowns; scope
  auto-loads when project selected; both fields submitted and passed
  as URL params when continuing to full form
- tasks/new page: read URL search params to pre-fill title, priority,
  due date, assigned user, project, and scope from quick task dialog

https://claude.ai/code/session_01PMrkt544fLYHwyw7usUJMK