### PR TITLE
fix: LCR column mapping persistence, sync filter, COGS account display

### DIFF
--- a/prisma/manual_migrations/add_lcr_min_project_number.sql
+++ b/prisma/manual_migrations/add_lcr_min_project_number.sql
@@ -1,0 +1,18 @@
+-- Add lcrMinProjectNumber to system_settings for LCR sync project number filter
+
+DROP PROCEDURE IF EXISTS add_lcr_min_project_number;
+DELIMITER $$
+CREATE PROCEDURE add_lcr_min_project_number()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'system_settings'
+      AND COLUMN_NAME = 'lcrMinProjectNumber'
+  ) THEN
+    ALTER TABLE system_settings ADD COLUMN lcrMinProjectNumber INT NULL;
+  END IF;
+END$$
+DELIMITER ;
+CALL add_lcr_min_project_number();
+DROP PROCEDURE IF EXISTS add_lcr_min_project_number;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2866,6 +2866,9 @@ model SystemSettings {
   // LCR Column Mapping (JSON, stores field key → 0-based column index)
   lcrColumnMapping Json?
 
+  // LCR Sync Filter — skip rows whose project number is below this value (null = sync all)
+  lcrMinProjectNumber Int?
+
   // IMS Logo (white version for dark/colored backgrounds)
   logoWhite String? @db.VarChar(500)
 

--- a/src/app/api/supply-chain/lcr/columns/route.ts
+++ b/src/app/api/supply-chain/lcr/columns/route.ts
@@ -3,15 +3,26 @@ import { z } from 'zod';
 import prisma from '@/lib/db';
 import { withApiContext } from '@/lib/api-utils';
 import { logger } from '@/lib/logger';
-import { DEFAULT_LCR_COL_MAP, loadColMap, type LcrColKey } from '@/lib/sync/lcrSync';
+import { DEFAULT_LCR_COL_MAP, loadColMap } from '@/lib/sync/lcrSync';
 
-const mappingSchema = z.record(z.string(), z.number().int().min(0).max(99));
+export const dynamic = 'force-dynamic';
+
+const mappingSchema = z.record(z.string(), z.number().int().min(0).max(499));
 
 export const GET = withApiContext(async (_req, _session) => {
   try {
-    // Use loadColMap which applies stale detection for wrong defaults
-    const mapping = await loadColMap();
-    return NextResponse.json({ mapping, defaults: DEFAULT_LCR_COL_MAP });
+    const [mapping, settings] = await Promise.all([
+      loadColMap(),
+      prisma.systemSettings.findFirst({
+        select: { lcrMinProjectNumber: true },
+        orderBy: { createdAt: 'asc' },
+      }),
+    ]);
+    return NextResponse.json({
+      mapping,
+      defaults: DEFAULT_LCR_COL_MAP,
+      minProjectNumber: settings?.lcrMinProjectNumber ?? null,
+    });
   } catch (error) {
     logger.error({ error }, 'Failed to fetch LCR column mapping');
     return NextResponse.json({ error: 'Failed to fetch mapping' }, { status: 500 });
@@ -24,22 +35,49 @@ export const PATCH = withApiContext(async (req: NextRequest, session) => {
   }
 
   const body = await req.json();
-  const parsed = mappingSchema.safeParse(body);
+
+  // Support both { mapping: {...}, minProjectNumber: N } and bare mapping objects
+  let rawMapping: unknown;
+  let minProjectNumber: number | null | undefined;
+
+  if (body && typeof body === 'object' && ('mapping' in body || 'minProjectNumber' in body)) {
+    rawMapping = body.mapping;
+    minProjectNumber = body.minProjectNumber;
+  } else {
+    rawMapping = body;
+  }
+
+  const parsed = mappingSchema.safeParse(rawMapping ?? {});
   if (!parsed.success) {
     return NextResponse.json({ error: 'Invalid mapping', details: parsed.error.flatten() }, { status: 400 });
   }
 
+  const minSchema = z.number().int().min(0).nullable().optional();
+  const parsedMin = minSchema.safeParse(minProjectNumber);
+  if (!parsedMin.success) {
+    return NextResponse.json({ error: 'Invalid minProjectNumber' }, { status: 400 });
+  }
+
   try {
-    let settings = await prisma.systemSettings.findFirst({ select: { id: true } });
+    let settings = await prisma.systemSettings.findFirst({
+      select: { id: true },
+      orderBy: { createdAt: 'asc' },
+    });
     if (!settings) {
       settings = await prisma.systemSettings.create({ data: {} });
     }
+
+    const updateData: Record<string, unknown> = { lcrColumnMapping: parsed.data };
+    if (parsedMin.data !== undefined) {
+      updateData.lcrMinProjectNumber = parsedMin.data ?? null;
+    }
+
     await prisma.systemSettings.update({
       where: { id: settings.id },
-      data: { lcrColumnMapping: parsed.data },
+      data: updateData,
     });
     logger.info({ updatedBy: session.userId }, 'LCR column mapping updated');
-    return NextResponse.json({ success: true, mapping: parsed.data });
+    return NextResponse.json({ success: true, mapping: parsed.data, minProjectNumber: parsedMin.data });
   } catch (error) {
     logger.error({ error }, 'Failed to save LCR column mapping');
     return NextResponse.json({ error: 'Failed to save mapping' }, { status: 500 });

--- a/src/app/supply-chain/lcr/columns/_page-client.tsx
+++ b/src/app/supply-chain/lcr/columns/_page-client.tsx
@@ -19,7 +19,9 @@ import {
   CommandItem,
   CommandList,
 } from '@/components/ui/command';
-import { ArrowLeft, Save, RotateCcw, Info, RefreshCw, Loader2, Wand2, ChevronsUpDown, Check } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { ArrowLeft, Save, RotateCcw, Info, RefreshCw, Loader2, Wand2, ChevronsUpDown, Check, Filter } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface ColumnHeader {
@@ -124,6 +126,10 @@ export default function LcrColumnMappingPage() {
   // In-progress selections (key → column letter like "A", "AB")
   const [selections, setSelections] = useState<Record<string, string>>({});
 
+  // Min project number filter
+  const [minProjectNumber, setMinProjectNumber]       = useState<string>('');
+  const [savedMinProjectNumber, setSavedMinProjectNumber] = useState<number | null>(null);
+
   // Google Sheet columns
   const [sheetColumns, setSheetColumns]     = useState<ColumnHeader[]>([]);
   const [loadingSheet, setLoadingSheet]     = useState(false);
@@ -136,7 +142,7 @@ export default function LcrColumnMappingPage() {
   const fetchMapping = useCallback(async () => {
     setLoadingMapping(true);
     try {
-      const res = await fetch('/api/supply-chain/lcr/columns');
+      const res = await fetch('/api/supply-chain/lcr/columns', { cache: 'no-store' });
       if (!res.ok) throw new Error('Failed to load mapping');
       const data = await res.json();
       setMapping(data.mapping);
@@ -146,6 +152,9 @@ export default function LcrColumnMappingPage() {
         init[k] = indexToLetter(v);
       }
       setSelections(init);
+      const savedMin = data.minProjectNumber ?? null;
+      setSavedMinProjectNumber(savedMin);
+      setMinProjectNumber(savedMin !== null ? String(savedMin) : '');
     } catch (error) {
       toast({ title: 'Failed to load mapping', description: String(error), variant: 'destructive' });
     } finally {
@@ -251,16 +260,22 @@ export default function LcrColumnMappingPage() {
       }
     }
 
+    const minVal = minProjectNumber.trim() === '' ? null : parseInt(minProjectNumber.trim(), 10);
+    if (minProjectNumber.trim() !== '' && (isNaN(minVal!) || minVal! < 0)) {
+      toast({ title: 'Invalid filter', description: 'Min project number must be a positive integer.', variant: 'destructive' });
+      return;
+    }
+
     setSaving(true);
     try {
       const res = await fetch('/api/supply-chain/lcr/columns', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
+        body: JSON.stringify({ mapping: payload, minProjectNumber: minVal }),
       });
       if (res.ok) {
         toast({
-          title: 'Mapping Saved',
+          title: 'Settings Saved',
           description: 'Run "Force Resync All" on the LCR page to re-process all rows with the new mapping.',
         });
         fetchMapping();
@@ -273,7 +288,13 @@ export default function LcrColumnMappingPage() {
     }
   };
 
-  const isDirty = Object.keys(FIELD_META).some(k => {
+  const minProjectNumberDirty = (() => {
+    const parsed = minProjectNumber.trim() === '' ? null : parseInt(minProjectNumber.trim(), 10);
+    if (minProjectNumber.trim() !== '' && isNaN(parsed!)) return false;
+    return parsed !== savedMinProjectNumber;
+  })();
+
+  const isDirty = minProjectNumberDirty || Object.keys(FIELD_META).some(k => {
     const col = sheetColumns.find(c => c.column === selections[k]);
     const currentIdx = col ? col.index : (mapping[k] ?? defaults[k]);
     return currentIdx !== (mapping[k] ?? defaults[k]);
@@ -314,6 +335,34 @@ export default function LcrColumnMappingPage() {
           </Button>
         </div>
       </div>
+
+      {/* Sync Filter */}
+      <Card>
+        <CardHeader className="py-3 pb-0">
+          <CardTitle className="text-sm font-semibold text-muted-foreground uppercase tracking-wide flex items-center gap-2">
+            <Filter className="size-3.5" /> Sync Filter
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="pt-3">
+          <div className="max-w-xs space-y-1">
+            <Label htmlFor="minProjectNumber" className="text-sm font-medium">
+              Minimum Project Number
+            </Label>
+            <Input
+              id="minProjectNumber"
+              type="number"
+              min={0}
+              placeholder="e.g. 230 (leave empty to sync all)"
+              value={minProjectNumber}
+              onChange={e => setMinProjectNumber(e.target.value)}
+              className="h-9 text-sm"
+            />
+            <p className="text-xs text-muted-foreground">
+              Only rows whose project number is ≥ this value will be synced. Leave empty to sync all projects.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
 
       {/* Sheet column fetch status */}
       <Card className={sheetError ? 'border-yellow-300 bg-yellow-50 dark:bg-yellow-950/20' : 'border-blue-200 bg-blue-50 dark:bg-blue-950/20 dark:border-blue-800'}>

--- a/src/lib/services/supply-chain/supplier-portal.service.ts
+++ b/src/lib/services/supply-chain/supplier-portal.service.ts
@@ -296,9 +296,9 @@ export async function getSupplierOverview(dolibarrId: number): Promise<SupplierO
       coa_ap_def.account_name AS ap_account_name,
       coa_ap_def.account_name_ar AS ap_account_name_ar,
       COALESCE(sc.cost_category, coa_cogs.account_name) AS cost_category,
-      sc.coa_account_code AS cogs_account_code,
-      coa_cogs.account_name AS cogs_account_name,
-      coa_cogs.account_name_ar AS cogs_account_name_ar
+      COALESCE(sc.coa_account_code, coa_legacy.coa_account_code) AS cogs_account_code,
+      COALESCE(coa_cogs.account_name, coa_legacy_def.account_name) AS cogs_account_name,
+      COALESCE(coa_cogs.account_name_ar, coa_legacy_def.account_name_ar) AS cogs_account_name_ar
     FROM dolibarr_thirdparties dt
     LEFT JOIN fin_chart_of_accounts coa_ap_def ON coa_ap_def.account_code = COALESCE(
       (SELECT config_value FROM fin_config WHERE config_key = 'default_ap_account' LIMIT 1),
@@ -306,6 +306,8 @@ export async function getSupplierOverview(dolibarrId: number): Promise<SupplierO
     )
     LEFT JOIN fin_supplier_classification sc ON sc.supplier_id = dt.dolibarr_id
     LEFT JOIN fin_chart_of_accounts coa_cogs ON coa_cogs.account_code = sc.coa_account_code
+    LEFT JOIN fin_supplier_coa_default coa_legacy ON coa_legacy.supplier_dolibarr_id = dt.dolibarr_id
+    LEFT JOIN fin_chart_of_accounts coa_legacy_def ON coa_legacy_def.account_code = coa_legacy.coa_account_code
     WHERE dt.dolibarr_id = ?
   `, dolibarrId);
 

--- a/src/lib/startup-migrations.ts
+++ b/src/lib/startup-migrations.ts
@@ -37,6 +37,7 @@ const STARTUP_MIGRATIONS = [
   'add_integration_toggles.sql',
   'add_lcr_column_mapping.sql',
   'add_lcr1_supplier_field.sql',
+  'add_lcr_min_project_number.sql',
   'add_credit_limit_to_thirdparties.sql',
   'add_is_locked_journal_entries.sql',
   'github_integration.sql',

--- a/src/lib/sync/lcrSync.ts
+++ b/src/lib/sync/lcrSync.ts
@@ -46,37 +46,14 @@ export const DEFAULT_LCR_COL_MAP = {
 
 export type LcrColKey = keyof typeof DEFAULT_LCR_COL_MAP;
 
-// Known stale LCR column patterns from previous wrong defaults.
-// If the saved mapping matches any of these, discard the LCR fields so new defaults take over.
-const STALE_LCR_PATTERNS = [
-  // Pre-17.24 gapped mapping
-  { LCR1: 24, LCR1_AMOUNT: 27 },
-  // Any mapping where LCR1 starts at 24 (wrong — groups start at 26)
-  { LCR1: 24 },
-  { LCR1_AMOUNT: 24 },
-  { PRICE_PER_TON_LCR1: 24 },
-  { LCR1: 24, LCR1_AMOUNT: 25 },
-  { LCR1_AMOUNT: 24, LCR1: 25 },
-];
-
-const LCR_FIELD_KEYS = [
-  'LCR1', 'LCR1_AMOUNT', 'PRICE_PER_TON_LCR1',
-  'LCR2', 'LCR2_AMOUNT', 'PRICE_PER_TON_LCR2',
-  'LCR3', 'LCR3_AMOUNT', 'PRICE_PER_TON_LCR3',
-];
-
 export async function loadColMap(): Promise<Record<LcrColKey, number>> {
   try {
-    const settings = await prisma.systemSettings.findFirst({ select: { lcrColumnMapping: true } });
+    const settings = await prisma.systemSettings.findFirst({
+      select: { lcrColumnMapping: true },
+      orderBy: { createdAt: 'asc' },
+    });
     if (settings?.lcrColumnMapping && typeof settings.lcrColumnMapping === 'object') {
-      const saved = { ...(settings.lcrColumnMapping as Record<string, number>) };
-      // Detect stale LCR columns from previous wrong defaults and discard them
-      const isStale = STALE_LCR_PATTERNS.some(
-        p => Object.entries(p).every(([k, v]) => saved[k] === v)
-      );
-      if (isStale) {
-        for (const key of LCR_FIELD_KEYS) delete saved[key];
-      }
+      const saved = settings.lcrColumnMapping as Record<string, number>;
       // Merge saved values over defaults so new fields added later still work
       return { ...DEFAULT_LCR_COL_MAP, ...saved } as Record<LcrColKey, number>;
     }
@@ -84,6 +61,18 @@ export async function loadColMap(): Promise<Record<LcrColKey, number>> {
     // DB not yet migrated — use defaults silently
   }
   return { ...DEFAULT_LCR_COL_MAP };
+}
+
+async function loadMinProjectNumber(): Promise<number | null> {
+  try {
+    const settings = await prisma.systemSettings.findFirst({
+      select: { lcrMinProjectNumber: true },
+      orderBy: { createdAt: 'asc' },
+    });
+    return settings?.lcrMinProjectNumber ?? null;
+  } catch {
+    return null;
+  }
 }
 
 function parseDate(value: string | undefined | null): Date | null {
@@ -283,8 +272,9 @@ export async function runLcrSync(triggeredBy: 'cron' | 'manual', forceRefresh = 
   let pendingAliases = 0;
 
   try {
-    // 0. Load column mapping from DB (falls back to defaults if not configured)
+    // 0. Load column mapping and settings from DB
     const col = await loadColMap();
+    const minProjectNumber = await loadMinProjectNumber();
 
     // 1. Authenticate with Google Sheets
     const keyJson = process.env.GOOGLE_SHEETS_KEY_JSON;
@@ -324,15 +314,31 @@ export async function runLcrSync(triggeredBy: 'cron' | 'manual', forceRefresh = 
 
     // 3. Compute sheetRowId + rowHash for each row
     const sheetData = new Map<string, { hash: string; cells: string[] }>();
+    const filteredOutRowIds = new Set<string>(); // rows skipped by project filter (keep existing DB records)
+    let skippedByFilter = 0;
     for (let i = 0; i < dataRows.length; i++) {
       const cells = dataRows[i].map((c: unknown) => String(c ?? ''));
       const rowNumber = String(i + 2); // 1-indexed, skip header
-      const hash = createHash('md5').update(cells.join('|')).digest('hex');
 
       // Skip completely empty rows
       if (cells.every((c: string) => c.trim() === '')) continue;
 
+      // Apply project number minimum filter if configured
+      if (minProjectNumber !== null) {
+        const projectNumRaw = cells[col.PROJECT_NUMBER]?.trim() ?? '';
+        const projectNum = parseInt(projectNumRaw, 10);
+        if (!isNaN(projectNum) && projectNum < minProjectNumber) {
+          filteredOutRowIds.add(rowNumber);
+          skippedByFilter++;
+          continue;
+        }
+      }
+
+      const hash = createHash('md5').update(cells.join('|')).digest('hex');
       sheetData.set(rowNumber, { hash, cells });
+    }
+    if (skippedByFilter > 0) {
+      log.info({ skippedByFilter, minProjectNumber }, 'Rows skipped by project number filter');
     }
 
     // 4. Load existing non-deleted entries
@@ -359,7 +365,7 @@ export async function runLcrSync(triggeredBy: 'cron' | 'manual', forceRefresh = 
     }
 
     for (const [rowId, { id }] of existingMap) {
-      if (!sheetData.has(rowId)) {
+      if (!sheetData.has(rowId) && !filteredOutRowIds.has(rowId)) {
         toSoftDelete.push(id);
       }
     }


### PR DESCRIPTION
1. LCR column mapping save not persisting
   - Remove overly aggressive stale detection from loadColMap() that could
     strip user-saved LCR column values (any LCR field at col index 24)
   - Add `orderBy: { createdAt: 'asc' }` to all SystemSettings.findFirst()
     calls to prevent non-determinism when multiple rows exist
   - Add `export const dynamic = 'force-dynamic'` to the GET columns route
   - Add `cache: 'no-store'` to the fetchMapping browser fetch
   - Raise Zod max column index from 99 → 499 (supports larger sheets)

2. LCR sync min project number filter
   - Add `lcrMinProjectNumber Int?` to SystemSettings schema
   - Add migration: add_lcr_min_project_number.sql
   - In runLcrSync(): skip rows where project number < minProjectNumber
   - Filtered-out rows are excluded from soft-delete (preserve existing data)
   - Columns setup page: add Sync Filter card with min project number input
   - PATCH endpoint: unified envelope {mapping, minProjectNumber} + GET returns minProjectNumber

3. Supplier portal COGS account not showing
   - getSupplierOverview(): COALESCE(sc.coa_account_code, coa_legacy.coa_account_code)
     Falls back to fin_supplier_coa_default when fin_supplier_classification has
     no COGS code — restores the account code that was previously visible before
     the AP account was fixed to use the global fin_config default

https://claude.ai/code/session_014BXWDNno13uCdw7BMxMAKy