### PR TITLE
Add filtering, sorting, and category support to procurement report

### DIFF
--- a/src/app/api/financial/reports/procurement-by-product/route.ts
+++ b/src/app/api/financial/reports/procurement-by-product/route.ts
@@ -12,65 +12,94 @@ export async function GET(req: Request) {
   const from = searchParams.get('from');
   const to = searchParams.get('to');
   const exportFormat = searchParams.get('export');
+  const category = searchParams.get('category') || '';
 
   const fromDate = from || new Date(new Date().getFullYear(), 0, 1).toISOString().slice(0, 10);
   const toDate = to || new Date().toISOString().slice(0, 10);
 
   try {
+    const categoryFilter = category ? `AND COALESCE(coa.account_category, 'Other / Unclassified') = ?` : '';
+    const queryParams: (string | number)[] = category
+      ? [fromDate, toDate, category]
+      : [fromDate, toDate];
+
     const rows: {
       product_ref: string;
       product_label: string | null;
       coa_code: string | null;
       coa_label: string | null;
+      coa_category: string | null;
       total_qty: number;
       total_amount: number;
     }[] = await prisma.$queryRawUnsafe(`
       SELECT
         sil.product_ref,
-        MIN(sil.product_label)                                                       AS product_label,
-        COALESCE(dam.dolibarr_account_code, sil.accounting_code, '')                 AS coa_code,
-        COALESCE(dam.dolibarr_account_label, dam.ots_cost_category, sil.accounting_code, 'Unknown Account') AS coa_label,
-        SUM(sil.qty)                                                                 AS total_qty,
-        SUM(sil.total_ht)                                                            AS total_amount
+        MIN(sil.product_label)                                          AS product_label,
+        COALESCE(pm.coa_account_code, '')                               AS coa_code,
+        COALESCE(coa.account_name, 'Other / Unclassified')             AS coa_label,
+        COALESCE(coa.account_category, 'Other / Unclassified')         AS coa_category,
+        SUM(sil.qty)                                                    AS total_qty,
+        SUM(sil.total_ht)                                               AS total_amount
       FROM fin_supplier_invoice_lines sil
       JOIN fin_supplier_invoices si ON si.dolibarr_id = sil.invoice_dolibarr_id
-      LEFT JOIN fin_dolibarr_account_mapping dam ON dam.dolibarr_account_id = sil.accounting_code
+      LEFT JOIN fin_product_coa_mapping pm ON pm.dolibarr_product_id = sil.fk_product
+      LEFT JOIN fin_chart_of_accounts coa ON coa.account_code = pm.coa_account_code
       WHERE si.is_active = 1
         AND si.status >= 1
         AND si.date_invoice BETWEEN ? AND ?
         AND sil.product_ref IS NOT NULL
         AND sil.product_ref != ''
-      GROUP BY sil.product_ref, sil.accounting_code, dam.dolibarr_account_code, dam.dolibarr_account_label, dam.ots_cost_category
+        ${categoryFilter}
+      GROUP BY sil.product_ref, pm.coa_account_code, coa.account_name, coa.account_category
       ORDER BY SUM(sil.total_ht) DESC
+    `, ...queryParams);
+
+    // Fetch available categories for filter dropdown (unfiltered)
+    const categoryRows: { coa_category: string }[] = await prisma.$queryRawUnsafe(`
+      SELECT DISTINCT
+        COALESCE(coa.account_category, 'Other / Unclassified') AS coa_category
+      FROM fin_supplier_invoice_lines sil
+      JOIN fin_supplier_invoices si ON si.dolibarr_id = sil.invoice_dolibarr_id
+      LEFT JOIN fin_product_coa_mapping pm ON pm.dolibarr_product_id = sil.fk_product
+      LEFT JOIN fin_chart_of_accounts coa ON coa.account_code = pm.coa_account_code
+      WHERE si.is_active = 1
+        AND si.status >= 1
+        AND si.date_invoice BETWEEN ? AND ?
+        AND sil.product_ref IS NOT NULL
+        AND sil.product_ref != ''
+      ORDER BY coa_category
     `, fromDate, toDate);
 
     const products = rows.map((r) => ({
       productRef: r.product_ref,
       productLabel: r.product_label || r.product_ref,
       coaCode: r.coa_code || '—',
-      coaLabel: r.coa_label || 'Unknown Account',
+      coaLabel: r.coa_label || 'Other / Unclassified',
+      coaCategory: r.coa_category || 'Other / Unclassified',
       totalQty: Number(r.total_qty),
       totalAmount: Number(r.total_amount),
     }));
 
     const totalAmount = products.reduce((s, p) => s + p.totalAmount, 0);
     const totalQty = products.reduce((s, p) => s + p.totalQty, 0);
+    const categories = categoryRows.map((c) => c.coa_category).filter(Boolean);
 
     if (exportFormat === 'excel') {
       let csv = '﻿';
       csv += `Procurement by Product,${fromDate} to ${toDate}\n`;
-      csv += 'Product Ref,Product Description,COA Code,COA Account Name,Total Qty,Total Amount (SAR)\n';
+      csv += 'Product Ref,Product Description,COA Code,COA Account Name,COA Category,Total Qty,Total Amount (SAR)\n';
       for (const p of products) {
         csv += [
           `"${p.productRef}"`,
           `"${p.productLabel}"`,
           `"${p.coaCode}"`,
           `"${p.coaLabel}"`,
+          `"${p.coaCategory}"`,
           p.totalQty.toFixed(4),
           p.totalAmount.toFixed(2),
         ].join(',') + '\n';
       }
-      csv += `,,,,${totalQty.toFixed(4)},${totalAmount.toFixed(2)}\n`;
+      csv += `,,,,,${totalQty.toFixed(4)},${totalAmount.toFixed(2)}\n`;
 
       return new NextResponse(csv, {
         headers: {
@@ -84,6 +113,7 @@ export async function GET(req: Request) {
       from: fromDate,
       to: toDate,
       products,
+      categories,
       summary: {
         productCount: products.length,
         totalAmount,

--- a/src/app/financial/reports/procurement-by-product/_page-client.tsx
+++ b/src/app/financial/reports/procurement-by-product/_page-client.tsx
@@ -1,12 +1,15 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from '@/components/ui/select';
+import {
   ArrowLeft, Loader2, FileSpreadsheet, FileText, ShoppingCart,
-  Package, DollarSign, Hash,
+  Package, DollarSign, Hash, Search, ArrowUpDown, ArrowUp, ArrowDown,
 } from 'lucide-react';
 import Link from 'next/link';
 
@@ -17,6 +20,7 @@ interface ProductRow {
   productLabel: string;
   coaCode: string;
   coaLabel: string;
+  coaCategory: string;
   totalQty: number;
   totalAmount: number;
 }
@@ -25,12 +29,16 @@ interface ReportData {
   from: string;
   to: string;
   products: ProductRow[];
+  categories: string[];
   summary: {
     productCount: number;
     totalAmount: number;
     totalQty: number;
   };
 }
+
+type SortField = 'productRef' | 'productLabel' | 'coaCode' | 'coaLabel' | 'coaCategory' | 'totalQty' | 'totalAmount';
+type SortDir = 'asc' | 'desc';
 
 // ── Formatters ────────────────────────────────────────────────────────────────
 
@@ -97,6 +105,45 @@ function KpiCard({
   );
 }
 
+// ── Sort Icon ─────────────────────────────────────────────────────────────────
+
+function SortIcon({ field, sortField, sortDir }: { field: SortField; sortField: SortField; sortDir: SortDir }) {
+  if (field !== sortField) return <ArrowUpDown className="h-3 w-3 ml-1 opacity-40" />;
+  return sortDir === 'asc'
+    ? <ArrowUp className="h-3 w-3 ml-1 text-indigo-600" />
+    : <ArrowDown className="h-3 w-3 ml-1 text-indigo-600" />;
+}
+
+// ── Logo loader for PDF ───────────────────────────────────────────────────────
+
+async function loadLogoForPDF() {
+  try {
+    const res = await fetch('/api/settings');
+    if (!res.ok) return undefined;
+    const data = await res.json();
+    const logoPath: string | undefined = data.logoWhite || data.companyLogo;
+    if (!logoPath) return undefined;
+
+    const imgRes = await fetch(logoPath);
+    if (!imgRes.ok) return undefined;
+    const blob = await imgRes.blob();
+    const base64 = await new Promise<string>((resolve) => {
+      const reader = new FileReader();
+      reader.onloadend = () => resolve(reader.result as string);
+      reader.readAsDataURL(blob);
+    });
+    const aspectRatio = await new Promise<number>((resolve) => {
+      const img = new Image();
+      img.onload = () => resolve(img.naturalWidth / img.naturalHeight || 1);
+      img.onerror = () => resolve(1);
+      img.src = base64;
+    });
+    return { base64, aspectRatio, isWhite: !!data.logoWhite };
+  } catch {
+    return undefined;
+  }
+}
+
 // ── Main Page ─────────────────────────────────────────────────────────────────
 
 export default function ProcurementByProductPage() {
@@ -110,12 +157,20 @@ export default function ProcurementByProductPage() {
   const [error, setError] = useState('');
   const [exportingPdf, setExportingPdf] = useState(false);
 
+  // Filters & sort
+  const [search, setSearch] = useState('');
+  const [categoryFilter, setCategoryFilter] = useState('__all__');
+  const [sortField, setSortField] = useState<SortField>('totalAmount');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
+
   const buildParams = () => new URLSearchParams({ from: fromDate, to: toDate });
 
   const handleGenerate = async () => {
     setLoading(true);
     setError('');
     setReport(null);
+    setSearch('');
+    setCategoryFilter('__all__');
     try {
       const res = await fetch(`/api/financial/reports/procurement-by-product?${buildParams()}`);
       const data = await res.json();
@@ -128,9 +183,63 @@ export default function ProcurementByProductPage() {
     }
   };
 
+  const handleSort = (field: SortField) => {
+    if (field === sortField) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortField(field);
+      setSortDir('desc');
+    }
+  };
+
+  // Client-side filter + sort
+  const filteredProducts = useMemo(() => {
+    if (!report) return [];
+    let rows = report.products;
+
+    if (categoryFilter !== '__all__') {
+      rows = rows.filter((p) => p.coaCategory === categoryFilter);
+    }
+
+    const q = search.trim().toLowerCase();
+    if (q) {
+      rows = rows.filter(
+        (p) =>
+          p.productRef.toLowerCase().includes(q) ||
+          p.productLabel.toLowerCase().includes(q) ||
+          p.coaCode.toLowerCase().includes(q) ||
+          p.coaLabel.toLowerCase().includes(q) ||
+          p.coaCategory.toLowerCase().includes(q),
+      );
+    }
+
+    rows = [...rows].sort((a, b) => {
+      const aVal = a[sortField];
+      const bVal = b[sortField];
+      if (typeof aVal === 'number' && typeof bVal === 'number') {
+        return sortDir === 'asc' ? aVal - bVal : bVal - aVal;
+      }
+      return sortDir === 'asc'
+        ? String(aVal).localeCompare(String(bVal))
+        : String(bVal).localeCompare(String(aVal));
+    });
+
+    return rows;
+  }, [report, search, categoryFilter, sortField, sortDir]);
+
+  const filteredTotal = useMemo(
+    () => filteredProducts.reduce((s, p) => s + p.totalAmount, 0),
+    [filteredProducts],
+  );
+  const filteredQty = useMemo(
+    () => filteredProducts.reduce((s, p) => s + p.totalQty, 0),
+    [filteredProducts],
+  );
+
   const exportExcel = async () => {
     const params = buildParams();
     params.set('export', 'excel');
+    if (categoryFilter !== '__all__') params.set('category', categoryFilter);
     const res = await fetch(`/api/financial/reports/procurement-by-product?${params}`);
     const blob = await res.blob();
     const url = URL.createObjectURL(blob);
@@ -148,37 +257,41 @@ export default function ProcurementByProductPage() {
     setExportingPdf(true);
     try {
       const { PDFReportBuilder } = await import('@/lib/pdf-builder');
-      const pdf = new PDFReportBuilder('landscape', 'blue');
+      const logo = await loadLogoForPDF();
+      const pdf = new PDFReportBuilder('landscape', 'steel');
 
-      pdf.addHeader(
-        'Hexa Steel®',
-        'Financial Reports — Procurement by Product',
-      );
+      pdf.addHeader('Hexa Steel®', 'Financial Reports — Procurement by Product', logo);
 
       pdf.addTitle(
         'Procurement by Product',
         `Period: ${formatDate(report.from)} — ${formatDate(report.to)}`,
       );
 
-      pdf.addMetadataBox({
+      const metaEntries: Record<string, string> = {
         'From': formatDate(report.from),
         'To': formatDate(report.to),
-        'Products': String(report.summary.productCount),
-        'Total Amount': formatSAR(report.summary.totalAmount),
+        'Products': String(filteredProducts.length),
+        'Total Amount': formatSAR(filteredTotal),
         'Generated': new Date().toLocaleDateString('en-SA-u-ca-gregory', {
           day: '2-digit', month: 'short', year: 'numeric',
         }),
-      });
+      };
+      if (categoryFilter !== '__all__') {
+        metaEntries['Category'] = categoryFilter;
+      }
+
+      pdf.addMetadataBox(metaEntries);
 
       pdf.addSectionHeader('Product Procurement Summary');
 
       pdf.addTable(
-        ['Product Ref', 'Product Description', 'COA Code', 'COA Account Name', 'Total Qty', 'Total Amount (SAR)'],
-        report.products.map((p) => [
+        ['Product Ref', 'Product Description', 'COA Code', 'COA Account Name', 'Category', 'Total Qty', 'Total Amount (SAR)'],
+        filteredProducts.map((p) => [
           p.productRef,
           p.productLabel,
           p.coaCode,
           p.coaLabel,
+          p.coaCategory,
           formatQty(p.totalQty),
           formatSAR(p.totalAmount),
         ]),
@@ -187,8 +300,8 @@ export default function ProcurementByProductPage() {
 
       pdf.addSectionHeader('Summary');
       pdf.addInfoGrid({
-        'Total Products': String(report.summary.productCount),
-        'Total Amount': formatSAR(report.summary.totalAmount),
+        'Total Products': String(filteredProducts.length),
+        'Total Amount': formatSAR(filteredTotal),
       }, 2);
 
       pdf.addFooter('Hexa Steel® OTS · Financial Reports · hexasteel.sa/ots');
@@ -197,6 +310,18 @@ export default function ProcurementByProductPage() {
       setExportingPdf(false);
     }
   };
+
+  const thBtn = (field: SortField, label: string, align: 'left' | 'right' = 'left', cls = '') => (
+    <th
+      className={`py-2.5 px-3 font-semibold text-slate-700 cursor-pointer select-none hover:bg-slate-100 transition-colors ${cls}`}
+      onClick={() => handleSort(field)}
+    >
+      <span className={`inline-flex items-center ${align === 'right' ? 'justify-end w-full' : ''}`}>
+        {label}
+        <SortIcon field={field} sortField={sortField} sortDir={sortDir} />
+      </span>
+    </th>
+  );
 
   return (
     <div className="min-h-screen bg-slate-50">
@@ -269,21 +394,21 @@ export default function ProcurementByProductPage() {
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
               <KpiCard
                 label="Products Purchased"
-                value={String(report.summary.productCount)}
-                sub="unique product references"
+                value={String(filteredProducts.length)}
+                sub={filteredProducts.length !== report.summary.productCount ? `of ${report.summary.productCount} total` : 'unique product references'}
                 icon={Package}
                 color="blue"
               />
               <KpiCard
                 label="Total Quantity"
-                value={formatQty(report.summary.totalQty)}
-                sub="combined units across all products"
+                value={formatQty(filteredQty)}
+                sub="combined units across filtered products"
                 icon={Hash}
                 color="amber"
               />
               <KpiCard
                 label="Total Amount"
-                value={`SAR ${compact(report.summary.totalAmount)}`}
+                value={`SAR ${compact(filteredTotal)}`}
                 sub={`${formatDate(report.from)} — ${formatDate(report.to)}`}
                 icon={DollarSign}
                 color="green"
@@ -298,15 +423,11 @@ export default function ProcurementByProductPage() {
                     <FileSpreadsheet className="h-5 w-5 text-blue-600" />
                     Product Procurement — {formatDate(report.from)} to {formatDate(report.to)}
                     <span className="text-sm font-normal text-muted-foreground">
-                      ({report.summary.productCount} products)
+                      ({filteredProducts.length} products)
                     </span>
                   </CardTitle>
                   <div className="flex gap-2">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={exportExcel}
-                    >
+                    <Button variant="outline" size="sm" onClick={exportExcel}>
                       <FileSpreadsheet className="h-4 w-4 mr-2 text-emerald-600" />
                       Export Excel
                     </Button>
@@ -323,29 +444,58 @@ export default function ProcurementByProductPage() {
                     </Button>
                   </div>
                 </div>
+
+                {/* Search + Category filter */}
+                <div className="flex flex-wrap gap-3 pt-2">
+                  <div className="relative flex-1 min-w-[200px]">
+                    <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400" />
+                    <Input
+                      placeholder="Search by product ref, description, or account…"
+                      className="pl-9"
+                      value={search}
+                      onChange={(e) => setSearch(e.target.value)}
+                    />
+                  </div>
+                  {report.categories.length > 0 && (
+                    <Select value={categoryFilter} onValueChange={setCategoryFilter}>
+                      <SelectTrigger className="w-[220px]">
+                        <SelectValue placeholder="All categories" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="__all__">All categories</SelectItem>
+                        {report.categories.map((cat) => (
+                          <SelectItem key={cat} value={cat}>{cat}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  )}
+                </div>
               </CardHeader>
               <CardContent>
-                {report.products.length === 0 ? (
+                {filteredProducts.length === 0 ? (
                   <p className="text-center text-muted-foreground py-12">
-                    No procurement data found for this period.
+                    {report.products.length === 0
+                      ? 'No procurement data found for this period.'
+                      : 'No products match the current filters.'}
                   </p>
                 ) : (
                   <div className="overflow-x-auto">
                     <table className="w-full text-sm border-collapse">
                       <thead>
                         <tr className="border-b-2 bg-slate-50">
-                          <th className="text-left py-2.5 px-3 font-semibold text-slate-700 w-[140px]">Product Ref</th>
-                          <th className="text-left py-2.5 px-3 font-semibold text-slate-700">Product Description</th>
-                          <th className="text-left py-2.5 px-3 font-semibold text-slate-700 w-[110px]">COA Code</th>
-                          <th className="text-left py-2.5 px-3 font-semibold text-slate-700">COA Account Name</th>
-                          <th className="text-right py-2.5 px-3 font-semibold text-slate-700 w-[110px]">Total Qty</th>
-                          <th className="text-right py-2.5 px-3 font-semibold text-slate-700 w-[150px]">Total Amount</th>
+                          {thBtn('productRef', 'Product Ref', 'left', 'w-[140px]')}
+                          {thBtn('productLabel', 'Product Description')}
+                          {thBtn('coaCode', 'COA Code', 'left', 'w-[110px]')}
+                          {thBtn('coaLabel', 'COA Account Name')}
+                          {thBtn('coaCategory', 'Category', 'left', 'w-[180px]')}
+                          {thBtn('totalQty', 'Total Qty', 'right', 'w-[110px]')}
+                          {thBtn('totalAmount', 'Total Amount', 'right', 'w-[150px]')}
                         </tr>
                       </thead>
                       <tbody>
-                        {report.products.map((p, idx) => (
+                        {filteredProducts.map((p, idx) => (
                           <tr
-                            key={`${p.productRef}-${p.coaCode}`}
+                            key={`${p.productRef}-${p.coaCode}-${idx}`}
                             className={`border-b transition-colors hover:bg-slate-50 ${idx % 2 === 0 ? 'bg-white' : 'bg-slate-50/50'}`}
                           >
                             <td className="py-2 px-3 font-mono text-xs font-semibold text-slate-700 whitespace-nowrap">
@@ -357,8 +507,13 @@ export default function ProcurementByProductPage() {
                             <td className="py-2 px-3 font-mono text-xs text-indigo-700 font-semibold whitespace-nowrap">
                               {p.coaCode}
                             </td>
-                            <td className="py-2 px-3 text-slate-600 text-xs max-w-[240px] truncate" title={p.coaLabel}>
+                            <td className="py-2 px-3 text-slate-600 text-xs max-w-[200px] truncate" title={p.coaLabel}>
                               {p.coaLabel}
+                            </td>
+                            <td className="py-2 px-3 text-xs max-w-[180px] truncate" title={p.coaCategory}>
+                              <span className="inline-block rounded px-1.5 py-0.5 bg-slate-100 text-slate-600 font-medium">
+                                {p.coaCategory}
+                              </span>
                             </td>
                             <td className="py-2 px-3 text-right font-mono text-xs text-slate-700 whitespace-nowrap">
                               {formatQty(p.totalQty)}
@@ -371,14 +526,14 @@ export default function ProcurementByProductPage() {
                       </tbody>
                       <tfoot>
                         <tr className="border-t-2 bg-slate-100 font-bold">
-                          <td className="py-2.5 px-3 text-slate-700" colSpan={4}>
-                            TOTAL
+                          <td className="py-2.5 px-3 text-slate-700" colSpan={5}>
+                            TOTAL {filteredProducts.length !== report.summary.productCount && `(filtered: ${filteredProducts.length} of ${report.summary.productCount})`}
                           </td>
                           <td className="py-2.5 px-3 text-right font-mono text-xs text-slate-700">
-                            {formatQty(report.summary.totalQty)}
+                            {formatQty(filteredQty)}
                           </td>
                           <td className="py-2.5 px-3 text-right font-mono text-xs text-emerald-800 bg-emerald-50">
-                            {formatSAR(report.summary.totalAmount)}
+                            {formatSAR(filteredTotal)}
                           </td>
                         </tr>
                       </tfoot>


### PR DESCRIPTION
## Summary
Enhanced the Procurement by Product financial report with client-side filtering, column sorting, and category-based organization. Users can now search across product references, descriptions, and account details, filter by COA category, and sort by any column. The report also now displays and exports category information.

## Key Changes

**Frontend (`_page-client.tsx`)**
- Added `useMemo`-based client-side filtering and sorting with real-time KPI updates
- Implemented search functionality across product ref, label, COA code/label, and category
- Added category dropdown filter (populated from report data)
- Made all table columns sortable with visual indicators (arrow icons)
- Updated KPI cards to reflect filtered results (with "of X total" notation when filtered)
- Added `coaCategory` field to `ProductRow` interface and display in table with styled badge
- Enhanced PDF export to include category column and respect active filters
- Added `loadLogoForPDF()` helper to fetch and embed company logo in PDF reports
- Changed PDF theme from 'blue' to 'steel' for better visual consistency

**Backend (`route.ts`)**
- Updated SQL query to join `fin_product_coa_mapping` and `fin_chart_of_accounts` tables instead of deprecated `fin_dolibarr_account_mapping`
- Added `account_category` field to query results with fallback to 'Other / Unclassified'
- Implemented server-side category filtering via `category` query parameter
- Added separate query to fetch all available categories for the filter dropdown
- Updated CSV export to include category column
- Added `categories` array to JSON response for populating filter UI

## Notable Implementation Details

- Filtering and sorting are performed client-side using `useMemo` to avoid unnecessary re-renders
- Filtered totals (quantity and amount) are computed separately and displayed in KPIs and table footer
- When filters are active, the table footer shows "TOTAL (filtered: X of Y)" notation
- Category filter respects the Excel export (passes category param to API)
- All date formatting uses `'en-SA-u-ca-gregory'` per project conventions
- Sort state persists across filter changes; filters reset when generating a new report

https://claude.ai/code/session_01G1MSdzTA9Y4sj32NteRjYs