### PR TITLE
Add server-side supplier search with debouncing

### DIFF
--- a/src/app/supply-chain/subcontractors/new/_page-client.tsx
+++ b/src/app/supply-chain/subcontractors/new/_page-client.tsx
@@ -79,8 +79,10 @@ export default function NewSubcontractorContractPage() {
     }
   }, []);
 
-  const fetchSuppliers = useCallback(async () => {
-    const res = await fetch('/api/supply-chain/suppliers?limit=200');
+  const fetchSuppliers = useCallback(async (search: string) => {
+    const params = new URLSearchParams({ limit: '100' });
+    if (search) params.set('search', search);
+    const res = await fetch(`/api/supply-chain/suppliers?${params}`);
     if (res.ok) {
       const data = await res.json();
       setSuppliers(Array.isArray(data.suppliers) ? data.suppliers : []);
@@ -93,7 +95,12 @@ export default function NewSubcontractorContractPage() {
     if (res.ok) setBuildings(await res.json());
   }, [selectedProject]);
 
-  useEffect(() => { fetchProjects(); fetchSuppliers(); }, [fetchProjects, fetchSuppliers]);
+  useEffect(() => { fetchProjects(); fetchSuppliers(''); }, [fetchProjects, fetchSuppliers]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => { fetchSuppliers(supplierSearch); }, 300);
+    return () => clearTimeout(timer);
+  }, [supplierSearch, fetchSuppliers]);
   useEffect(() => { if (selectedProject) fetchBuildings(); }, [selectedProject, fetchBuildings]);
 
   useEffect(() => {
@@ -352,14 +359,6 @@ export default function NewSubcontractorContractPage() {
                         <CommandEmpty>No subcontractors found.</CommandEmpty>
                         <CommandGroup>
                           {suppliers
-                            .filter(s => {
-                              if (!supplierSearch) return true;
-                              const q = supplierSearch.toLowerCase();
-                              return (
-                                s.name.toLowerCase().includes(q) ||
-                                (s.code_supplier ?? '').toLowerCase().includes(q)
-                              );
-                            })
                             .map(s => (
                               <CommandItem
                                 key={s.dolibarr_id}

--- a/src/lib/services/supply-chain/supplier-portal.service.ts
+++ b/src/lib/services/supply-chain/supplier-portal.service.ts
@@ -201,8 +201,8 @@ export async function getSupplierList(
   sortDir: 'asc' | 'desc' = 'asc',
 ): Promise<{ suppliers: SupplierListRow[]; total: number }> {
   const offset = (page - 1) * limit;
-  const searchFilter = search ? `AND dt.name LIKE ?` : '';
-  const searchArgs = search ? [`%${search}%`] : [];
+  const searchFilter = search ? `AND (dt.name LIKE ? OR dt.code_supplier LIKE ?)` : '';
+  const searchArgs = search ? [`%${search}%`, `%${search}%`] : [];
   const col = SORT_COL_MAP[sortKey] ?? 'dt.name';
   const dir = sortDir === 'desc' ? 'DESC' : 'ASC';
   const orderClause = `ORDER BY (${col} IS NULL) ASC, ${col} ${dir}, dt.name ASC`;


### PR DESCRIPTION
## Summary
Moved supplier filtering from client-side to server-side API, implementing debounced search that queries both supplier name and code fields. This improves performance for large datasets and provides more consistent search behavior.

## Key Changes
- **Backend (`supplier-portal.service.ts`)**: Enhanced `getSupplierList()` search filter to match against both `dt.name` and `dt.code_supplier` fields using OR logic
- **Frontend (`_page-client.tsx`)**:
  - Modified `fetchSuppliers()` to accept a `search` parameter and pass it to the API via URLSearchParams
  - Reduced API limit from 200 to 100 (server-side pagination now handles filtering)
  - Added debounced search effect (300ms) that triggers `fetchSuppliers()` when `supplierSearch` state changes
  - Removed client-side filter logic from the suppliers list rendering, relying on server-filtered results instead
  - Updated initial fetch to pass empty string to `fetchSuppliers()`

## Implementation Details
- Debouncing prevents excessive API calls during rapid user input
- Server-side search is more efficient and scalable than filtering 200+ items in the browser
- Search now covers both supplier name and code, matching backend capability
- Cleanup function properly cancels pending timers to avoid state updates on unmounted components

https://claude.ai/code/session_01RHv36h4hTbLgFL7G7uS1Au