### PR TITLE
fix: MIR inspection UX, rejectedQty, workflow auto-advance, and LCR r…

### DIFF
--- a/prisma/manual_migrations/v33_0_mir_backfill_soc_id_and_workflow.sql
+++ b/prisma/manual_migrations/v33_0_mir_backfill_soc_id_and_workflow.sql
@@ -1,0 +1,42 @@
+-- v33.0 — MIR Backfill: dolibarr_soc_id + workflow_status
+-- Part A: Backfill dolibarr_soc_id for old MIRs that have a supplier_name but no soc_id
+--         (dolibarr_soc_id was added in v32.0, so MIRs created before that have NULL)
+-- Part B: Backfill workflow_status = 'Inspected' for MIRs that are fully received & accepted
+--         but still show 'Draft' because they predate the auto-advance logic
+
+-- ── Part A: Backfill dolibarr_soc_id ────────────────────────────────────────
+
+DROP PROCEDURE IF EXISTS mir_backfill_soc_id;
+DELIMITER $$
+CREATE PROCEDURE mir_backfill_soc_id()
+BEGIN
+  UPDATE material_inspection_receipts mir
+  SET mir.dolibarr_soc_id = (
+    SELECT dt.dolibarr_id
+    FROM dolibarr_thirdparties dt
+    WHERE dt.name = mir.supplier_name
+    LIMIT 1
+  )
+  WHERE mir.dolibarr_soc_id IS NULL
+    AND mir.supplier_name IS NOT NULL;
+END$$
+DELIMITER ;
+CALL mir_backfill_soc_id();
+DROP PROCEDURE IF EXISTS mir_backfill_soc_id;
+
+-- ── Part B: Backfill workflow_status for completed MIRs ─────────────────────
+
+DROP PROCEDURE IF EXISTS mir_backfill_workflow_status;
+DELIMITER $$
+CREATE PROCEDURE mir_backfill_workflow_status()
+BEGIN
+  -- Mark as Inspected: fully received & accepted but still sitting at Draft
+  UPDATE material_inspection_receipts
+  SET workflow_status = 'Inspected',
+      submitted_at    = COALESCE(submitted_at, updated_at, NOW())
+  WHERE workflow_status = 'Draft'
+    AND status IN ('Received and Accepted', 'Partially Accepted', 'Rejected');
+END$$
+DELIMITER ;
+CALL mir_backfill_workflow_status();
+DROP PROCEDURE IF EXISTS mir_backfill_workflow_status;

--- a/src/app/api/qc/material-receipts/items/route.ts
+++ b/src/app/api/qc/material-receipts/items/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { verifySession } from '@/lib/jwt';
 import prisma from '@/lib/db';
+import { logger } from '@/lib/logger';
 
 export const dynamic = 'force-dynamic';
 
@@ -72,9 +73,20 @@ export async function PATCH(request: NextRequest) {
     // Build update data
     const updateData: Record<string, unknown> = {};
 
-    if (receivedQty !== undefined) updateData.receivedQty = parseFloat(receivedQty);
-    if (acceptedQty !== undefined) updateData.acceptedQty = parseFloat(acceptedQty);
-    if (rejectedQty !== undefined) updateData.rejectedQty = parseFloat(rejectedQty);
+    const parsedReceivedQty = receivedQty !== undefined ? parseFloat(receivedQty) : undefined;
+    const parsedAcceptedQty = acceptedQty !== undefined ? parseFloat(acceptedQty) : undefined;
+
+    if (parsedReceivedQty !== undefined && !isNaN(parsedReceivedQty)) updateData.receivedQty = parsedReceivedQty;
+    if (parsedAcceptedQty !== undefined && !isNaN(parsedAcceptedQty)) updateData.acceptedQty = parsedAcceptedQty;
+
+    // Auto-compute rejectedQty: if not provided or empty, derive from received - accepted
+    if (rejectedQty !== undefined && rejectedQty !== '' && !isNaN(parseFloat(rejectedQty))) {
+      updateData.rejectedQty = parseFloat(rejectedQty);
+    } else if (parsedAcceptedQty !== undefined && !isNaN(parsedAcceptedQty)) {
+      const rec = parsedReceivedQty ?? 0;
+      updateData.rejectedQty = Math.max(0, rec - parsedAcceptedQty);
+    }
+
     if (qualityStatus) updateData.qualityStatus = qualityStatus;
 
     if (surfaceCondition !== undefined) updateData.surfaceCondition = surfaceCondition;
@@ -125,14 +137,35 @@ export async function PATCH(request: NextRequest) {
     });
 
     const newStatus = computeReceiptStatus(allItems);
