### PR TITLE
feat(qc): MIR workflow notifications + shipment evaluation bank (v32.0.0)

### DIFF
--- a/prisma/manual_migrations/v32_0_mir_workflow_and_evaluation.sql
+++ b/prisma/manual_migrations/v32_0_mir_workflow_and_evaluation.sql
@@ -1,0 +1,140 @@
+-- v32.0.0 — MIR Workflow Notifications + Shipment Evaluation Bank
+-- Part A: Add dolibarr_soc_id to material_inspection_receipts
+-- Part B: Create mir_shipment_evaluations table
+-- Part C: Seed WorkflowDefinition for MIR_INSPECTION (3 steps)
+
+-- ── Part A: dolibarr_soc_id on material_inspection_receipts ─────────────────
+
+DROP PROCEDURE IF EXISTS mir_add_dolibarr_soc_id;
+DELIMITER $$
+CREATE PROCEDURE mir_add_dolibarr_soc_id()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME   = 'material_inspection_receipts'
+      AND COLUMN_NAME  = 'dolibarr_soc_id'
+  ) THEN
+    ALTER TABLE `material_inspection_receipts`
+      ADD COLUMN `dolibarr_soc_id` INT NULL COMMENT 'FK to dolibarr_thirdparties.dolibarr_id'
+      AFTER `supplier_name`;
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME   = 'material_inspection_receipts'
+      AND INDEX_NAME   = 'idx_mir_soc_id'
+  ) THEN
+    ALTER TABLE `material_inspection_receipts`
+      ADD INDEX `idx_mir_soc_id` (`dolibarr_soc_id`);
+  END IF;
+END$$
+DELIMITER ;
+CALL mir_add_dolibarr_soc_id();
+DROP PROCEDURE IF EXISTS mir_add_dolibarr_soc_id;
+
+-- ── Part B: mir_shipment_evaluations table ───────────────────────────────────
+
+DROP PROCEDURE IF EXISTS create_mir_shipment_evaluations;
+DELIMITER $$
+CREATE PROCEDURE create_mir_shipment_evaluations()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME   = 'mir_shipment_evaluations'
+  ) THEN
+    CREATE TABLE `mir_shipment_evaluations` (
+      `id`                  CHAR(36)     NOT NULL,
+      `mir_id`              CHAR(36)     NOT NULL COMMENT 'FK to material_inspection_receipts.id',
+      `dolibarr_id`         INT          NOT NULL COMMENT 'FK to dolibarr_thirdparties.dolibarr_id',
+      `evaluation_date`     DATE         NOT NULL,
+      `score_quality`       TINYINT      NOT NULL DEFAULT 3 COMMENT '30% — Total Shipment Quality',
+      `score_otif`          TINYINT      NOT NULL DEFAULT 3 COMMENT '25% — On Time In Full',
+      `score_service`       TINYINT      NOT NULL DEFAULT 3 COMMENT '15% — Service & Communication',
+      `score_documentation` TINYINT      NOT NULL DEFAULT 3 COMMENT '15% — Documentation & Compliance',
+      `score_hse`           TINYINT      NOT NULL DEFAULT 3 COMMENT '10% — HSE & Ethics',
+      `score_stacking`      TINYINT      NOT NULL DEFAULT 3 COMMENT '5%  — Stacking & Packaging',
+      `notes_quality`       TEXT         NULL,
+      `notes_otif`          TEXT         NULL,
+      `notes_service`       TEXT         NULL,
+      `notes_documentation` TEXT         NULL,
+      `notes_hse`           TEXT         NULL,
+      `notes_stacking`      TEXT         NULL,
+      `general_notes`       TEXT         NULL,
+      `weighted_score`      DECIMAL(6,2) NOT NULL COMMENT 'out of 100',
+      `rating`              VARCHAR(1)   NOT NULL COMMENT 'A/B/C/D',
+      `outcome`             VARCHAR(20)  NOT NULL COMMENT 'APPROVED/CONDITIONAL/SUSPENDED/REJECTED',
+      `evaluator_id`        CHAR(36)     NULL,
+      `created_by_id`       CHAR(36)     NOT NULL,
+      `created_at`          DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+      `updated_at`          DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+      PRIMARY KEY (`id`),
+      UNIQUE INDEX `uq_mse_mir`    (`mir_id`),
+      INDEX `idx_mse_dolibarr`     (`dolibarr_id`),
+      INDEX `idx_mse_date`         (`evaluation_date`),
+      INDEX `idx_mse_rating`       (`rating`),
+      CONSTRAINT `fk_mse_mir`        FOREIGN KEY (`mir_id`)        REFERENCES `material_inspection_receipts`(`id`) ON DELETE CASCADE,
+      CONSTRAINT `fk_mse_evaluator`  FOREIGN KEY (`evaluator_id`)  REFERENCES `User`(`id`) ON DELETE SET NULL,
+      CONSTRAINT `fk_mse_created_by` FOREIGN KEY (`created_by_id`) REFERENCES `User`(`id`) ON DELETE RESTRICT
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+  END IF;
+END$$
+DELIMITER ;
+CALL create_mir_shipment_evaluations();
+DROP PROCEDURE IF EXISTS create_mir_shipment_evaluations;
+
+-- ── Part C: Seed WorkflowDefinition for MIR_INSPECTION ──────────────────────
+
+DROP PROCEDURE IF EXISTS seed_mir_inspection_workflow;
+DELIMITER $$
+CREATE PROCEDURE seed_mir_inspection_workflow()
+BEGIN
+  DECLARE def_id CHAR(36);
+  IF EXISTS (
+    SELECT 1 FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'WorkflowDefinition'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM WorkflowDefinition
+    WHERE `key` = 'MIR_INSPECTION' AND deletedAt IS NULL
+  ) THEN
+    SET def_id = UUID();
+    INSERT INTO WorkflowDefinition
+      (id, `key`, name, description, entityType, version, isActive, createdAt, updatedAt)
+    VALUES (
+      def_id,
+      'MIR_INSPECTION',
+      'Material Inspection Receipt',
+      'Three-step MIR workflow: Inspector submits → Reviewer reviews → Approver approves/rejects. Designated personnel are resolved by PBAC permissions.',
+      'MaterialInspectionReceipt',
+      1, 1, NOW(), NOW()
+    );
+
+    INSERT INTO WorkflowStep
+      (id, definitionId, sequence, name, approverResolver, minApprovals, slaHours, onRejectBehavior, createdAt, updatedAt)
+    VALUES (
+      UUID(), def_id, 1, 'Inspector Submission',
+      '{"type":"PBAC_PERMISSION","permission":"quality.mir.inspect"}',
+      1, 48, 'RETURN_PREVIOUS', NOW(), NOW()
+    );
+
+    INSERT INTO WorkflowStep
+      (id, definitionId, sequence, name, approverResolver, minApprovals, slaHours, onRejectBehavior, createdAt, updatedAt)
+    VALUES (
+      UUID(), def_id, 2, 'QC Review',
+      '{"type":"PBAC_PERMISSION","permission":"quality.mir.review"}',
+      1, 48, 'RETURN_PREVIOUS', NOW(), NOW()
+    );
+
+    INSERT INTO WorkflowStep
+      (id, definitionId, sequence, name, approverResolver, minApprovals, slaHours, onRejectBehavior, createdAt, updatedAt)
+    VALUES (
+      UUID(), def_id, 3, 'Final Approval',
+      '{"type":"PBAC_PERMISSION","permission":"quality.mir.approve"}',
+      1, 72, 'TERMINATE', NOW(), NOW()
+    );
+  END IF;
+END$$
+DELIMITER ;
+CALL seed_mir_inspection_workflow();
+DROP PROCEDURE IF EXISTS seed_mir_inspection_workflow;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -350,6 +350,10 @@ model User {
   createdTrainingPrograms HrTrainingProgram[] @relation("HrTrainingProgramCreatedBy")
   deletedTrainingPrograms HrTrainingProgram[] @relation("HrTrainingProgramDeletedBy")
 
+  // MIR Shipment Evaluation back-relations (32.0.0)
+  mirEvaluations    MirShipmentEvaluation[] @relation("MirEvaluator")
+  mirEvalsCreated   MirShipmentEvaluation[] @relation("MirEvalCreatedBy")
+
   // Workflow Engine back-relations (21.0.0)
   initiatedWorkflows  WorkflowInstance[] @relation("WorkflowInitiatedBy")
   cancelledWorkflows  WorkflowInstance[] @relation("WorkflowCancelledBy")
@@ -1624,6 +1628,7 @@ model MaterialInspectionReceipt {
   dolibarrPoId  String  @map("dolibarr_po_id")
   dolibarrPoRef String  @map("dolibarr_po_ref")
   supplierName  String? @map("supplier_name")
+  dolibarrSocId Int?    @map("dolibarr_soc_id")
   projectId     String? @map("project_id") @db.Char(36)
 
   // Receipt info
@@ -1655,6 +1660,7 @@ model MaterialInspectionReceipt {
   approvedBy   User?                                 @relation("MIRApprovedBy", fields: [approvedById], references: [id])
   items        MaterialInspectionReceiptItem[]
   attachments  MaterialInspectionReceiptAttachment[]
+  evaluation   MirShipmentEvaluation?
 
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
@@ -1665,6 +1671,7 @@ model MaterialInspectionReceipt {
   @@index([receiptDate])
   @@index([status])
   @@index([workflowStatus])
+  @@index([dolibarrSocId])
   @@map("material_inspection_receipts")
 }
 
@@ -1763,6 +1770,46 @@ model MaterialInspectionReceiptAttachment {
   @@index([itemId])
   @@index([attachmentType])
   @@map("material_inspection_receipt_attachments")
+}
+
+// Shipment evaluation (one per MIR) — feeds the supplier Evaluations Receiving Bank (v32.0.0)
+model MirShipmentEvaluation {
+  id                 String   @id @default(uuid()) @db.Char(36)
+  mirId              String   @unique @map("mir_id") @db.Char(36)
+  dolibarrId         Int      @map("dolibarr_id")
+  evaluationDate     DateTime @map("evaluation_date") @db.Date
+
+  scoreQuality       Int      @map("score_quality") @db.TinyInt
+  scoreOtif          Int      @map("score_otif") @db.TinyInt
+  scoreService       Int      @map("score_service") @db.TinyInt
+  scoreDocumentation Int      @map("score_documentation") @db.TinyInt
+  scoreHse           Int      @map("score_hse") @db.TinyInt
+  scoreStacking      Int      @map("score_stacking") @db.TinyInt
+
+  notesQuality       String?  @map("notes_quality") @db.Text
+  notesOtif          String?  @map("notes_otif") @db.Text
+  notesService       String?  @map("notes_service") @db.Text
+  notesDocumentation String?  @map("notes_documentation") @db.Text
+  notesHse           String?  @map("notes_hse") @db.Text
+  notesStacking      String?  @map("notes_stacking") @db.Text
+  generalNotes       String?  @map("general_notes") @db.Text
+
+  weightedScore      Decimal  @map("weighted_score") @db.Decimal(6, 2)
+  rating             String   @map("rating") @db.VarChar(1)
+  outcome            String   @map("outcome") @db.VarChar(20)
+
+  evaluatorId        String?  @map("evaluator_id") @db.Char(36)
+  createdById        String   @map("created_by_id") @db.Char(36)
+  createdAt          DateTime @default(now()) @map("created_at")
+  updatedAt          DateTime @updatedAt @map("updated_at")
+
+  mir       MaterialInspectionReceipt @relation(fields: [mirId], references: [id], onDelete: Cascade)
+  evaluator User?                     @relation("MirEvaluator", fields: [evaluatorId], references: [id], onDelete: SetNull)
+  createdBy User                      @relation("MirEvalCreatedBy", fields: [createdById], references: [id])
+
+  @@index([dolibarrId])
+  @@index([evaluationDate])
+  @@map("mir_shipment_evaluations")
 }
 
 model WeldingInspection {

--- a/src/app/api/qc/material-receipts/evaluate/route.ts
+++ b/src/app/api/qc/material-receipts/evaluate/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withApiContext } from '@/lib/api-utils';
+import {
+  getMirEvaluation,
+  createMirEvaluation,
+  updateMirEvaluation,
+} from '@/lib/services/qc/mir-evaluation.service';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+const scoreField = z.number().int().min(1).max(5);
+
+const createSchema = z.object({
+  mirId:              z.string().uuid(),
+  evaluationDate:     z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  scoreQuality:       scoreField,
+  scoreOtif:          scoreField,
+  scoreService:       scoreField,
+  scoreDocumentation: scoreField,
+  scoreHse:           scoreField,
+  scoreStacking:      scoreField,
+  notesQuality:       z.string().optional().nullable(),
+  notesOtif:          z.string().optional().nullable(),
+  notesService:       z.string().optional().nullable(),
+  notesDocumentation: z.string().optional().nullable(),
+  notesHse:           z.string().optional().nullable(),
+  notesStacking:      z.string().optional().nullable(),
+  generalNotes:       z.string().optional().nullable(),
+  evaluatorId:        z.string().uuid().optional().nullable(),
+});
+
+const updateSchema = createSchema.partial().omit({ mirId: true });
+
+export const GET = withApiContext(async (req: NextRequest, session) => {
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { searchParams } = new URL(req.url);
+  const mirId = searchParams.get('mirId');
+  if (!mirId) return NextResponse.json({ error: 'mirId is required' }, { status: 400 });
+
+  const evaluation = await getMirEvaluation(mirId);
+  if (!evaluation) return NextResponse.json({ error: 'No evaluation found for this MIR' }, { status: 404 });
+  return NextResponse.json(evaluation);
+});
+
+export const POST = withApiContext(async (req: NextRequest, session) => {
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const body: unknown = await req.json();
+  const parsed = createSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input', details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  try {
+    const evaluation = await createMirEvaluation({
+      ...parsed.data,
+      createdById: session.userId,
+    });
+    return NextResponse.json(evaluation, { status: 201 });
+  } catch (err) {
+    const e = err as Error & { status?: number };
+    logger.error({ err, mirId: parsed.data.mirId }, '[MIR Eval] Failed to create evaluation');
+    return NextResponse.json({ error: e.message }, { status: e.status ?? 500 });
+  }
+});
+
+export const PATCH = withApiContext(async (req: NextRequest, session) => {
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { searchParams } = new URL(req.url);
+  const id = searchParams.get('id');
+  if (!id) return NextResponse.json({ error: 'id is required' }, { status: 400 });
+
+  const body: unknown = await req.json();
+  const parsed = updateSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input', details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  try {
+    const evaluation = await updateMirEvaluation(id, parsed.data);
+    return NextResponse.json(evaluation);
+  } catch (err) {
+    const e = err as Error & { status?: number };
+    logger.error({ err, id }, '[MIR Eval] Failed to update evaluation');
+    return NextResponse.json({ error: e.message }, { status: e.status ?? 500 });
+  }
+});

--- a/src/app/api/qc/material-receipts/route.ts
+++ b/src/app/api/qc/material-receipts/route.ts
@@ -144,6 +144,7 @@ export async function GET(request: NextRequest) {
             mtcFilePath: true,
           },
         },
+        evaluation: { select: { id: true, rating: true, weightedScore: true } },
       },
       orderBy: { receiptDate: 'desc' },
     });
