### PR TITLE
fix: sync date_livraison from Dolibarr detail endpoint for MIR planned delivery date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [23.9.0] - 2026-05-24
+
+### Fixed
+- **Dolibarr: Planned delivery date always "Not set" in MIR and PO modal** — Dolibarr's `supplierorders` list endpoint returns `date_livraison: 0` even when the date is configured in the ERP. The correct timestamp is only available from the individual PO detail endpoint (`supplierorders/{id}`). Both the Dolibarr Integration page PO modal and the MIR creation flow were using list data and therefore always showed `—` / "Not set".
+- **Dolibarr Integration page: PO modal "Delivery Date: —"** — Clicking a PO row now fires a follow-up fetch to `/api/dolibarr/purchase-orders?orderId={id}` to retrieve the full detail. The modal opens immediately with list data and shows a brief "Loading…" indicator while fetching; the real delivery date is rendered once the detail arrives.
+- **MIR creation: `plannedDeliveryDate` always `null`** — After the user selects a PO in the lookup dialog, the full PO detail is now fetched before the MIR is submitted. The correct Unix timestamp is converted and persisted to the DB.
+- **sync-delivery-dates: `date_livraison: "0"` string bypassing update** — The previous `!po.date_livraison` guard was truthy-falsy and missed the string `"0"` case. Replaced with an explicit `Number(ts) <= 0` check so any zero-value (numeric or string) is treated as "date not set".
+
+### Notes
+- Existing MIRs with `plannedDeliveryDate: null` can be fixed in one pass by pressing **"Sync Delivery Dates"** on the Dolibarr Integration page.
+
+---
+
 ## [23.8.0] - 2026-05-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
 # Hexa Steel® Operations Tracking System (OTS™)
 
-**Version:** 23.5.0 | **Release Date:** May 8, 2026
+**Version:** 23.9.0 | **Release Date:** May 24, 2026
 
 A comprehensive Enterprise Resource Planning (ERP) system specifically designed for steel fabrication and construction projects. Built with Next.js 15, TypeScript, Prisma 6, and MySQL 8.
 
-### What's New in 23.5.0 — Version synchronization
-- Version synchronization across all surfaces following branch consolidation.
+### What's New in 23.9.0 — Dolibarr Planned Delivery Date Fix
+- **Fixed:** Dolibarr planned delivery date (`date_livraison`) was always showing as "Not set" in MIRs and the Dolibarr PO modal. The list endpoint returns `0`; the fix fetches the full PO detail on demand.
+- **MIR creation:** `plannedDeliveryDate` is now correctly persisted by fetching the PO detail before the MIR is written.
+- **Sync Delivery Dates:** improved `date_livraison: "0"` string guard in the sync endpoint.
+
+### What's New in 23.8.0 — Report a Violation, Dolibarr PO Sync & MIR Eval Icon
+- New confidential/anonymous "Report a Violation" feature for all team members.
+- Dolibarr: "Sync Delivery Dates" button updates MIR planned delivery from `date_livraison`.
+- MIR list: Eval column with A/B/C/D rating badge.
 
 ### What's New in 22.5.3 — Stability & Version Alignment
 - Confirms **22.5.2** features as stable: Account Invoice Report, orphan purge, and sidebar double-render fix.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexa-steel-ots",
