### PR TITLE
Fix supplier data reference in subcontractor contract form

### DIFF
--- a/src/app/supply-chain/subcontractors/new/_page-client.tsx
+++ b/src/app/supply-chain/subcontractors/new/_page-client.tsx
@@ -247,8 +247,8 @@ export default function NewSubcontractorContractPage() {
         body: JSON.stringify({
           projectId: selectedProject,
           buildingId: selectedBuilding || null,
-          supplierId: supp?.approved_supplier_id ?? null,
-          dolibarrId: supp?.dolibarr_id ?? null,
+          supplierId: selectedSupplierData?.approved_supplier_id ?? null,
+          dolibarrId: selectedSupplierData?.dolibarr_id ?? null,
           dolibarrPoId: selectedPO?.id ?? null,
           dolibarrPoRef: selectedPO?.ref ?? null,
           scopeLevel,
@@ -289,7 +289,6 @@ export default function NewSubcontractorContractPage() {
   };
 
   const proj = projects.find(p => p.id === selectedProject);
-  const supp = suppliers.find(s => String(s.dolibarr_id) === selectedSupplier);
   const bldg = buildings.find(b => b.id === selectedBuilding);
 
   return (
@@ -794,7 +793,7 @@ export default function NewSubcontractorContractPage() {
               <div className="grid grid-cols-2 gap-4">
                 {[
                   { label: 'Project', value: proj ? `${proj.projectNumber} — ${proj.name}` : '—' },
-                  { label: 'Subcontractor', value: supp ? `${supp.code_supplier ?? supp.dolibarr_id} — ${supp.name}` : '—' },
+                  { label: 'Subcontractor', value: selectedSupplierData ? `${selectedSupplierData.code_supplier ?? selectedSupplierData.dolibarr_id} — ${selectedSupplierData.name}` : '—' },
                   { label: 'Purchase Order', value: selectedPO ? selectedPO.ref : '—' },
                   { label: 'Building', value: bldg ? `${bldg.designation} — ${bldg.name}` : 'Full Project' },
                   { label: 'Scope Types', value: selectedScopeTypes.map(st => SCOPE_LABELS[st] ?? st).join(', ') },


### PR DESCRIPTION
## Summary
Fixed a bug in the new subcontractor contract page where supplier data was being referenced from an incorrect variable, causing the form to use stale or undefined supplier information when submitting.

## Key Changes
- Replaced references to `supp` (derived from `selectedSupplier` string ID) with `selectedSupplierData` (the actual supplier object) in:
  - API request body for `supplierId` and `dolibarrId` fields
  - Display summary showing subcontractor code/name
- Removed the now-unused `supp` variable declaration that was performing a string-based lookup

## Implementation Details
The original code was finding the supplier object by matching `dolibarr_id` as a string against `selectedSupplier`, which could fail or return stale data. The fix uses `selectedSupplierData` which is the properly selected supplier object, ensuring:
- Correct supplier IDs are sent to the API
- Display values match the actual selected supplier
- No unnecessary lookups or type coercions

https://claude.ai/code/session_01FVef5HxeDDiKMosWWUSJfv