@@ -174,6 +175,7 @@ export async function POST(request: NextRequest) {
       dolibarrPoId,
       dolibarrPoRef,
       supplierName,
+      dolibarrSocId,
       projectId,
       receiptDate,
       items,
@@ -200,6 +202,7 @@ export async function POST(request: NextRequest) {
           dolibarrPoId,
           dolibarrPoRef,
           supplierName: supplierName || null,
+          dolibarrSocId: dolibarrSocId ? Number(dolibarrSocId) : null,
           projectId: projectId || null,
           receiptDate: receiptDate ? new Date(receiptDate) : new Date(),
           inspectorId: session.sub,

--- a/src/app/api/qc/material-receipts/workflow/route.ts
+++ b/src/app/api/qc/material-receipts/workflow/route.ts
@@ -8,6 +8,9 @@
  *   Inspected  → Reviewed   (action: 'review')
  *   Inspected|Reviewed → Approved (action: 'approve')
  *   Inspected|Reviewed → Rejected (action: 'reject')
+ *
+ * Designated personnel are notified at each transition via the NotificationService.
+ * Recipients are resolved by PBAC permission (quality.mir.review / quality.mir.approve).
  */
 
 import { NextRequest, NextResponse } from 'next/server';
@@ -15,6 +18,11 @@ import { z } from 'zod';
 import { withApiContext } from '@/lib/api-utils';
 import prisma from '@/lib/db';
 import { logger } from '@/lib/logger';
+import { NotificationService } from '@/lib/services/notification.service';
+import {
+  resolvePermissionsFromData,
+  parseCustomPermissions,
+} from '@/lib/services/permission-resolution.service';
 
 export const dynamic = 'force-dynamic';
 
@@ -23,6 +31,33 @@ const workflowSchema = z.object({
   action: z.enum(['submit', 'review', 'approve', 'reject']),
   notes: z.string().optional(),
 });
+
+// Resolve all active users that hold the given PBAC permission
+async function getUsersWithPermission(permission: string): Promise<{ id: string; name: string }[]> {
+  const users = await prisma.user.findMany({
+    where: { status: 'active' },
+    select: {
+      id: true,
+      name: true,
+      isAdmin: true,
+      role: { select: { permissions: true, restrictedModules: true } },
+      customPermissions: true,
+    },
+  });
+
+  return users.filter(u => {
+    const rolePermissions = (u.role.permissions as string[]) ?? [];
+    const customPerms = parseCustomPermissions(u.customPermissions);
+    const restrictedModules = (u.role.restrictedModules as string[]) ?? [];
+    const resolved = resolvePermissionsFromData({
+      isAdmin: u.isAdmin,
+      rolePermissions,
+      customPermissions: customPerms,
+      restrictedModules,
+    });
+    return resolved.includes(permission);
+  });
+}
 
 export const POST = withApiContext(async (req: NextRequest, session) => {
   const body: unknown = await req.json();
@@ -38,13 +73,15 @@ export const POST = withApiContext(async (req: NextRequest, session) => {
   const { receiptId, action, notes } = parsed.data;
   const userId = session!.userId;
 
-  // Fetch the receipt with its items to validate state
+  // Fetch the receipt with items + inspector/submitter IDs for notifications
   const receipt = await prisma.materialInspectionReceipt.findUnique({
     where: { id: receiptId },
     select: {
       id: true,
       receiptNumber: true,
       workflowStatus: true,
+      inspectorId: true,
+      submittedById: true,
       items: {
         select: { id: true, inspectionResult: true },
       },
@@ -94,6 +131,7 @@ export const POST = withApiContext(async (req: NextRequest, session) => {
         reviewedBy: { select: { id: true, name: true } },
         approvedBy: { select: { id: true, name: true } },
         items: true,
+        evaluation: { select: { id: true } },
       },
     });
 
@@ -101,6 +139,20 @@ export const POST = withApiContext(async (req: NextRequest, session) => {
       { receiptId, receiptNumber: receipt.receiptNumber, action, userId },
       '[MIR Workflow] Receipt submitted for inspection review',
     );
+
+    // Notify all users with quality.mir.review permission
+    getUsersWithPermission('quality.mir.review').then(reviewers => {
+      reviewers.forEach(r =>
+        NotificationService.createNotification({
+          userId: r.id,
+          type: 'APPROVAL_REQUIRED',
+          title: 'MIR Ready for Review',
+          message: `MIR ${receipt.receiptNumber} has been submitted and requires your QC review.`,
+          relatedEntityType: 'MaterialInspectionReceipt',
+          relatedEntityId: receiptId,
+        }).catch(err => logger.error({ err, reviewerId: r.id }, '[MIR] Failed to notify reviewer')),
+      );
+    }).catch(err => logger.error({ err }, '[MIR] Failed to fetch reviewers for submit notification'));
 
     return NextResponse.json(updated);
   }
@@ -130,6 +182,7 @@ export const POST = withApiContext(async (req: NextRequest, session) => {
         reviewedBy: { select: { id: true, name: true } },
         approvedBy: { select: { id: true, name: true } },
         items: true,
+        evaluation: { select: { id: true } },
       },
     });
 
@@ -137,6 +190,20 @@ export const POST = withApiContext(async (req: NextRequest, session) => {
       { receiptId, receiptNumber: receipt.receiptNumber, action, userId },
       '[MIR Workflow] Receipt reviewed',
     );
+
+    // Notify all users with quality.mir.approve permission
+    getUsersWithPermission('quality.mir.approve').then(approvers => {
+      approvers.forEach(a =>
+        NotificationService.createNotification({
+          userId: a.id,
+          type: 'APPROVAL_REQUIRED',
+          title: 'MIR Awaiting Final Approval',
+          message: `MIR ${receipt.receiptNumber} has been reviewed and awaits your final approval.`,
+          relatedEntityType: 'MaterialInspectionReceipt',
+          relatedEntityId: receiptId,
+        }).catch(err => logger.error({ err, approverId: a.id }, '[MIR] Failed to notify approver')),
+      );
+    }).catch(err => logger.error({ err }, '[MIR] Failed to fetch approvers for review notification'));
 
     return NextResponse.json(updated);
   }
@@ -166,12 +233,26 @@ export const POST = withApiContext(async (req: NextRequest, session) => {
         reviewedBy: { select: { id: true, name: true } },
         approvedBy: { select: { id: true, name: true } },
         items: true,
+        evaluation: { select: { id: true } },
       },
     });
 
     logger.info(
       { receiptId, receiptNumber: receipt.receiptNumber, action, userId },
       '[MIR Workflow] Receipt approved',
+    );
+
+    // Notify inspector and submitter (deduplicated)
+    const notifyIds = [...new Set([receipt.inspectorId, receipt.submittedById].filter((id): id is string => !!id))];
+    notifyIds.forEach(uid =>
+      NotificationService.createNotification({
+        userId: uid,
+        type: 'APPROVED',
+        title: 'MIR Approved',
+        message: `MIR ${receipt.receiptNumber} has been approved.${notes ? ` Note: ${notes}` : ''}`,
+        relatedEntityType: 'MaterialInspectionReceipt',
+        relatedEntityId: receiptId,
+      }).catch(err => logger.error({ err, uid }, '[MIR] Failed to send approval notification')),
     );
 
     return NextResponse.json(updated);
@@ -203,12 +284,26 @@ export const POST = withApiContext(async (req: NextRequest, session) => {
       reviewedBy: { select: { id: true, name: true } },
       approvedBy: { select: { id: true, name: true } },
       items: true,
+      evaluation: { select: { id: true } },
     },
   });
 
   logger.info(
     { receiptId, receiptNumber: receipt.receiptNumber, action, userId },
     '[MIR Workflow] Receipt rejected',
+  );
+
+  // Notify inspector and submitter (deduplicated)
+  const notifyIds = [...new Set([receipt.inspectorId, receipt.submittedById].filter((id): id is string => !!id))];
+  notifyIds.forEach(uid =>
+    NotificationService.createNotification({
+      userId: uid,
+      type: 'REJECTED',
+      title: 'MIR Rejected',
+      message: `MIR ${receipt.receiptNumber} has been rejected.${notes ? ` Reason: ${notes}` : ''}`,
+      relatedEntityType: 'MaterialInspectionReceipt',
+      relatedEntityId: receiptId,
+    }).catch(err => logger.error({ err, uid }, '[MIR] Failed to send rejection notification')),
   );
 
   return NextResponse.json(updated);

--- a/src/app/api/supply-chain/suppliers/[id]/shipment-evaluations/route.ts
+++ b/src/app/api/supply-chain/suppliers/[id]/shipment-evaluations/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import { withApiContext } from '@/lib/api-utils';
+import { getSupplierShipmentEvaluations } from '@/lib/services/qc/mir-evaluation.service';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+export const GET = withApiContext(async (req, session, ctx) => {
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const id = parseInt(ctx?.params?.id ?? '', 10);
+  if (isNaN(id)) return NextResponse.json({ error: 'Invalid supplier id' }, { status: 400 });
+
+  try {
+    const evaluations = await getSupplierShipmentEvaluations(id);
+    return NextResponse.json(evaluations);
+  } catch (err) {
+    logger.error({ err, supplierId: id }, '[MIR Eval] Failed to fetch supplier shipment evaluations');
+    return NextResponse.json({ error: 'Failed to fetch evaluations' }, { status: 500 });
+  }
+});

--- a/src/app/qc/material/_page-client.tsx
+++ b/src/app/qc/material/_page-client.tsx
@@ -37,7 +37,9 @@ import {
   ClipboardCheck,
   Trash2,
   MoreHorizontal,
+  Star,
 } from 'lucide-react';
+import ShipmentEvaluationDialog, { type ExistingEvaluation } from '@/components/qc/ShipmentEvaluationDialog';
 import {
   Dialog,
   DialogContent,
@@ -100,10 +102,12 @@ type MaterialReceipt = {
   dolibarrPoId: string;
   dolibarrPoRef: string;
   supplierName?: string;
+  dolibarrSocId?: number | null;
   projectId?: string;
   receiptDate: string;
   status: string;
   workflowStatus: string;
+  evaluation?: { id: string; rating: string; weightedScore: number } | null;
   submittedAt?: string;
   submittedById?: string;
   submittedBy?: { id: string; name: string } | null;
@@ -215,6 +219,11 @@ export default function MaterialInspectionReceiptPage() {
   const [workflowNotes, setWorkflowNotes] = useState('');
   const [processingWorkflow, setProcessingWorkflow] = useState(false);
 
+  // Shipment evaluation
+  const [evaluationDialogMir, setEvaluationDialogMir] = useState<MaterialReceipt | null>(null);
+  const [evaluationDialogExisting, setEvaluationDialogExisting] = useState<ExistingEvaluation | null>(null);
+  const [evaluationPromptReceipt, setEvaluationPromptReceipt] = useState<MaterialReceipt | null>(null);
+
   useEffect(() => {
     fetchReceipts();
     fetchProjects();
@@ -316,6 +325,7 @@ export default function MaterialInspectionReceiptPage() {
           dolibarrPoId: selectedPO.id.toString(),
           dolibarrPoRef: selectedPO.ref,
           supplierName: selectedPO.supplier_name,
+          dolibarrSocId: selectedPO.socid ?? null,
           projectId: (selectedProject && selectedProject !== '__none__') ? selectedProject : null,
           items,
         }),
@@ -522,12 +532,18 @@ export default function MaterialInspectionReceiptPage() {
       });
       if (res.ok) {
         const updated = await res.json();
+        const wasSubmit = workflowDialog.action === 'submit';
+        const submittedReceipt = workflowDialog.receipt;
         setWorkflowDialog(null);
         setWorkflowNotes('');
-        if (selectedReceipt?.id === workflowDialog.receipt.id) {
+        if (selectedReceipt?.id === submittedReceipt.id) {
           setSelectedReceipt(updated);
         }
         fetchReceipts();
+        // Prompt to rate the shipment after inspector submits (only if no evaluation yet)
+        if (wasSubmit && !submittedReceipt.evaluation && submittedReceipt.dolibarrSocId) {
+          setEvaluationPromptReceipt(submittedReceipt);
+        }
       }
     } catch {
       // silently handled
@@ -808,6 +824,27 @@ export default function MaterialInspectionReceiptPage() {
                             <DropdownMenuItem onClick={() => handlePrintPDF(receipt)} disabled={generatingPdf}>
                               <Printer className="h-4 w-4 mr-2" /> Export PDF
                             </DropdownMenuItem>
+                            <DropdownMenuSeparator />
+                            {receipt.evaluation ? (
+                              <DropdownMenuItem
+                                onClick={async () => {
+                                  const res = await fetch(`/api/qc/material-receipts/evaluate?mirId=${receipt.id}`);
+                                  const data: ExistingEvaluation = await res.json();
+                                  setEvaluationDialogExisting(data);
+                                  setEvaluationDialogMir(receipt);
+                                }}
+                              >
+                                <Star className="h-4 w-4 mr-2 fill-amber-400 text-amber-400" /> View Evaluation
+                              </DropdownMenuItem>
+                            ) : (
+                              <DropdownMenuItem
+                                disabled={!receipt.dolibarrSocId}
+                                onClick={() => { setEvaluationDialogExisting(null); setEvaluationDialogMir(receipt); }}
+                                title={!receipt.dolibarrSocId ? 'This MIR predates shipment evaluations' : undefined}
+                              >
+                                <Star className="h-4 w-4 mr-2" /> Evaluate Shipment
+                              </DropdownMenuItem>
+                            )}
                             {['Admin', 'CEO'].includes(currentUserRole) && (
                               <>
                                 <DropdownMenuSeparator />
@@ -1840,6 +1877,45 @@ export default function MaterialInspectionReceiptPage() {
             </DialogFooter>
           </DialogContent>
         </Dialog>
+      )}
+
+      {/* Evaluation prompt — appears after inspector submits */}
+      <Dialog open={!!evaluationPromptReceipt} onOpenChange={() => setEvaluationPromptReceipt(null)}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Star className="h-5 w-5 text-amber-500" /> Rate This Shipment?
+            </DialogTitle>
+            <DialogDescription>
+              {evaluationPromptReceipt?.receiptNumber} has been submitted. Would you like to evaluate the quality of this supplier shipment?
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="gap-2">
+            <Button variant="outline" onClick={() => setEvaluationPromptReceipt(null)}>
+              Skip
+            </Button>
+            <Button onClick={() => {
+              setEvaluationDialogExisting(null);
+              setEvaluationDialogMir(evaluationPromptReceipt);
+              setEvaluationPromptReceipt(null);
+            }}>
+              Evaluate Shipment
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Shipment Evaluation Dialog */}
+      {evaluationDialogMir && (
+        <ShipmentEvaluationDialog
+          open={!!evaluationDialogMir}
+          onOpenChange={open => { if (!open) { setEvaluationDialogMir(null); setEvaluationDialogExisting(null); } }}
+          mirId={evaluationDialogMir.id}
+          mirNumber={evaluationDialogMir.receiptNumber}
+          supplierName={evaluationDialogMir.supplierName}
+          existingEvaluation={evaluationDialogExisting}
+          onSuccess={() => { setEvaluationDialogMir(null); setEvaluationDialogExisting(null); fetchReceipts(); }}
+        />
       )}
     </div>
   );

--- a/src/app/supply-chain/suppliers/[id]/_page-client.tsx
+++ b/src/app/supply-chain/suppliers/[id]/_page-client.tsx
@@ -6,7 +6,7 @@ import {
   Factory, ArrowLeft, Mail, Phone, MapPin, Building2, ChevronRight,
   ShieldCheck, ShieldAlert, ShieldOff, Shield, ClipboardList, CreditCard,
   FileText, ShoppingCart, Banknote, BarChart3, Plus, ClipboardCheck,
-  AlertTriangle, Users, Handshake, Trash2,
+  AlertTriangle, Users, Handshake, Trash2, Star, Package, TrendingUp, Loader2,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
@@ -286,7 +286,8 @@ export function SupplierDetailClient({ supplierId }: { supplierId: number }) {
             <TabsTrigger value="pos"><ShoppingCart className="h-4 w-4 mr-1.5" />Purchase Orders</TabsTrigger>
             <TabsTrigger value="payments"><Banknote className="h-4 w-4 mr-1.5" />Payments</TabsTrigger>
             <TabsTrigger value="soa"><BarChart3 className="h-4 w-4 mr-1.5" />Statement</TabsTrigger>
-            <TabsTrigger value="evaluations"><ClipboardCheck className="h-4 w-4 mr-1.5" />Evaluations</TabsTrigger>
+            <TabsTrigger value="shipment-ratings"><Star className="h-4 w-4 mr-1.5" />Shipment Ratings</TabsTrigger>
+            <TabsTrigger value="evaluations"><ClipboardCheck className="h-4 w-4 mr-1.5" />Manual Evaluations</TabsTrigger>
             <TabsTrigger value="coa"><ClipboardList className="h-4 w-4 mr-1.5" />CoA & COGS</TabsTrigger>
             {subcontractsCount > 0 && (
               <TabsTrigger value="subcontracts">
@@ -317,6 +318,9 @@ export function SupplierDetailClient({ supplierId }: { supplierId: number }) {
               type="ap"
               apiBase={`/api/supply-chain/suppliers/${supplierId}/soa`}
             />
+          </TabsContent>
+          <TabsContent value="shipment-ratings">
+            <ShipmentRatingsTab supplierId={supplierId} />
           </TabsContent>
           <TabsContent value="evaluations">
             <EvaluationsTab supplierId={supplierId} supplierName={overview.name} onEvaluated={fetchOverview} />
@@ -1278,6 +1282,141 @@ function SupplierSubcontractsTab({ supplierId }: { supplierId: number }) {
                   <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${SC_STATUS_STYLE[c.status] ?? 'bg-slate-100 text-slate-700'}`}>
                     {c.status}
                   </span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+// ─── Shipment Ratings Tab ─────────────────────────────────────────────────────
+
+interface ShipmentEvaluationRow {
+  id: string;
+  mirId: string;
+  mirNumber: string;
+  dolibarrId: number;
+  evaluationDate: string;
+  scoreQuality: number;
+  scoreOtif: number;
+  scoreService: number;
+  scoreDocumentation: number;
+  scoreHse: number;
+  scoreStacking: number;
+  weightedScore: number;
+  rating: string;
+  outcome: string;
+  generalNotes: string | null;
+  evaluatorName: string | null;
+  createdAt: string;
+}
+
+const RATING_BADGE: Record<string, string> = {
+  A: 'bg-green-100 text-green-800 border-green-200',
+  B: 'bg-blue-100 text-blue-800 border-blue-200',
+  C: 'bg-yellow-100 text-yellow-800 border-yellow-200',
+  D: 'bg-red-100 text-red-800 border-red-200',
+};
+
+function ShipmentRatingsTab({ supplierId }: { supplierId: number }) {
+  const [rows, setRows] = useState<ShipmentEvaluationRow[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch(`/api/supply-chain/suppliers/${supplierId}/shipment-evaluations`)
+      .then(r => r.ok ? r.json() : [])
+      .then(setRows)
+      .catch(() => setRows([]))
+      .finally(() => setLoading(false));
+  }, [supplierId]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-16 text-muted-foreground">
+        <Loader2 className="h-6 w-6 animate-spin mr-2" /> Loading shipment evaluations…
+      </div>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-muted-foreground gap-3">
+        <Star className="h-12 w-12 opacity-20" />
+        <p className="text-sm">No shipment evaluations yet.</p>
+        <p className="text-xs">Evaluations are submitted during the MIR receiving process.</p>
+      </div>
+    );
+  }
+
+  const avg = rows.reduce((s, r) => s + r.weightedScore, 0) / rows.length;
+  const avgRating = avg >= 85 ? 'A' : avg >= 70 ? 'B' : avg >= 55 ? 'C' : 'D';
+
+  return (
+    <div className="space-y-4">
+      {/* Aggregate summary */}
+      <div className="flex items-center gap-6 p-4 rounded-xl border bg-muted/30">
+        <div>
+          <p className="text-xs text-muted-foreground mb-1 flex items-center gap-1"><TrendingUp className="h-3 w-3" /> Aggregate Rating</p>
+          <div className="flex items-center gap-2">
+            <span className="text-3xl font-bold">{avg.toFixed(1)}</span>
+            <span className="text-sm text-muted-foreground">/ 100</span>
+            <span className={`text-sm font-bold px-2 py-0.5 rounded border ${RATING_BADGE[avgRating]}`}>{avgRating}</span>
+          </div>
+        </div>
+        <div className="flex-1">
+          <div className="h-3 rounded-full bg-muted overflow-hidden">
+            <div
+              className={`h-full rounded-full ${avgRating === 'A' ? 'bg-green-500' : avgRating === 'B' ? 'bg-blue-500' : avgRating === 'C' ? 'bg-yellow-500' : 'bg-red-500'}`}
+              style={{ width: `${Math.min(avg, 100)}%` }}
+            />
+          </div>
+        </div>
+        <div className="text-right">
+          <p className="text-2xl font-bold">{rows.length}</p>
+          <p className="text-xs text-muted-foreground">shipments rated</p>
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-x-auto rounded-lg border">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/50">
+            <tr>
+              <th className="px-3 py-2 text-left font-medium text-xs">MIR</th>
+              <th className="px-3 py-2 text-left font-medium text-xs">Date</th>
+              <th className="px-3 py-2 text-center font-medium text-xs">Quality</th>
+              <th className="px-3 py-2 text-center font-medium text-xs">OTIF</th>
+              <th className="px-3 py-2 text-center font-medium text-xs">Service</th>
+              <th className="px-3 py-2 text-center font-medium text-xs">Docs</th>
+              <th className="px-3 py-2 text-center font-medium text-xs">HSE</th>
+              <th className="px-3 py-2 text-center font-medium text-xs">Stacking</th>
+              <th className="px-3 py-2 text-center font-medium text-xs">Score</th>
+              <th className="px-3 py-2 text-center font-medium text-xs">Rating</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y">
+            {rows.map(row => (
+              <tr key={row.id} className="hover:bg-muted/30">
+                <td className="px-3 py-2 font-mono text-xs font-semibold">{row.mirNumber}</td>
+                <td className="px-3 py-2 text-xs text-muted-foreground">{new Date(row.evaluationDate).toLocaleDateString('en-SA-u-ca-gregory')}</td>
+                {(['scoreQuality', 'scoreOtif', 'scoreService', 'scoreDocumentation', 'scoreHse', 'scoreStacking'] as const).map(k => (
+                  <td key={k} className="px-3 py-2 text-center">
+                    <span className={`inline-block w-6 h-6 rounded-full text-xs font-bold leading-6 ${
+                      row[k] >= 4 ? 'bg-green-100 text-green-800' :
+                      row[k] >= 3 ? 'bg-blue-100 text-blue-800' :
+                      row[k] >= 2 ? 'bg-yellow-100 text-yellow-800' :
+                      'bg-red-100 text-red-800'
+                    }`}>
+                      {row[k]}
+                    </span>
+                  </td>
+                ))}
+                <td className="px-3 py-2 text-center font-semibold text-xs">{Number(row.weightedScore).toFixed(1)}</td>
+                <td className="px-3 py-2 text-center">
+                  <span className={`text-xs font-bold px-2 py-0.5 rounded border ${RATING_BADGE[row.rating] ?? ''}`}>{row.rating}</span>
                 </td>
               </tr>
             ))}

--- a/src/components/qc/ShipmentEvaluationDialog.tsx
+++ b/src/components/qc/ShipmentEvaluationDialog.tsx
@@ -1,0 +1,346 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Loader2, Star, TrendingUp } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface ScoreKey {
+  key: 'quality' | 'otif' | 'service' | 'documentation' | 'hse' | 'stacking';
+  label: string;
+  weight: string;
+  weightNum: number;
+  description: string;
+}
+
+const MIR_CRITERIA: ScoreKey[] = [
+  { key: 'quality',       label: 'Shipment Quality',          weight: '30%', weightNum: 0.30, description: 'Material conformity to spec, defect rate, physical condition' },
+  { key: 'otif',          label: 'OTIF',                      weight: '25%', weightNum: 0.25, description: 'On Time In Full — punctuality and completeness of delivery' },
+  { key: 'service',       label: 'Service & Communication',   weight: '15%', weightNum: 0.15, description: 'Supplier responsiveness, account management, coordination' },
+  { key: 'documentation', label: 'Documentation & Compliance',weight: '15%', weightNum: 0.15, description: 'MTCs, certifications, packing lists, traceability documents' },
+  { key: 'hse',           label: 'HSE & Ethics',              weight: '10%', weightNum: 0.10, description: 'Driver behavior, site safety compliance, ethical conduct' },
+  { key: 'stacking',      label: 'Stacking & Packaging',      weight: '5%',  weightNum: 0.05, description: 'Packaging condition, stacking quality, protection of materials' },
+];
+
+const SCORE_LABELS: Record<number, string> = {
+  1: '1 — Poor',
+  2: '2 — Below Average',
+  3: '3 — Acceptable',
+  4: '4 — Good',
+  5: '5 — Excellent',
+};
+
+const RATING_COLORS: Record<string, string> = {
+  A: 'bg-green-100 text-green-800 border-green-200',
+  B: 'bg-blue-100 text-blue-800 border-blue-200',
+  C: 'bg-yellow-100 text-yellow-800 border-yellow-200',
+  D: 'bg-red-100 text-red-800 border-red-200',
+};
+
+type Scores = Record<ScoreKey['key'], number>;
+type Notes  = Partial<Record<ScoreKey['key'] | 'general', string>>;
+
+export interface ExistingEvaluation {
+  id: string;
+  scoreQuality: number;
+  scoreOtif: number;
+  scoreService: number;
+  scoreDocumentation: number;
+  scoreHse: number;
+  scoreStacking: number;
+  notesQuality?: string | null;
+  notesOtif?: string | null;
+  notesService?: string | null;
+  notesDocumentation?: string | null;
+  notesHse?: string | null;
+  notesStacking?: string | null;
+  generalNotes?: string | null;
+  weightedScore: number;
+  rating: string;
+  outcome: string;
+  evaluationDate?: string;
+}
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  mirId: string;
+  mirNumber: string;
+  supplierName?: string | null;
+  existingEvaluation?: ExistingEvaluation | null;
+  onSuccess: () => void;
+}
+
+// ─── Pure helpers (match server-side weights exactly) ─────────────────────────
+
+function computeScore(scores: Scores): number {
+  return MIR_CRITERIA.reduce(
+    (sum, c) => sum + scores[c.key] * 20 * c.weightNum,
+    0,
+  );
+}
+
+function scoreToRating(score: number): 'A' | 'B' | 'C' | 'D' {
+  if (score >= 85) return 'A';
+  if (score >= 70) return 'B';
+  if (score >= 55) return 'C';
+  return 'D';
+}
+
+function ratingToOutcome(rating: string): string {
+  if (rating === 'A') return 'APPROVED';
+  if (rating === 'B') return 'CONDITIONAL';
+  if (rating === 'C') return 'SUSPENDED';
+  return 'REJECTED';
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export default function ShipmentEvaluationDialog({
+  open,
+  onOpenChange,
+  mirId,
+  mirNumber,
+  supplierName,
+  existingEvaluation,
+  onSuccess,
+}: Props) {
+  const today = new Date().toISOString().slice(0, 10);
+  const isReadOnly = !!existingEvaluation;
+
+  const initialScores: Scores = existingEvaluation
+    ? {
+        quality:       existingEvaluation.scoreQuality,
+        otif:          existingEvaluation.scoreOtif,
+        service:       existingEvaluation.scoreService,
+        documentation: existingEvaluation.scoreDocumentation,
+        hse:           existingEvaluation.scoreHse,
+        stacking:      existingEvaluation.scoreStacking,
+      }
+    : { quality: 3, otif: 3, service: 3, documentation: 3, hse: 3, stacking: 3 };
+
+  const initialNotes: Notes = existingEvaluation
+    ? {
+        quality:       existingEvaluation.notesQuality       ?? '',
+        otif:          existingEvaluation.notesOtif          ?? '',
+        service:       existingEvaluation.notesService       ?? '',
+        documentation: existingEvaluation.notesDocumentation ?? '',
+        hse:           existingEvaluation.notesHse           ?? '',
+        stacking:      existingEvaluation.notesStacking      ?? '',
+        general:       existingEvaluation.generalNotes       ?? '',
+      }
+    : {};
+
+  const [scores, setScores] = useState<Scores>(initialScores);
+  const [notes, setNotes]   = useState<Notes>(initialNotes);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset when dialog opens
+  useEffect(() => {
+    if (open) {
+      setScores(initialScores);
+      setNotes(initialNotes);
+      setError(null);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const liveScore  = computeScore(scores);
+  const liveRating = scoreToRating(liveScore);
+  const liveOutcome = ratingToOutcome(liveRating);
+
+  const displayScore  = isReadOnly ? existingEvaluation!.weightedScore : liveScore;
+  const displayRating = isReadOnly ? existingEvaluation!.rating        : liveRating;
+  const displayOutcome = isReadOnly ? existingEvaluation!.outcome       : liveOutcome;
+
+  async function handleSubmit() {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/qc/material-receipts/evaluate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          mirId,
+          evaluationDate: today,
+          scoreQuality:       scores.quality,
+          scoreOtif:          scores.otif,
+          scoreService:       scores.service,
+          scoreDocumentation: scores.documentation,
+          scoreHse:           scores.hse,
+          scoreStacking:      scores.stacking,
+          notesQuality:       notes.quality       || null,
+          notesOtif:          notes.otif          || null,
+          notesService:       notes.service       || null,
+          notesDocumentation: notes.documentation || null,
+          notesHse:           notes.hse           || null,
+          notesStacking:      notes.stacking      || null,
+          generalNotes:       notes.general       || null,
+        }),
+      });
+      if (!res.ok) {
+        const data: { error?: string } = await res.json();
+        throw new Error(data.error ?? 'Failed to save evaluation');
+      }
+      onSuccess();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to save evaluation');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Star className="h-5 w-5 text-amber-500" />
+            {isReadOnly ? 'Shipment Evaluation' : 'Evaluate Shipment'}
+          </DialogTitle>
+          <p className="text-sm text-muted-foreground">
+            {mirNumber}{supplierName ? ` · ${supplierName}` : ''}
+          </p>
+        </DialogHeader>
+
+        {/* Live score preview */}
+        <div className="flex items-center gap-4 p-4 rounded-lg border bg-muted/40">
+          <div className="flex-1">
+            <div className="flex items-center gap-2 mb-1">
+              <TrendingUp className="h-4 w-4 text-muted-foreground" />
+              <span className="text-sm font-medium">Weighted Score</span>
+            </div>
+            <div className="flex items-center gap-3">
+              <span className="text-2xl font-bold">{displayScore.toFixed(1)}</span>
+              <span className="text-sm text-muted-foreground">/ 100</span>
+              <Badge className={`text-sm font-bold ${RATING_COLORS[displayRating]}`}>
+                {displayRating}
+              </Badge>
+              <Badge variant="outline" className="text-xs">
+                {displayOutcome}
+              </Badge>
+            </div>
+          </div>
+          {/* Score bar */}
+          <div className="w-32">
+            <div className="h-3 rounded-full bg-muted overflow-hidden">
+              <div
+                className={`h-full rounded-full transition-all duration-300 ${
+                  displayRating === 'A' ? 'bg-green-500' :
+                  displayRating === 'B' ? 'bg-blue-500'  :
+                  displayRating === 'C' ? 'bg-yellow-500' :
+                  'bg-red-500'
+                }`}
+                style={{ width: `${Math.min(displayScore, 100)}%` }}
+              />
+            </div>
+            <div className="flex justify-between mt-1">
+              <span className="text-[10px] text-muted-foreground">0</span>
+              <span className="text-[10px] text-muted-foreground">100</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Criteria rows */}
+        <div className="space-y-4">
+          {MIR_CRITERIA.map(criterion => (
+            <div key={criterion.key} className="space-y-2">
+              <div className="flex items-center justify-between">
+                <div>
+                  <span className="text-sm font-medium">{criterion.label}</span>
+                  <Badge variant="outline" className="ml-2 text-xs">{criterion.weight}</Badge>
+                  <p className="text-xs text-muted-foreground mt-0.5">{criterion.description}</p>
+                </div>
+                {isReadOnly ? (
+                  <Badge variant="secondary" className="min-w-[80px] justify-center">
+                    {SCORE_LABELS[scores[criterion.key]] ?? scores[criterion.key]}
+                  </Badge>
+                ) : (
+                  <Select
+                    value={String(scores[criterion.key])}
+                    onValueChange={val =>
+                      setScores(prev => ({ ...prev, [criterion.key]: parseInt(val) }))
+                    }
+                  >
+                    <SelectTrigger className="w-44">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {[1, 2, 3, 4, 5].map(n => (
+                        <SelectItem key={n} value={String(n)}>
+                          {SCORE_LABELS[n]}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              </div>
+              {!isReadOnly && (
+                <Textarea
+                  placeholder={`Notes for ${criterion.label} (optional)`}
+                  value={notes[criterion.key] ?? ''}
+                  onChange={e => setNotes(prev => ({ ...prev, [criterion.key]: e.target.value }))}
+                  className="text-sm resize-none h-16"
+                />
+              )}
+              {isReadOnly && notes[criterion.key] && (
+                <p className="text-xs text-muted-foreground italic px-1">{notes[criterion.key]}</p>
+              )}
+            </div>
+          ))}
+
+          {/* General notes */}
+          <div>
+            <label className="text-sm font-medium">General Notes</label>
+            {isReadOnly ? (
+              notes.general
+                ? <p className="text-sm text-muted-foreground mt-1 italic">{notes.general}</p>
+                : <p className="text-sm text-muted-foreground mt-1">—</p>
+            ) : (
+              <Textarea
+                placeholder="Overall comments, recommendations, or observations (optional)"
+                value={notes.general ?? ''}
+                onChange={e => setNotes(prev => ({ ...prev, general: e.target.value }))}
+                className="mt-1 resize-none h-20"
+              />
+            )}
+          </div>
+        </div>
+
+        {error && (
+          <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-md p-3">{error}</p>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            {isReadOnly ? 'Close' : 'Cancel'}
+          </Button>
+          {!isReadOnly && (
+            <Button onClick={handleSubmit} disabled={submitting}>
+              {submitting && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+              Submit Evaluation
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -114,6 +114,9 @@ export const PERMISSIONS: PermissionCategory[] = [
       { id: 'quality.view_ncr', name: 'View NCR', description: 'View Non-Conformance Reports', category: 'quality' },
       { id: 'quality.create_ncr', name: 'Create NCR', description: 'Create NCR reports', category: 'quality' },
       { id: 'quality.close_ncr', name: 'Close NCR', description: 'Close NCR reports', category: 'quality' },
+      { id: 'quality.mir.inspect', name: 'Inspect MIR', description: 'Perform material inspection and submit MIR for review', category: 'quality' },
+      { id: 'quality.mir.review',  name: 'Review MIR',  description: 'Conduct QC review of submitted Material Inspection Receipts', category: 'quality' },
+      { id: 'quality.mir.approve', name: 'Approve MIR', description: 'Approve or reject reviewed Material Inspection Receipts', category: 'quality' },
     ],
   },
   {
@@ -690,6 +693,9 @@ export const DEFAULT_ROLE_PERMISSIONS: Record<string, string[]> = {
     'quality.create_wps',
     'quality.edit_wps',
     'quality.approve_wps',
+    'quality.mir.inspect',
+    'quality.mir.review',
+    'quality.mir.approve',
     // Project Planning
     'planning.view',
     'planning.create',
@@ -849,6 +855,7 @@ export const DEFAULT_ROLE_PERMISSIONS: Record<string, string[]> = {
     'quality.view_wps',
     'quality.create_wps',
     'quality.edit_wps',
+    'quality.mir.inspect',
     // Project Planning
     'planning.view',
     // Document Access

--- a/src/lib/services/qc/mir-evaluation.service.ts
+++ b/src/lib/services/qc/mir-evaluation.service.ts
@@ -1,0 +1,354 @@
+/**
+ * MIR Shipment Evaluation Service (v32.0.0)
+ * Manages per-shipment supplier evaluations linked to Material Inspection Receipts.
+ * Evaluations feed the "Evaluations Receiving Bank" and drive supplier aggregate ratings.
+ */
+
+import prisma from '@/lib/db';
+import { logger } from '@/lib/logger';
+import { v4 as uuidv4 } from 'uuid';
+
+// ─── Weight constants ─────────────────────────────────────────────────────────
+
+const MIR_WEIGHTS = {
+  quality:       0.30,
+  otif:          0.25,
+  service:       0.15,
+  documentation: 0.15,
+  hse:           0.10,
+  stacking:      0.05,
+} as const;
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface MirScores {
+  quality:       number;
+  otif:          number;
+  service:       number;
+  documentation: number;
+  hse:           number;
+  stacking:      number;
+}
+
+export interface CreateMirEvaluationInput {
+  mirId:              string;
+  evaluationDate:     string; // YYYY-MM-DD
+  scoreQuality:       number;
+  scoreOtif:          number;
+  scoreService:       number;
+  scoreDocumentation: number;
+  scoreHse:           number;
+  scoreStacking:      number;
+  notesQuality?:       string | null;
+  notesOtif?:          string | null;
+  notesService?:       string | null;
+  notesDocumentation?: string | null;
+  notesHse?:           string | null;
+  notesStacking?:      string | null;
+  generalNotes?:       string | null;
+  evaluatorId?:        string | null;
+  createdById:         string;
+}
+
+export interface ShipmentEvaluationRow {
+  id:                string;
+  mirId:             string;
+  mirNumber:         string;
+  dolibarrId:        number;
+  evaluationDate:    string;
+  scoreQuality:      number;
+  scoreOtif:         number;
+  scoreService:      number;
+  scoreDocumentation:number;
+  scoreHse:          number;
+  scoreStacking:     number;
+  weightedScore:     number;
+  rating:            string;
+  outcome:           string;
+  generalNotes:      string | null;
+  evaluatorName:     string | null;
+  createdAt:         string;
+}
+
+// ─── Pure helpers ─────────────────────────────────────────────────────────────
+
+export function computeMirWeightedScore(scores: MirScores): number {
+  return (
+    scores.quality       * 20 * MIR_WEIGHTS.quality +
+    scores.otif          * 20 * MIR_WEIGHTS.otif +
+    scores.service       * 20 * MIR_WEIGHTS.service +
+    scores.documentation * 20 * MIR_WEIGHTS.documentation +
+    scores.hse           * 20 * MIR_WEIGHTS.hse +
+    scores.stacking      * 20 * MIR_WEIGHTS.stacking
+  );
+}
+
+export function mirScoreToRating(score: number): 'A' | 'B' | 'C' | 'D' {
+  if (score >= 85) return 'A';
+  if (score >= 70) return 'B';
+  if (score >= 55) return 'C';
+  return 'D';
+}
+
+export function mirRatingToOutcome(rating: string): string {
+  if (rating === 'A') return 'APPROVED';
+  if (rating === 'B') return 'CONDITIONAL';
+  if (rating === 'C') return 'SUSPENDED';
+  return 'REJECTED';
+}
+
+// ─── Service functions ────────────────────────────────────────────────────────
+
+export async function getMirEvaluation(mirId: string) {
+  return prisma.mirShipmentEvaluation.findUnique({ where: { mirId } });
+}
+
+export async function createMirEvaluation(input: CreateMirEvaluationInput) {
+  const mir = await prisma.materialInspectionReceipt.findUnique({
+    where: { id: input.mirId },
+    select: { id: true, dolibarrSocId: true, receiptNumber: true },
+  });
+
+  if (!mir) throw Object.assign(new Error('MIR not found'), { status: 404 });
+  if (!mir.dolibarrSocId) {
+    throw Object.assign(
+      new Error('Cannot evaluate: this MIR has no supplier linked. It may predate the evaluation system.'),
+      { status: 422 },
+    );
+  }
+
+  const existing = await prisma.mirShipmentEvaluation.findUnique({ where: { mirId: input.mirId } });
+  if (existing) {
+    throw Object.assign(
+      new Error('An evaluation already exists for this MIR. Use PATCH to update it.'),
+      { status: 409 },
+    );
+  }
+
+  const weightedScore = computeMirWeightedScore({
+    quality:       input.scoreQuality,
+    otif:          input.scoreOtif,
+    service:       input.scoreService,
+    documentation: input.scoreDocumentation,
+    hse:           input.scoreHse,
+    stacking:      input.scoreStacking,
+  });
+  const rating  = mirScoreToRating(weightedScore);
+  const outcome = mirRatingToOutcome(rating);
+
+  const evaluation = await prisma.mirShipmentEvaluation.create({
+    data: {
+      id:                uuidv4(),
+      mirId:             input.mirId,
+      dolibarrId:        mir.dolibarrSocId,
+      evaluationDate:    new Date(input.evaluationDate),
+      scoreQuality:      input.scoreQuality,
+      scoreOtif:         input.scoreOtif,
+      scoreService:      input.scoreService,
+      scoreDocumentation:input.scoreDocumentation,
+      scoreHse:          input.scoreHse,
+      scoreStacking:     input.scoreStacking,
+      notesQuality:      input.notesQuality       ?? null,
+      notesOtif:         input.notesOtif          ?? null,
+      notesService:      input.notesService        ?? null,
+      notesDocumentation:input.notesDocumentation ?? null,
+      notesHse:          input.notesHse            ?? null,
+      notesStacking:     input.notesStacking       ?? null,
+      generalNotes:      input.generalNotes        ?? null,
+      weightedScore,
+      rating,
+      outcome,
+      evaluatorId:       input.evaluatorId  ?? null,
+      createdById:       input.createdById,
+    },
+  });
+
+  logger.info(
+    { mirId: input.mirId, mirNumber: mir.receiptNumber, dolibarrId: mir.dolibarrSocId, rating, weightedScore },
+    '[MIR Eval] Shipment evaluation created',
+  );
+
+  await recomputeSupplierAggregate(mir.dolibarrSocId);
+  return evaluation;
+}
+
+export async function updateMirEvaluation(
+  id: string,
+  input: Partial<Omit<CreateMirEvaluationInput, 'mirId' | 'createdById'>>,
+) {
+  const existing = await prisma.mirShipmentEvaluation.findUnique({
+    where: { id },
+    select: { dolibarrId: true },
+  });
+  if (!existing) throw Object.assign(new Error('Evaluation not found'), { status: 404 });
+
+  const scores: Partial<MirScores> = {
+    quality:       input.scoreQuality,
+    otif:          input.scoreOtif,
+    service:       input.scoreService,
+    documentation: input.scoreDocumentation,
+    hse:           input.scoreHse,
+    stacking:      input.scoreStacking,
+  };
+
+  const currentEval = await prisma.mirShipmentEvaluation.findUnique({ where: { id } });
+  if (!currentEval) throw Object.assign(new Error('Evaluation not found'), { status: 404 });
+
+  const mergedScores: MirScores = {
+    quality:       scores.quality       ?? currentEval.scoreQuality,
+    otif:          scores.otif          ?? currentEval.scoreOtif,
+    service:       scores.service       ?? currentEval.scoreService,
+    documentation: scores.documentation ?? currentEval.scoreDocumentation,
+    hse:           scores.hse           ?? currentEval.scoreHse,
+    stacking:      scores.stacking      ?? currentEval.scoreStacking,
+  };
+
+  const weightedScore = computeMirWeightedScore(mergedScores);
+  const rating  = mirScoreToRating(weightedScore);
+  const outcome = mirRatingToOutcome(rating);
+
+  const updated = await prisma.mirShipmentEvaluation.update({
+    where: { id },
+    data: {
+      ...(input.evaluationDate     !== undefined && { evaluationDate: new Date(input.evaluationDate) }),
+      ...(input.scoreQuality       !== undefined && { scoreQuality: input.scoreQuality }),
+      ...(input.scoreOtif          !== undefined && { scoreOtif: input.scoreOtif }),
+      ...(input.scoreService       !== undefined && { scoreService: input.scoreService }),
+      ...(input.scoreDocumentation !== undefined && { scoreDocumentation: input.scoreDocumentation }),
+      ...(input.scoreHse           !== undefined && { scoreHse: input.scoreHse }),
+      ...(input.scoreStacking      !== undefined && { scoreStacking: input.scoreStacking }),
+      ...(input.notesQuality       !== undefined && { notesQuality: input.notesQuality }),
+      ...(input.notesOtif          !== undefined && { notesOtif: input.notesOtif }),
+      ...(input.notesService       !== undefined && { notesService: input.notesService }),
+      ...(input.notesDocumentation !== undefined && { notesDocumentation: input.notesDocumentation }),
+      ...(input.notesHse           !== undefined && { notesHse: input.notesHse }),
+      ...(input.notesStacking      !== undefined && { notesStacking: input.notesStacking }),
+      ...(input.generalNotes       !== undefined && { generalNotes: input.generalNotes }),
+      ...(input.evaluatorId        !== undefined && { evaluatorId: input.evaluatorId }),
+      weightedScore,
+      rating,
+      outcome,
+    },
+  });
+
+  await recomputeSupplierAggregate(existing.dolibarrId);
+  return updated;
+}
+
+export async function getSupplierShipmentEvaluations(dolibarrId: number): Promise<ShipmentEvaluationRow[]> {
+  const rows = await prisma.$queryRawUnsafe<Record<string, unknown>[]>(`
+    SELECT
+      e.id,
+      e.mir_id       AS mirId,
+      r.receipt_number AS mirNumber,
+      e.dolibarr_id  AS dolibarrId,
+      e.evaluation_date AS evaluationDate,
+      e.score_quality      AS scoreQuality,
+      e.score_otif         AS scoreOtif,
+      e.score_service      AS scoreService,
+      e.score_documentation AS scoreDocumentation,
+      e.score_hse          AS scoreHse,
+      e.score_stacking     AS scoreStacking,
+      e.weighted_score     AS weightedScore,
+      e.rating,
+      e.outcome,
+      e.general_notes      AS generalNotes,
+      ev.name              AS evaluatorName,
+      e.created_at         AS createdAt
+    FROM mir_shipment_evaluations e
+    JOIN material_inspection_receipts r ON r.id = e.mir_id
+    LEFT JOIN User ev ON ev.id = e.evaluator_id
+    WHERE e.dolibarr_id = ?
+    ORDER BY e.evaluation_date DESC
+  `, dolibarrId);
+
+  const s = (v: unknown) => (v == null ? null : String(v));
+  return rows.map(r => ({
+    id:                s(r.id)!,
+    mirId:             s(r.mirId)!,
+    mirNumber:         s(r.mirNumber)!,
+    dolibarrId:        Number(r.dolibarrId),
+    evaluationDate:    r.evaluationDate instanceof Date
+      ? r.evaluationDate.toISOString().slice(0, 10)
+      : String(r.evaluationDate),
+    scoreQuality:       Number(r.scoreQuality),
+    scoreOtif:          Number(r.scoreOtif),
+    scoreService:       Number(r.scoreService),
+    scoreDocumentation: Number(r.scoreDocumentation),
+    scoreHse:           Number(r.scoreHse),
+    scoreStacking:      Number(r.scoreStacking),
+    weightedScore:      Number(r.weightedScore),
+    rating:             s(r.rating)!,
+    outcome:            s(r.outcome)!,
+    generalNotes:       s(r.generalNotes),
+    evaluatorName:      s(r.evaluatorName),
+    createdAt:          r.createdAt instanceof Date ? r.createdAt.toISOString() : String(r.createdAt),
+  }));
+}
+
+// ─── Private: recompute supplier aggregate ────────────────────────────────────
+
+async function recomputeSupplierAggregate(dolibarrId: number): Promise<void> {
+  try {
+    const aggRows = await prisma.$queryRawUnsafe<[{ avg_score: number | null; cnt: bigint }]>(`
+      SELECT AVG(weighted_score) AS avg_score, COUNT(*) AS cnt
+      FROM mir_shipment_evaluations
+      WHERE dolibarr_id = ?
+    `, dolibarrId);
+
+    const avg = Number(aggRows[0]?.avg_score ?? 0);
+    const cnt = Number(aggRows[0]?.cnt ?? 0);
+    if (cnt === 0) return;
+
+    const rating  = mirScoreToRating(avg);
+    const outcome = mirRatingToOutcome(rating);
+    const approvalStatus =
+      outcome === 'APPROVED'    ? 'APPROVED' :
+      outcome === 'CONDITIONAL' ? 'CONDITIONAL' :
+      'SUSPENDED';
+
+    const nameRows = await prisma.$queryRawUnsafe<[{ name: string; code_supplier: string | null }]>(`
+      SELECT name, code_supplier FROM dolibarr_thirdparties WHERE dolibarr_id = ?
+    `, dolibarrId);
+    if (!nameRows.length) return;
+
+    const codeSupplier = nameRows[0].code_supplier ?? null;
+    let supplierCode = codeSupplier;
+    if (!supplierCode) {
+      const last = await prisma.scApprovedSupplier.findFirst({
+        where: { supplierCode: { startsWith: 'SUP-' } },
+        orderBy: { supplierCode: 'desc' },
+        select: { supplierCode: true },
+      });
+      const n = last ? (parseInt(last.supplierCode.replace('SUP-', '')) || 0) + 1 : 1;
+      supplierCode = `SUP-${String(n).padStart(3, '0')}`;
+    }
+
+    const existing = await prisma.scApprovedSupplier.findFirst({
+      where: { dolibarrId, deletedAt: null },
+      select: { id: true },
+    });
+
+    if (existing) {
+      await prisma.scApprovedSupplier.update({
+        where: { id: existing.id },
+        data: { approvalStatus, rating, updatedAt: new Date() },
+      });
+    } else {
+      await prisma.scApprovedSupplier.create({
+        data: {
+          dolibarrId,
+          supplierCode,
+          name: nameRows[0].name,
+          approvalStatus,
+          rating,
+          approvalDate: new Date(),
+        },
+      });
+    }
+
+    logger.info({ dolibarrId, avg, rating, cnt }, '[MIR Eval] Supplier aggregate rating updated');
+  } catch (err) {
+    logger.error({ err, dolibarrId }, '[MIR Eval] Failed to recompute supplier aggregate');
+  }
+}

--- a/src/lib/startup-migrations.ts
+++ b/src/lib/startup-migrations.ts
@@ -233,8 +233,20 @@ const STARTUP_MIGRATIONS = [
   // ── Project wizard: arch drawings received flag on Building ───────────────
   'add_building_arch_drawings.sql',   // archDrawingsReceived BOOLEAN on Building
 
+  // ── v28.0.0 — MIR status backfill ────────────────────────────────────────
+  'v28_0_mir_status_backfill.sql',    // Backfill status field on existing MIR records
+
   // ── v29.0.0 — MIR Workflow (Inspector → Reviewer → Approver) ─────────────
   'v29_0_mir_workflow.sql',           // workflow_status + submission/review/approval timestamps on MIR
+
+  // ── v30.0.0 — MIR global serial ───────────────────────────────────────────
+  'v30_0_mir_global_serial.sql',      // Global receipt number serial (no monthly reset)
+
+  // ── v31.0.0 — SC contract PO link ─────────────────────────────────────────
+  'v31_0_sc_contract_po_link.sql',    // dolibarr_po_id on SubcontractorContract
+
+  // ── v32.0.0 — MIR workflow notifications + shipment evaluation bank ────────
+  'v32_0_mir_workflow_and_evaluation.sql', // dolibarr_soc_id on MIR; mir_shipment_evaluations table; MIR_INSPECTION workflow definition
 ];
 
 /**


### PR DESCRIPTION
**MIR Workflow Notifications**
- Seed WorkflowDefinition `MIR_INSPECTION` (3 steps: Inspector/Reviewer/Approver)
  resolved via PBAC permissions quality.mir.inspect/review/approve
- Add PBAC notifications to MIR workflow route on every transition:
  submit → notifies all users with quality.mir.review
  review → notifies all users with quality.mir.approve
  approve/reject → notifies inspector + submitter (deduplicated)
- Add 3 new permissions: quality.mir.inspect, quality.mir.review, quality.mir.approve
  (Engineer gets inspect, Manager gets all three)

**Shipment Evaluation Bank**
- New `mir_shipment_evaluations` table (one per MIR): Quality 30%, OTIF 25%,
  Service 15%, Documentation 15%, HSE & Ethics 10%, Stacking 5%
- Evaluation aggregate drives ScApprovedSupplier.rating (replaces manual FRM-002
  as primary source)
- New API routes: POST/GET/PATCH /api/qc/material-receipts/evaluate
  GET /api/supply-chain/suppliers/[id]/shipment-evaluations
- MIR table gains dolibarrSocId column (populated from PO socid on create)
- MIR list table 3-dot menu: "Evaluate Shipment" / "View Evaluation" per row
- Prompt to rate shipment appears after inspector submits (Draft → Inspected)
- ShipmentEvaluationDialog component with live weighted score preview
- Supplier portal: new "Shipment Ratings" tab (primary); existing Evaluations
  tab relabelled "Manual Evaluations" (secondary/legacy)

**Migrations**
- v32_0_mir_workflow_and_evaluation.sql: dolibarr_soc_id column, evaluations
  table, WorkflowDefinition seed
- Also registers previously unregistered v28, v30, v31 in startup-migrations

https://claude.ai/code/session_01ETyrGFCGduwf75aCPezfjP