-  "version": "23.8.0",
+  "version": "23.9.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/api/dolibarr/sync-delivery-dates/route.ts
+++ b/src/app/api/dolibarr/sync-delivery-dates/route.ts
@@ -46,9 +46,12 @@ export const POST = withApiContext(async (_req: NextRequest) => {
     if (!mir.dolibarrPoId) continue;
     try {
       const po = await client.getPurchaseOrderById(String(mir.dolibarrPoId));
-      if (!po || !po.date_livraison) continue;
+      if (!po) continue;
+      // Dolibarr returns 0 (number or string) when the date is not set
+      const tsNum = Number(po.date_livraison);
+      if (!tsNum || tsNum <= 0) continue;
 
-      const newDeliveryDate = new Date(Number(po.date_livraison) * 1000);
+      const newDeliveryDate = new Date(tsNum * 1000);
       const existingDate = mir.plannedDeliveryDate ? new Date(mir.plannedDeliveryDate) : null;
 
       // Only update if date actually changed (compare day-level)

--- a/src/app/api/system/latest-version/route.ts
+++ b/src/app/api/system/latest-version/route.ts
@@ -7,22 +7,23 @@ const { version: pkgVersion } = require('../../../../../package.json') as { vers
 
 const CURRENT_VERSION = {
   version: pkgVersion,
-  date: 'May 8, 2026',
+  date: 'May 24, 2026',
   type: 'minor' as const,
-  mainTitle: 'Version synchronization',
+  mainTitle: 'Dolibarr Planned Delivery Date Fix',
   highlights: [
-    'Version synchronization across all surfaces following branch consolidation.',
+    'Fixed: Dolibarr planned delivery date (date_livraison) was always showing as "Not set" in MIRs and the Dolibarr PO modal.',
+    'Dolibarr Integration page: PO modal now fetches full PO detail on click — delivery date shows correctly.',
+    'MIR creation: planned delivery date is now fetched from the Dolibarr detail endpoint before the MIR is written, so it is always persisted correctly.',
+    'Sync Delivery Dates: improved guard handles date_livraison returned as string "0" from the API.',
   ],
   changes: {
-    added: [
-      'Submitter name and date shown in backlog item detail page header.',
-      'Copy description button with visual feedback on backlog item detail page.',
-      'Share on WhatsApp button in Quick Actions sidebar.',
+    added: [],
+    fixed: [
+      'Dolibarr planned delivery date (date_livraison) displayed as "—" / "Not set" — the list endpoint returns 0 even when the date is set; now fetches full PO detail on demand.',
+      'MIR plannedDeliveryDate always null on creation — now resolved by fetching the PO detail endpoint after user selects a PO.',
+      'sync-delivery-dates: date_livraison "0" string no longer triggers a bogus epoch update.',
     ],
-    fixed: [],
-    changed: [
-      'Version bumped to 23.5.0',
-    ],
+    changed: [],
   },
 };
 

--- a/src/app/changelog/_page-client.tsx
+++ b/src/app/changelog/_page-client.tsx
@@ -23,10 +23,34 @@ type ChangelogVersion = {
 // Version order: Most recent first
 const hardcodedVersions: ChangelogVersion[] = [
   {
+    version: '23.9.0',
+    date: 'May 24, 2026',
+    type: 'minor',
+    status: 'current',
+    mainTitle: 'Dolibarr Planned Delivery Date Fix',
+    highlights: [
+      'Fixed: Dolibarr planned delivery date (date_livraison) was always "Not set" in MIRs and the Dolibarr PO modal — the list endpoint returns 0 even when the date is set in Dolibarr.',
+      'Dolibarr Integration page: clicking a PO row now fetches the full detail so the delivery date shows correctly in the modal (with a brief "Loading…" indicator).',
+      'MIR creation: after selecting a PO, the full PO detail is fetched before the MIR is written — plannedDeliveryDate is now always persisted correctly.',
+      'Sync Delivery Dates endpoint: improved guard handles date_livraison returned as string "0" or numeric 0 from the Dolibarr API.',
+    ],
+    changes: {
+      added: [],
+      fixed: [
+        'Dolibarr PO modal "Delivery Date: —" — the supplierorders list endpoint returns date_livraison: 0 even when the date is set; the modal now fires a follow-up fetch to supplierorders/{id} on click and shows the real date.',
+        'MIR plannedDeliveryDate always null on creation — handleSelectPO now fetches the PO detail endpoint after user selection so the correct timestamp is used when writing the MIR to the DB.',
+        'MIR create dialog "Planned Delivery Date: Not set in Dolibarr" — same root cause as above; resolved by the detail fetch.',
+        'sync-delivery-dates: !po.date_livraison check was skipping records where date_livraison was returned as string "0"; replaced with Number(ts) <= 0 guard.',
+        'Existing MIRs with plannedDeliveryDate: null can now be fixed by pressing "Sync Delivery Dates" on the Dolibarr Integration page.',
+      ],
+      changed: [],
+    },
+  },
+  {
     version: '23.8.0',
     date: 'May 23, 2026',
     type: 'minor',
-    status: 'current',
+    status: 'previous',
     mainTitle: 'Report a Violation, Dolibarr PO Sync & MIR Eval Icon',
     highlights: [
       'New confidential/anonymous "Report a Violation" feature for all team members — categories include Misconduct, Financial Misuse, Safety Violation, etc.',

--- a/src/app/dolibarr/_page-client.tsx
+++ b/src/app/dolibarr/_page-client.tsx
@@ -163,6 +163,7 @@ export default function DolibarrIntegrationPage() {
   const [poSearch, setPoSearch] = useState('');
   const [syncingDeliveryDates, setSyncingDeliveryDates] = useState(false);
   const [deliveryDateSyncResult, setDeliveryDateSyncResult] = useState<{ updated: number; errors: number } | null>(null);
+  const [poDetailLoading, setPoDetailLoading] = useState(false);
   const [poRealTotal, setPoRealTotal] = useState<number | null>(null);
   const [poCountLoading, setPoCountLoading] = useState(false);
   const [lastPoRefresh, setLastPoRefresh] = useState<string | null>(null);
@@ -1020,7 +1021,19 @@ export default function DolibarrIntegrationPage() {
                           <tr
                             key={po.id}
                             className="border-b last:border-0 hover:bg-muted/50 cursor-pointer transition-colors"
-                            onClick={() => setSelectedPO(po)}
+                            onClick={async () => {
+                              setSelectedPO(po); // Show modal immediately with list data
+                              setPoDetailLoading(true);
+                              try {
+                                const res = await fetch(`/api/dolibarr/purchase-orders?orderId=${po.id}`);
+                                if (res.ok) {
+                                  const data = await res.json();
+                                  if (data.order) setSelectedPO(data.order);
+                                }
+                              } catch { /* non-fatal — keep list data */ } finally {
+                                setPoDetailLoading(false);
+                              }
+                            }}
                           >
                             <td className="py-2 px-3 font-mono text-xs font-semibold">{po.ref}</td>
                             <td className="py-2 px-3 text-xs">{po.supplier_name || '—'}</td>
@@ -1116,7 +1129,13 @@ export default function DolibarrIntegrationPage() {
                       <div>
                         <p className="text-xs text-muted-foreground">Delivery Date</p>
                         <p className="font-medium mt-1">
-                          {selectedPO.date_livraison ? new Date(Number(selectedPO.date_livraison) * 1000).toLocaleDateString() : '—'}
+                          {poDetailLoading ? (
+                            <span className="text-muted-foreground text-xs animate-pulse">Loading…</span>
+                          ) : (
+                            (Number(selectedPO.date_livraison) > 0)
+                              ? new Date(Number(selectedPO.date_livraison) * 1000).toLocaleDateString('en-SA-u-ca-gregory', { day: '2-digit', month: 'short', year: 'numeric' })
+                              : '—'
+                          )}
                         </p>
                       </div>
                     </div>

--- a/src/app/qc/material/_page-client.tsx
+++ b/src/app/qc/material/_page-client.tsx
@@ -304,10 +304,25 @@ export default function MaterialInspectionReceiptPage() {
     }
   };
 
-  const handleSelectPO = (po: PurchaseOrder) => {
+  const handleSelectPO = async (po: PurchaseOrder) => {
     setSelectedPO(po);
     setShowPOLookup(false);
     setShowCreateReceipt(true);
+
+    // Dolibarr's list endpoint returns date_livraison: 0 even when the date is
+    // set in Dolibarr — only the detail endpoint returns the real value.
+    // Fetch the full PO so the planned delivery date is correct on the MIR.
+    try {
+      const res = await fetch(`/api/dolibarr/purchase-orders?orderId=${po.id}`);
+      if (res.ok) {
+        const data = await res.json();
+        if (data.order) {
+          setSelectedPO(prev =>
+            prev ? { ...prev, date_livraison: data.order.date_livraison ?? prev.date_livraison } : prev,
+          );
+        }
+      }
+    } catch { /* non-fatal — proceed with list data */ }
   };
 
   const handleCreateReceipt = async () => {
@@ -335,7 +350,7 @@ export default function MaterialInspectionReceiptPage() {
           supplierName: selectedPO.supplier_name,
           dolibarrSocId: selectedPO.socid ?? null,
           projectId: (selectedProject && selectedProject !== '__none__') ? selectedProject : null,
-          plannedDeliveryDate: selectedPO.date_livraison
+          plannedDeliveryDate: (Number(selectedPO.date_livraison) > 0)
             ? new Date(Number(selectedPO.date_livraison) * 1000).toISOString()
             : null,
           items,
@@ -1058,8 +1073,8 @@ export default function MaterialInspectionReceiptPage() {
                 </div>
                 <div>
                   <p className="text-xs text-muted-foreground">Planned Delivery Date</p>
-                  <p className={`font-medium ${selectedPO.date_livraison ? '' : 'text-muted-foreground'}`}>
-                    {selectedPO.date_livraison
+                  <p className={`font-medium ${Number(selectedPO.date_livraison) > 0 ? '' : 'text-muted-foreground'}`}>
+                    {Number(selectedPO.date_livraison) > 0
                       ? new Date(Number(selectedPO.date_livraison) * 1000).toLocaleDateString('en-SA-u-ca-gregory', { day: '2-digit', month: 'short', year: 'numeric' })
                       : 'Not set in Dolibarr'}
                   </p>

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -9,7 +9,7 @@ const { version: pkgVersion } = require('../../package.json') as { version: stri
 
 export const APP_VERSION = {
   version: pkgVersion,
-  date: 'May 8, 2026',
+  date: 'May 24, 2026',
   type: 'minor' as const,
   name: 'Hexa Steel Operation Tracking System',
 };


### PR DESCRIPTION
Dolibarr's supplierorders list endpoint returns date_livraison: 0 even
when a planned delivery date is set in the ERP. The correct value is only
available from the individual PO detail endpoint (supplierorders/{id}).

Fixes:
- Dolibarr Integration page: fetch full PO detail on row click so the
  modal shows the real delivery date (with 'Loading…' while fetching)
- MIR create flow: after user selects a PO, fetch its full detail to
  populate date_livraison before the MIR is written to the DB
- Guard all date_livraison checks with Number(ts) > 0 so a '0' / 0
  value is treated as 'not set' in both display and save paths
- sync-delivery-dates: replace !po.date_livraison with an explicit
  tsNum <= 0 check so string '0' is also handled correctly

Existing MIRs with plannedDeliveryDate: null can be fixed by running
the 'Sync Delivery Dates' button on the Dolibarr Integration page.