### PR TITLE
fix: add missing back-relation fields on InvWarehouse and InvItem for InvAdjustment

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7836,10 +7836,11 @@ model InvWarehouse {
   updatedAt   DateTime @updatedAt
   deletedAt   DateTime?
 
-  balances InvStockBalance[]
-  ledger   InvStockLedger[]
-  lines    InvMirOutLine[]
-  returns  InvReturn[]
+  balances    InvStockBalance[]
+  ledger      InvStockLedger[]
+  lines       InvMirOutLine[]
+  returns     InvReturn[]
+  adjustments InvAdjustment[]
 
   @@index([siteId])
   @@index([type])
@@ -7886,10 +7887,11 @@ model InvItem {
   updatedAt   DateTime @updatedAt
   deletedAt   DateTime?
 
-  balances InvStockBalance[]
-  ledger   InvStockLedger[]
-  lines    InvMirOutLine[]
-  returns  InvReturn[]
+  balances    InvStockBalance[]
+  ledger      InvStockLedger[]
+  lines       InvMirOutLine[]
+  returns     InvReturn[]
+  adjustments InvAdjustment[]
 
   @@index([category])
   @@index([defaultWhType])


### PR DESCRIPTION
Prisma requires both sides of every relation. InvAdjustment declared
warehouse -> InvWarehouse and item -> InvItem relations, but neither
InvWarehouse nor InvItem had the corresponding InvAdjustment[] back-
relation field, causing P1012 schema validation failure at build time.

Added:
  InvWarehouse.adjustments  InvAdjustment[]
  InvItem.adjustments       InvAdjustment[]

https://claude.ai/code/session_01No7ivnfcoQPqybWcdvodjD