+
+    // Auto-advance workflow from Draft → Inspected when all items have been inspected
+    const allInspected = allItems.length > 0 && allItems.every(i => i.inspectionResult !== 'Pending');
+    const receiptMeta = allInspected
+      ? await prisma.materialInspectionReceipt.findUnique({
+          where: { id: item.receiptId },
+          select: { workflowStatus: true },
+        })
+      : null;
+
+    const shouldAutoAdvance =
+      allInspected &&
+      (receiptMeta?.workflowStatus === 'Draft' || receiptMeta?.workflowStatus === null);
+
     await prisma.materialInspectionReceipt.update({
       where: { id: item.receiptId },
-      data: { status: newStatus },
+      data: {
+        status: newStatus,
+        ...(shouldAutoAdvance && {
+          workflowStatus: 'Inspected',
+          submittedAt: new Date(),
+          submittedById: session.sub,
+        }),
+      },
     });
 
-    return NextResponse.json(item);
+    return NextResponse.json({ ...item, _receiptAutoAdvanced: shouldAutoAdvance });
   } catch (error) {
-    console.error('Error updating receipt item:', error);
+    logger.error({ error }, 'Error updating receipt item');
     return NextResponse.json(
       { error: 'Failed to update receipt item' },
       { status: 500 }
@@ -179,7 +212,7 @@ export async function DELETE(request: NextRequest) {
 
     return NextResponse.json({ success: true });
   } catch (error) {
-    console.error('Error deleting receipt item:', error);
+    logger.error({ error }, 'Error deleting receipt item');
     return NextResponse.json(
       { error: 'Failed to delete receipt item' },
       { status: 500 }

--- a/src/app/qc/material/_page-client.tsx
+++ b/src/app/qc/material/_page-client.tsx
@@ -402,12 +402,18 @@ export default function MaterialInspectionReceiptPage() {
       });
 
       if (response.ok) {
+        const itemResult = await response.json();
+        const autoAdvanced = itemResult._receiptAutoAdvanced === true;
         setInspectingItem(null);
         if (selectedReceipt) {
           const refreshResponse = await fetch(`/api/qc/material-receipts?id=${selectedReceipt.id}`);
           if (refreshResponse.ok) {
             const updatedReceipt = await refreshResponse.json();
             setSelectedReceipt(updatedReceipt);
+            // Show evaluation prompt when all items are inspected (workflow auto-advanced)
+            if (autoAdvanced && !updatedReceipt.evaluation && (updatedReceipt.dolibarrSocId || updatedReceipt.supplierName)) {
+              setEvaluationPromptReceipt(updatedReceipt);
+            }
           }
         }
         fetchReceipts();
@@ -541,7 +547,7 @@ export default function MaterialInspectionReceiptPage() {
         }
         fetchReceipts();
         // Prompt to rate the shipment after inspector submits (only if no evaluation yet)
-        if (wasSubmit && !submittedReceipt.evaluation && submittedReceipt.dolibarrSocId) {
+        if (wasSubmit && !submittedReceipt.evaluation && (submittedReceipt.dolibarrSocId || submittedReceipt.supplierName)) {
           setEvaluationPromptReceipt(submittedReceipt);
         }
       }
@@ -838,9 +844,9 @@ export default function MaterialInspectionReceiptPage() {
                               </DropdownMenuItem>
                             ) : (
                               <DropdownMenuItem
-                                disabled={!receipt.dolibarrSocId}
+                                disabled={!receipt.dolibarrSocId && !receipt.supplierName}
                                 onClick={() => { setEvaluationDialogExisting(null); setEvaluationDialogMir(receipt); }}
-                                title={!receipt.dolibarrSocId ? 'This MIR predates shipment evaluations' : undefined}
+                                title={!receipt.dolibarrSocId && !receipt.supplierName ? 'No supplier linked to this MIR' : undefined}
                               >
                                 <Star className="h-4 w-4 mr-2" /> Evaluate Shipment
                               </DropdownMenuItem>

--- a/src/lib/services/qc/mir-evaluation.service.ts
+++ b/src/lib/services/qc/mir-evaluation.service.ts
@@ -106,11 +106,33 @@ export async function getMirEvaluation(mirId: string) {
 export async function createMirEvaluation(input: CreateMirEvaluationInput) {
   const mir = await prisma.materialInspectionReceipt.findUnique({
     where: { id: input.mirId },
-    select: { id: true, dolibarrSocId: true, receiptNumber: true },
+    select: { id: true, dolibarrSocId: true, receiptNumber: true, supplierName: true },
   });
 
   if (!mir) throw Object.assign(new Error('MIR not found'), { status: 404 });
-  if (!mir.dolibarrSocId) {
+
+  // If dolibarrSocId is missing, try to resolve it from dolibarr_thirdparties by supplier name
+  let resolvedSocId = mir.dolibarrSocId;
+  if (!resolvedSocId && mir.supplierName) {
+    try {
+      const rows = await prisma.$queryRawUnsafe<[{ dolibarr_id: number }]>(
+        'SELECT dolibarr_id FROM dolibarr_thirdparties WHERE name = ? LIMIT 1',
+        mir.supplierName,
+      );
+      if (rows.length > 0 && rows[0].dolibarr_id) {
+        resolvedSocId = Number(rows[0].dolibarr_id);
+        await prisma.materialInspectionReceipt.update({
+          where: { id: mir.id },
+          data: { dolibarrSocId: resolvedSocId },
+        });
+        logger.info({ mirId: mir.id, resolvedSocId, supplierName: mir.supplierName }, '[MIR Eval] Resolved dolibarrSocId from supplier name');
+      }
+    } catch (err) {
+      logger.warn({ err, mirId: mir.id }, '[MIR Eval] Could not auto-resolve dolibarrSocId from supplier name');
+    }
+  }
+
+  if (!resolvedSocId) {
     throw Object.assign(
       new Error('Cannot evaluate: this MIR has no supplier linked. It may predate the evaluation system.'),
       { status: 422 },
@@ -140,7 +162,7 @@ export async function createMirEvaluation(input: CreateMirEvaluationInput) {
     data: {
       id:                uuidv4(),
       mirId:             input.mirId,
-      dolibarrId:        mir.dolibarrSocId,
+      dolibarrId:        resolvedSocId,
       evaluationDate:    new Date(input.evaluationDate),
       scoreQuality:      input.scoreQuality,
       scoreOtif:         input.scoreOtif,
@@ -164,11 +186,11 @@ export async function createMirEvaluation(input: CreateMirEvaluationInput) {
   });
 
   logger.info(
-    { mirId: input.mirId, mirNumber: mir.receiptNumber, dolibarrId: mir.dolibarrSocId, rating, weightedScore },
+    { mirId: input.mirId, mirNumber: mir.receiptNumber, dolibarrId: resolvedSocId, rating, weightedScore },
     '[MIR Eval] Shipment evaluation created',
   );
 
-  await recomputeSupplierAggregate(mir.dolibarrSocId);
+  await recomputeSupplierAggregate(resolvedSocId);
   return evaluation;
 }
 

--- a/src/lib/sync/lcrSync.ts
+++ b/src/lib/sync/lcrSync.ts
@@ -278,6 +278,9 @@ export async function runLcrSync(triggeredBy: 'cron' | 'manual', forceRefresh = 
   let pendingAliases = 0;
 
   try {
+    // Ensure Prisma engine is connected (cron jobs may run after idle periods where engine disconnects)
+    await prisma.$connect();
+
     // 0. Load column mapping and settings from DB
     const col = await loadColMap();
     const minProjectNumber = await loadMinProjectNumber();
@@ -571,22 +574,30 @@ async function writeSyncLog(
   durationMs: number,
   errorMessage: string | null,
 ): Promise<void> {
-  try {
-    await prisma.lcrSyncLog.create({
-      data: {
-        status,
-        triggeredBy,
-        totalRows,
-        rowsInserted,
-        rowsUpdated,
-        rowsUnchanged,
-        rowsDeleted,
-        pendingAliases,
-        durationMs,
-        errorMessage,
-      },
-    });
-  } catch (err) {
-    log.error({ error: err }, 'Failed to write LCR sync log');
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      await prisma.lcrSyncLog.create({
+        data: {
+          status,
+          triggeredBy,
+          totalRows,
+          rowsInserted,
+          rowsUpdated,
+          rowsUnchanged,
+          rowsDeleted,
+          pendingAliases,
+          durationMs,
+          errorMessage,
+        },
+      });
+      return;
+    } catch (err) {
+      if (attempt === 0) {
+        // Engine may have disconnected — reconnect and retry once
+        try { await prisma.$connect(); } catch { /* ignore */ }
+      } else {
+        log.error({ error: err }, 'Failed to write LCR sync log');
+      }
+    }
   }
 }


### PR DESCRIPTION
…econnect

- items/route: auto-compute rejectedQty as max(0, received-accepted) when not provided — fixes Prisma missing-argument error when all qty is accepted
- items/route: auto-advance workflowStatus Draft→Inspected when all items are inspected, and signal _receiptAutoAdvanced to the client
- _page-client: enable "Evaluate Shipment" for any MIR with a supplierName (not just those with dolibarrSocId); show evaluation prompt on auto-advance
- mir-evaluation.service: auto-resolve dolibarrSocId from dolibarr_thirdparties by supplier name when the MIR record has null soc_id (pre-v32 MIRs)
- v33 migration: backfill dolibarr_soc_id for old MIRs by matching supplier name; backfill workflow_status=Inspected for Received & Accepted MIRs
- lcrSync: call prisma.$connect() at sync start and add reconnect-retry in writeSyncLog to handle "Engine is not yet connected" cron-idle errors

https://claude.ai/code/session_01JmqZnTC1JNezstbwAW9qZV