### PR TITLE
feat: Sync PO button + delivery date sync via new /api/dolibarr/sync-pos

### DIFF
--- a/src/app/api/dolibarr/sync-pos/route.ts
+++ b/src/app/api/dolibarr/sync-pos/route.ts
@@ -1,0 +1,127 @@
+/**
+ * POST /api/dolibarr/sync-pos
+ *
+ * Syncs Purchase Order data from Dolibarr:
+ * - For each MIR that has a dolibarrPoId, fetches the current PO detail from
+ *   Dolibarr (detail endpoint returns real date_livraison; list endpoint returns 0)
+ *   and updates plannedDeliveryDate if it differs.
+ * - Logs the result to dolibarr_sync_log (entity_type = 'purchaseorders').
+ * - Stores last_po_sync timestamp in dolibarr_integration_config.
+ */
+
+import { NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
+import { withApiContext } from '@/lib/api-utils';
+import { getCurrentUserPermissions } from '@/lib/permission-checker';
+import prisma from '@/lib/db';
+import { createDolibarrClient } from '@/lib/dolibarr/dolibarr-client';
+import { logger } from '@/lib/logger';
+
+export const POST = withApiContext(async (_req: NextRequest) => {
+  const permissions = await getCurrentUserPermissions();
+  const canSync = permissions.some(p =>
+    ['dolibarr.sync', 'dolibarr.view', 'admin.identity.reconcile'].includes(p)
+  );
+
+  if (!canSync) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const startTime = Date.now();
+  const client = createDolibarrClient();
+
+  // Fetch all MIRs that have a linked Dolibarr PO
+  const mirs = await prisma.materialInspectionReceipt.findMany({
+    where: { dolibarrPoId: { not: '' } },
+    select: {
+      id: true,
+      dolibarrPoId: true,
+      plannedDeliveryDate: true,
+    },
+  });
+
+  let updated = 0;
+  let errors = 0;
+
+  for (const mir of mirs) {
+    if (!mir.dolibarrPoId) continue;
+    try {
+      // Use detail endpoint — list endpoint always returns date_livraison: 0
+      const po = await client.getPurchaseOrderById(String(mir.dolibarrPoId));
+      if (!po) continue;
+
+      // Dolibarr returns 0 (number or string) when the delivery date is not set
+      const tsNum = Number(po.date_livraison);
+      if (!tsNum || tsNum <= 0) continue;
+
+      const newDeliveryDate = new Date(tsNum * 1000);
+      const existingDate = mir.plannedDeliveryDate ? new Date(mir.plannedDeliveryDate) : null;
+
+      // Compare at day level to avoid spurious updates from time-of-day differences
+      const newDay = newDeliveryDate.toISOString().split('T')[0];
+      const existingDay = existingDate ? existingDate.toISOString().split('T')[0] : null;
+
+      if (newDay !== existingDay) {
+        await prisma.materialInspectionReceipt.update({
+          where: { id: mir.id },
+          data: { plannedDeliveryDate: newDeliveryDate },
+        });
+        updated++;
+        logger.info(
+          { mirId: mir.id, dolibarrPoId: mir.dolibarrPoId, newDeliveryDate },
+          'MIR planned delivery date synced from Dolibarr PO sync'
+        );
+      }
+    } catch (err) {
+      errors++;
+      logger.warn(
+        { err, mirId: mir.id, dolibarrPoId: mir.dolibarrPoId },
+        'Failed to sync delivery date for MIR during PO sync'
+      );
+    }
+  }
+
+  const durationMs = Date.now() - startTime;
+  const now = new Date().toISOString();
+  const syncStatus =
+    errors === 0 ? 'success' : updated > 0 ? 'partial' : 'error';
+
+  // Log to dolibarr_sync_log so it appears in the Sync History table
+  try {
+    await prisma.$executeRawUnsafe(
+      `INSERT INTO dolibarr_sync_log (
+         entity_type, status, records_created, records_updated,
+         records_unchanged, records_deactivated, total_records,
+         duration_ms, error_message, triggered_by
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      'purchaseorders',
+      syncStatus,
+      0,
+      updated,
+      mirs.length - updated - errors,
+      0,
+      mirs.length,
+      durationMs,
+      errors > 0 ? `${errors} MIR(s) failed` : null,
+      'manual',
+    );
+  } catch (logErr) {
+    logger.warn({ logErr }, 'Failed to log PO sync to dolibarr_sync_log');
+  }
+
+  // Persist last sync time so the overview card shows a real timestamp
+  try {
+    await prisma.$executeRawUnsafe(
+      `INSERT INTO dolibarr_integration_config (config_key, config_value)
+       VALUES (?, ?)
+       ON DUPLICATE KEY UPDATE config_value = ?, updated_at = NOW()`,
+      'last_po_sync',
+      now,
+      now,
+    );
+  } catch (configErr) {
+    logger.warn({ configErr }, 'Failed to save last_po_sync to dolibarr_integration_config');
+  }
+
+  return NextResponse.json({ updated, errors, total: mirs.length });
+});

--- a/src/app/dolibarr/_page-client.tsx
+++ b/src/app/dolibarr/_page-client.tsx
@@ -47,6 +47,7 @@ interface SyncStatus {
   lastThirdpartiesSync: string | null;
   lastContactsSync: string | null;
   lastFullSync: string | null;
+  lastPoSync: string | null;
   recordCounts: {
     products: { total: number; active: number; withSpecs: number };
     thirdparties: { total: number; active: number };
@@ -161,12 +162,11 @@ export default function DolibarrIntegrationPage() {
   const [poTotal, setPoTotal] = useState(0);
   const [selectedPO, setSelectedPO] = useState<PurchaseOrder | null>(null);
   const [poSearch, setPoSearch] = useState('');
-  const [syncingDeliveryDates, setSyncingDeliveryDates] = useState(false);
-  const [deliveryDateSyncResult, setDeliveryDateSyncResult] = useState<{ updated: number; errors: number } | null>(null);
+  const [syncingPos, setSyncingPos] = useState(false);
+  const [poSyncResult, setPoSyncResult] = useState<{ updated: number; errors: number } | null>(null);
   const [poDetailLoading, setPoDetailLoading] = useState(false);
   const [poRealTotal, setPoRealTotal] = useState<number | null>(null);
   const [poCountLoading, setPoCountLoading] = useState(false);
-  const [lastPoRefresh, setLastPoRefresh] = useState<string | null>(null);
 
   // Reference data
   const [refData, setRefData] = useState<any>(null);
@@ -290,8 +290,6 @@ export default function DolibarrIntegrationPage() {
     fetchSyncStatus();
     fetchReferenceData();
     fetchPoCount();
-    const stored = localStorage.getItem('dolibarr_last_po_refresh');
-    if (stored) setLastPoRefresh(stored);
   }, [fetchSyncStatus, fetchReferenceData, fetchPoCount]);
   useEffect(() => { if (activeTab === 'products') fetchProducts(); }, [activeTab, fetchProducts]);
   useEffect(() => { if (activeTab === 'thirdparties') fetchThirdParties(); }, [activeTab, fetchThirdParties]);
@@ -335,19 +333,21 @@ export default function DolibarrIntegrationPage() {
     }
   };
 
-  const handleSyncDeliveryDates = async () => {
-    setSyncingDeliveryDates(true);
-    setDeliveryDateSyncResult(null);
+  const handleSyncPos = async () => {
+    setSyncingPos(true);
+    setPoSyncResult(null);
     try {
-      const res = await fetch('/api/dolibarr/sync-delivery-dates', { method: 'POST' });
+      const res = await fetch('/api/dolibarr/sync-pos', { method: 'POST' });
       if (res.ok) {
         const data = await res.json();
-        setDeliveryDateSyncResult({ updated: data.updated ?? 0, errors: data.errors ?? 0 });
+        setPoSyncResult({ updated: data.updated ?? 0, errors: data.errors ?? 0 });
+        // Refresh sync status so the Last Sync timestamp and history update
+        fetchSyncStatus();
       }
     } catch (err) {
-      console.error('Delivery date sync failed:', err);
+      console.error('PO sync failed:', err);
     } finally {
-      setSyncingDeliveryDates(false);
+      setSyncingPos(false);
     }
   };
 
@@ -540,7 +540,7 @@ export default function DolibarrIntegrationPage() {
                       </div>
                       <div className="flex justify-between text-sm">
                         <span className="text-muted-foreground">Purchase Orders:</span>
-                        <span>{lastPoRefresh ? formatDate(lastPoRefresh) : 'Not refreshed'}</span>
+                        <span>{syncStatus.lastPoSync ? formatDate(syncStatus.lastPoSync) : 'Not synced'}</span>
                       </div>
                     </CardContent>
                   </Card>
@@ -603,23 +603,19 @@ export default function DolibarrIntegrationPage() {
                     <Button variant="outline" size="sm" onClick={() => handleSync('contacts')} disabled={syncing}>
                       <FileText className="h-4 w-4 mr-1" /> Sync Contacts
                     </Button>
-                    <Button variant="outline" size="sm" onClick={() => { setActiveTab('purchase-orders'); fetchPurchaseOrders(); const now = new Date().toISOString(); setLastPoRefresh(now); localStorage.setItem('dolibarr_last_po_refresh', now); }} disabled={poLoading}>
-                      {poLoading ? <Loader2 className="h-4 w-4 animate-spin mr-1" /> : <RefreshCw className="h-4 w-4 mr-1" />}
-                      Refresh P.O&apos;s
-                    </Button>
-                    <Button variant="outline" size="sm" onClick={handleSyncDeliveryDates} disabled={syncingDeliveryDates}>
-                      {syncingDeliveryDates ? <Loader2 className="h-4 w-4 animate-spin mr-1" /> : <RefreshCw className="h-4 w-4 mr-1" />}
-                      Sync Delivery Dates
+                    <Button variant="outline" size="sm" onClick={handleSyncPos} disabled={syncingPos}>
+                      {syncingPos ? <Loader2 className="h-4 w-4 animate-spin mr-1" /> : <RefreshCw className="h-4 w-4 mr-1" />}
+                      Sync PO
                     </Button>
                     <Button size="sm" onClick={() => handleSync()} disabled={syncing}>
                       {syncing ? <Loader2 className="h-4 w-4 animate-spin mr-1" /> : <RefreshCw className="h-4 w-4 mr-1" />}
                       Full Sync
                     </Button>
                   </CardContent>
-                  {deliveryDateSyncResult && (
+                  {poSyncResult && (
                     <div className="px-4 pb-3 text-sm text-muted-foreground">
-                      Delivery date sync complete: {deliveryDateSyncResult.updated} updated
-                      {deliveryDateSyncResult.errors > 0 && `, ${deliveryDateSyncResult.errors} errors`}
+                      PO sync complete: {poSyncResult.updated} delivery date{poSyncResult.updated !== 1 ? 's' : ''} updated
+                      {poSyncResult.errors > 0 && `, ${poSyncResult.errors} error${poSyncResult.errors !== 1 ? 's' : ''}`}
                     </div>
                   )}
                 </Card>

--- a/src/lib/dolibarr/sync-service.ts
+++ b/src/lib/dolibarr/sync-service.ts
@@ -45,6 +45,7 @@ export interface SyncStatus {
   lastThirdpartiesSync: string | null;
   lastContactsSync: string | null;
   lastFullSync: string | null;
+  lastPoSync: string | null;
   recordCounts: {
     products: { total: number; active: number; withSpecs: number };
     thirdparties: { total: number; active: number };
@@ -572,6 +573,7 @@ export class DolibarrSyncService {
       lastThirdpartiesSync: config.get('last_thirdparties_sync') || null,
       lastContactsSync: config.get('last_contacts_sync') || null,
       lastFullSync: config.get('last_full_sync') || null,
+      lastPoSync: config.get('last_po_sync') || null,
       recordCounts: {
         products: {
           total: Number(pc.total) || 0,


### PR DESCRIPTION
- Rename 'Refresh P.O.s' button → 'Sync PO' in Dolibarr integration overview
- Remove separate 'Sync Delivery Dates' button (merged into Sync PO)
- New POST /api/dolibarr/sync-pos endpoint:
  • Iterates MIRs with dolibarrPoId, fetches PO detail from Dolibarr
    (detail endpoint returns real date_livraison; list endpoint returns 0)
  • Updates MIR.plannedDeliveryDate when Dolibarr has a delivery date set
  • Logs result to dolibarr_sync_log (entity_type = 'purchaseorders')
  • Persists last_po_sync timestamp in dolibarr_integration_config
- SyncStatus interface + getSyncStatus() now expose lastPoSync field
- 'Last Sync › Purchase Orders' card reads from DB (lastPoSync) instead
  of ephemeral localStorage, so it survives page reloads
- Sync History table will now show 'purchaseorders' rows after each Sync PO

https://claude.ai/code/session_01L7Ndq7d5KThhQ14poYQaAG