### PR TITLE
feat: Material Master Enrichment System — product intelligence & unit conversion engine

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,10 +57,18 @@ LCR_SYNC_INTERVAL_MINUTES="30"
 ENABLE_LCR_SCHEDULER="false"
 
 # Ops Agent (Claude Messages API) — 19.0.0
-# Anthropic API key — required for the Ops Agent to call Claude
+# Anthropic API key — required for the Ops Agent and Material Master AI classifier
 ANTHROPIC_API_KEY="sk-ant-..."
 # Model to use for the agent (default: claude-sonnet-4-6)
 # OPS_AGENT_MODEL="claude-sonnet-4-6"
+
+# Material Master — Google Gemini (web enrichment for consumables)
+# Get your API key from: https://aistudio.google.com/apikey
+GEMINI_API_KEY="AIza..."
+
+# Material Master — Grok / xAI (optional secondary classifier)
+# Get your API key from: https://console.x.ai/
+XAI_API_KEY="xai-..."
 # Shared secret used to authenticate internal agent tool calls (generate: openssl rand -hex 32)
 OTS_INTERNAL_API_SECRET="your-32-char-random-secret-here"
 # Enable/disable the Ops Agent cron scheduler (set to "true" in production)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "hexa-steel-ots",
-  "version": "23.0.0",
+  "version": "24.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hexa-steel-ots",
-      "version": "23.0.0",
+      "version": "24.0.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.90.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@google/generative-ai": "^0.24.1",
         "@hookform/resolvers": "^5.2.2",
         "@prisma/client": "^6.17.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -899,6 +900,15 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
+      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@hookform/resolvers": {
       "version": "5.2.2",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@google/generative-ai": "^0.24.1",
     "@hookform/resolvers": "^5.2.2",
     "@prisma/client": "^6.17.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/prisma/manual_migrations/v36_1_material_master_enrichment.sql
+++ b/prisma/manual_migrations/v36_1_material_master_enrichment.sql
@@ -1,0 +1,226 @@
+-- ============================================================
+-- v36_1 — Material Master Enrichment
+-- Adds product intelligence columns to dolibarr_products
+-- All statements use IF NOT EXISTS for idempotency
+-- ============================================================
+
+-- ── BLOCK 1: Classification ──────────────────────────────────────────────
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS item_class ENUM(
+    'RAW_MATERIAL','CONSUMABLE','SPARE_PART','SERVICE','TOOL','UNKNOWN'
+  ) DEFAULT 'UNKNOWN' AFTER is_active;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS material_nature ENUM(
+    'CARBON_STEEL','STAINLESS_STEEL','ALUMINUM','GALVANIZED_STEEL',
+    'HARDWARE','WELDING_CONSUMABLE','CHEMICAL','PPE','GAS',
+    'ELECTRICAL','SERVICE','OTHER','UNKNOWN'
+  ) DEFAULT 'UNKNOWN' AFTER item_class;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS material_category ENUM(
+    'SHEET','PLATE','CHECKERED_PLATE',
+    'PROFILE_H','PROFILE_I','PROFILE_C','PROFILE_ANGLE',
+    'FLAT_BAR','ROUND_BAR','SQUARE_BAR',
+    'PIPE_ROUND','PIPE_SQUARE','PIPE_RECTANGULAR',
+    'BOLT','NUT','WASHER','ANCHOR','STUD',
+    'WELDING_ELECTRODE','WELDING_WIRE_SOLID','WELDING_WIRE_FLUX',
+    'WELDING_FLUX_SAW','WELDING_PPE','WELDING_ACCESSORY',
+    'PAINT','PRIMER','THINNER','ABRASIVE',
+    'GAS_CYLINDER','SAFETY_PPE','ELECTRICAL','OTHER','UNKNOWN'
+  ) DEFAULT 'UNKNOWN' AFTER material_nature;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS grade VARCHAR(50) NULL COMMENT 'e.g. A36, S355, A572-G50, 10.9, 304SS' AFTER material_category;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS finish VARCHAR(50) NULL COMMENT 'e.g. Black Steel, Hot-Dip Galvanized, Zinc' AFTER grade;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS unit_of_measure ENUM('KG','TON','M','LM','M2','PC','SET','BOX','L','ROLL') DEFAULT 'PC' AFTER finish;
+
+-- ── BLOCK 2: Profile / Section Attributes ────────────────────────────────
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS profile_type ENUM(
+    'HEA','HEB','HEM','IPE','IPO','IPN',
+    'UPN','UPE','JIS_H','JIS_I',
+    'EQUAL_ANGLE','UNEQUAL_ANGLE',
+    'FLAT_BAR','ROUND_BAR','SQUARE_BAR',
+    'CHS','SHS','RHS',
+    'SHEET','PLATE','CHECKERED',
+    'OTHER'
+  ) NULL AFTER unit_of_measure;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS profile_designation VARCHAR(30) NULL COMMENT 'e.g. HEA 200, IPE 300, L 80x80x8' AFTER profile_type;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS section_standard VARCHAR(20) NULL COMMENT 'EN10365 | AISC | JIS_G3192 | DIN' AFTER profile_designation;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS bar_length_m DECIMAL(6,2) NULL COMMENT 'Standard bar/beam length from ref (6 or 12)' AFTER section_standard;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS dim_h_mm DECIMAL(8,2) NULL COMMENT 'Total height' AFTER bar_length_m;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS dim_b_mm DECIMAL(8,2) NULL COMMENT 'Flange width' AFTER dim_h_mm;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS dim_tf_mm DECIMAL(6,3) NULL COMMENT 'Flange thickness' AFTER dim_b_mm;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS dim_tw_mm DECIMAL(6,3) NULL COMMENT 'Web thickness' AFTER dim_tf_mm;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS dim_r_mm DECIMAL(6,2) NULL COMMENT 'Root fillet radius' AFTER dim_tw_mm;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS dim_width_mm DECIMAL(8,2) NULL COMMENT 'Sheet/plate width' AFTER dim_r_mm;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS dim_length_mm DECIMAL(8,2) NULL COMMENT 'Sheet/plate length' AFTER dim_width_mm;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS dim_thickness_mm DECIMAL(7,3) NULL COMMENT 'Sheet/plate thickness' AFTER dim_length_mm;
+
+-- Cross-section mechanical properties
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS weight_kg_per_m DECIMAL(8,3) NULL COMMENT 'kg/m — profiles and bars' AFTER dim_thickness_mm;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS area_cm2 DECIMAL(8,3) NULL AFTER weight_kg_per_m;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS Ix_cm4 DECIMAL(12,3) NULL AFTER area_cm2;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS Iy_cm4 DECIMAL(12,3) NULL AFTER Ix_cm4;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS Wx_cm3 DECIMAL(10,3) NULL AFTER Iy_cm4;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS Wy_cm3 DECIMAL(10,3) NULL AFTER Wx_cm3;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS ix_cm DECIMAL(7,3) NULL AFTER Wy_cm3;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS iy_cm DECIMAL(7,3) NULL AFTER ix_cm;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS section_props_json JSON NULL COMMENT 'Full section props blob including Avz, It, Iw etc' AFTER iy_cm;
+
+-- ── BLOCK 3: Fastener Attributes ─────────────────────────────────────────
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS fastener_standard VARCHAR(30) NULL COMMENT 'DIN 914, DIN 6914, ISO 4017, ASTM A194' AFTER section_props_json;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS fastener_thread VARCHAR(20) NULL COMMENT 'M12, M16, M20, M27' AFTER fastener_standard;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS fastener_length_mm DECIMAL(7,2) NULL AFTER fastener_thread;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS fastener_grade VARCHAR(20) NULL COMMENT '8.8, 10.9, 12.9, 2H, B7' AFTER fastener_length_mm;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS fastener_surface VARCHAR(30) NULL COMMENT 'Black Steel, HDG, Zinc, PTFE' AFTER fastener_grade;
+
+-- ── BLOCK 4: Welding Attributes ──────────────────────────────────────────
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS aws_class VARCHAR(30) NULL COMMENT 'E6013, E7018, E308L, E71T-1, E308LT1' AFTER fastener_surface;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS weld_process ENUM('SMAW','GMAW','FCAW','SAW','GTAW') NULL AFTER aws_class;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS weld_base_material ENUM('MILD_STEEL','STAINLESS','LOW_ALLOY','ALUMINUM') NULL AFTER weld_process;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS weld_diameter_mm DECIMAL(5,2) NULL AFTER weld_base_material;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS weld_current_type VARCHAR(20) NULL COMMENT 'AC, DC+, DC-, AC/DC' AFTER weld_diameter_mm;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS weld_tensile_mpa INT NULL AFTER weld_current_type;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS weld_yield_mpa INT NULL AFTER weld_tensile_mpa;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS weld_elongation_pct DECIMAL(5,2) NULL AFTER weld_yield_mpa;
+
+-- ── BLOCK 5: Unit Conversion Engine ──────────────────────────────────────
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS density_kg_m3 DECIMAL(8,2) DEFAULT 7850.00 COMMENT '7850=carbon, 7930=SS, 2700=Al' AFTER weld_elongation_pct;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS kg_per_m2 DECIMAL(10,4) NULL COMMENT 'Sheets/plates: kg per 1 m²' AFTER density_kg_m3;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS kg_per_lm DECIMAL(10,4) NULL COMMENT 'Profiles/bars: kg per 1 linear meter' AFTER kg_per_m2;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS unit_area_m2 DECIMAL(10,6) NULL COMMENT 'Sheets: width_m * length_m (one unit piece)' AFTER kg_per_lm;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS kg_per_unit DECIMAL(10,4) NULL COMMENT 'Weight of one standard unit (one sheet or one bar)' AFTER unit_area_m2;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS disburse_unit ENUM('KG','TON','M2','LM','PC') DEFAULT 'KG'
+  COMMENT 'Preferred unit for production disbursement display' AFTER kg_per_unit;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS unit_conversions_json JSON NULL
+  COMMENT 'Cached conversions: {kg_per_m2, m2_per_ton, kg_per_sheet, sheets_per_ton, lm_per_ton, kg_per_bar, bars_per_ton}' AFTER disburse_unit;
+
+-- ── BLOCK 6: Web Enrichment ───────────────────────────────────────────────
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS manufacturer VARCHAR(100) NULL AFTER unit_conversions_json;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS manufacturer_ref VARCHAR(100) NULL AFTER manufacturer;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS image_url VARCHAR(500) NULL AFTER manufacturer_ref;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS tds_url VARCHAR(500) NULL AFTER image_url;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS technical_attrs_json JSON NULL
+  COMMENT 'Flexible per-category: welding params, paint specs, bolt proof loads, etc.' AFTER tds_url;
+
+-- ── BLOCK 7: Classification Metadata ─────────────────────────────────────
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS classified_by ENUM(
+    'RULE_ENGINE','SECTION_LIBRARY','AI_BATCH','MANUAL','UNCLASSIFIED'
+  ) DEFAULT 'UNCLASSIFIED' AFTER technical_attrs_json;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS classification_conf DECIMAL(3,2) DEFAULT 0.00 COMMENT '0.00 to 1.00' AFTER classified_by;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS enriched_at DATETIME NULL AFTER classification_conf;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS review_required BOOLEAN DEFAULT FALSE COMMENT 'true when conf < 0.75' AFTER enriched_at;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS review_notes TEXT NULL AFTER review_required;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS reviewed_by INT NULL COMMENT 'FK to users table' AFTER review_notes;
+
+ALTER TABLE dolibarr_products
+  ADD COLUMN IF NOT EXISTS reviewed_at DATETIME NULL AFTER reviewed_by;
+
+-- ── Indexes ───────────────────────────────────────────────────────────────
+CREATE INDEX IF NOT EXISTS idx_dp_item_class ON dolibarr_products(item_class);
+CREATE INDEX IF NOT EXISTS idx_dp_material_category ON dolibarr_products(material_category);
+CREATE INDEX IF NOT EXISTS idx_dp_profile_type ON dolibarr_products(profile_type);
+CREATE INDEX IF NOT EXISTS idx_dp_review_required ON dolibarr_products(review_required);
+CREATE INDEX IF NOT EXISTS idx_dp_classified_by ON dolibarr_products(classified_by);

--- a/src/app/api/admin/material-master/classify/route.ts
+++ b/src/app/api/admin/material-master/classify/route.ts
@@ -1,0 +1,167 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { withApiContext } from '@/lib/api-utils'
+import { checkPermission } from '@/lib/permission-checker'
+import { logger } from '@/lib/logger'
+import prisma from '@/lib/db'
+import { classifyProduct } from '@/lib/material-master/classifier'
+import { runAIBatchClassification } from '@/lib/material-master/ai-classifier'
+import { enrichConsumable } from '@/lib/material-master/web-enrichment'
+
+export const dynamic = 'force-dynamic'
+
+// POST /api/admin/material-master/classify
+// Body: { pass: 'rule' | 'ai' | 'enrichment' | 'all' }
+export const POST = withApiContext(async (req: NextRequest, _session): Promise<NextResponse> => {
+  if (!(await checkPermission('inv.admin'))) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const body = await req.json() as { pass?: string }
+  const passType = body.pass ?? 'rule'
+
+  if (!['rule', 'ai', 'enrichment', 'all'].includes(passType)) {
+    return NextResponse.json({ error: 'Invalid pass type' }, { status: 400 })
+  }
+
+  const startTime = Date.now()
+  let ruleProcessed = 0, ruleErrors = 0
+  let aiProcessed = 0, aiErrors = 0
+  let enrichmentProcessed = 0, enrichmentErrors = 0
+
+  // ── PASS 1: Rule-Based Classification ────────────────────────────────────
+  if (passType === 'rule' || passType === 'all') {
+    try {
+      const products: Array<{ dolibarr_id: number; ref: string; label: string }> =
+        await prisma.$queryRawUnsafe(
+          'SELECT dolibarr_id, ref, label FROM dolibarr_products ORDER BY dolibarr_id'
+        )
+
+      for (const p of products) {
+        const result = classifyProduct(p.ref, p.label)
+        if (result.classification_conf > 0) {
+          try {
+            await prisma.$executeRawUnsafe(
+              `UPDATE dolibarr_products SET
+                item_class=?, material_nature=?, material_category=?, grade=?,
+                finish=?, unit_of_measure=?, bar_length_m=?,
+                profile_type=?, profile_designation=?, section_standard=?,
+                dim_h_mm=?, dim_b_mm=?, dim_tf_mm=?, dim_tw_mm=?, dim_r_mm=?,
+                dim_width_mm=?, dim_length_mm=?, dim_thickness_mm=?,
+                weight_kg_per_m=?, area_cm2=?, Ix_cm4=?, Iy_cm4=?, Wx_cm3=?, Wy_cm3=?,
+                ix_cm=?, iy_cm=?, section_props_json=?,
+                fastener_standard=?, fastener_thread=?, fastener_length_mm=?,
+                fastener_grade=?, fastener_surface=?,
+                aws_class=?, weld_process=?, weld_base_material=?, weld_diameter_mm=?,
+                density_kg_m3=?, kg_per_m2=?, kg_per_lm=?, unit_area_m2=?,
+                kg_per_unit=?, disburse_unit=?, unit_conversions_json=?,
+                manufacturer=?,
+                classified_by=?, classification_conf=?, review_required=?, enriched_at=NOW()
+              WHERE dolibarr_id=?`,
+              result.item_class, result.material_nature, result.material_category, result.grade,
+              result.finish, result.unit_of_measure, result.bar_length_m,
+              result.profile_type, result.profile_designation, result.section_standard,
+              result.dim_h_mm, result.dim_b_mm, result.dim_tf_mm, result.dim_tw_mm, result.dim_r_mm,
+              result.dim_width_mm, result.dim_length_mm, result.dim_thickness_mm,
+              result.weight_kg_per_m, result.area_cm2, result.Ix_cm4, result.Iy_cm4,
+              result.Wx_cm3, result.Wy_cm3, result.ix_cm, result.iy_cm,
+              result.section_props_json ? JSON.stringify(result.section_props_json) : null,
+              result.fastener_standard, result.fastener_thread, result.fastener_length_mm,
+              result.fastener_grade, result.fastener_surface,
+              result.aws_class, result.weld_process, result.weld_base_material, result.weld_diameter_mm,
+              result.density_kg_m3, result.kg_per_m2, result.kg_per_lm, result.unit_area_m2,
+              result.kg_per_unit, result.disburse_unit,
+              result.unit_conversions_json ? JSON.stringify(result.unit_conversions_json) : null,
+              result.manufacturer,
+              result.classified_by, result.classification_conf, result.review_required ? 1 : 0,
+              p.dolibarr_id
+            )
+            ruleProcessed++
+          } catch (err) {
+            logger.error({ err, dolibarr_id: p.dolibarr_id }, 'Rule classifier DB update failed')
+            ruleErrors++
+          }
+        }
+      }
+      logger.info({ processed: ruleProcessed, errors: ruleErrors }, 'Rule classification pass complete')
+    } catch (err) {
+      logger.error({ err }, 'Rule classification pass failed')
+      ruleErrors++
+    }
+  }
+
+  // ── PASS 2: AI Batch Classification ──────────────────────────────────────
+  if (passType === 'ai' || passType === 'all') {
+    try {
+      // Provide a db-like interface for the AI classifier
+      const dbInterface = {
+        query: async (sql: string, params?: unknown[]): Promise<unknown[][]> => {
+          const rows = params
+            ? await prisma.$queryRawUnsafe(sql, ...params)
+            : await prisma.$queryRawUnsafe(sql)
+          return [rows as unknown[]]
+        }
+      }
+      const result = await runAIBatchClassification(dbInterface)
+      aiProcessed = result.processed
+      aiErrors = result.errors
+      logger.info({ processed: aiProcessed, errors: aiErrors }, 'AI classification pass complete')
+    } catch (err) {
+      logger.error({ err }, 'AI classification pass failed')
+      aiErrors++
+    }
+  }
+
+  // ── PASS 3: Web Enrichment (Consumables) ─────────────────────────────────
+  if (passType === 'enrichment' || passType === 'all') {
+    try {
+      const consumables: Array<{
+        dolibarr_id: number
+        ref: string
+        label: string
+        aws_class: string | null
+        material_category: string
+      }> = await prisma.$queryRawUnsafe(
+        `SELECT dolibarr_id, ref, label, aws_class, material_category
+         FROM dolibarr_products
+         WHERE item_class = 'CONSUMABLE'
+         AND image_url IS NULL
+         LIMIT 200`
+      )
+
+      for (const c of consumables) {
+        try {
+          const result = await enrichConsumable(
+            c.dolibarr_id, c.ref, c.label, c.aws_class, c.material_category
+          )
+          await prisma.$executeRawUnsafe(
+            `UPDATE dolibarr_products SET
+              image_url=?, tds_url=?, technical_attrs_json=?,
+              manufacturer=COALESCE(manufacturer, ?)
+            WHERE dolibarr_id=?`,
+            result.image_url, result.tds_url,
+            result.technical_attrs_json ? JSON.stringify(result.technical_attrs_json) : null,
+            result.manufacturer, c.dolibarr_id
+          )
+          enrichmentProcessed++
+          await new Promise(r => setTimeout(r, 300))
+        } catch (err) {
+          logger.error({ err, dolibarr_id: c.dolibarr_id }, 'Web enrichment item failed')
+          enrichmentErrors++
+        }
+      }
+      logger.info({ processed: enrichmentProcessed, errors: enrichmentErrors }, 'Web enrichment pass complete')
+    } catch (err) {
+      logger.error({ err }, 'Web enrichment pass failed')
+      enrichmentErrors++
+    }
+  }
+
+  const duration_ms = Date.now() - startTime
+  return NextResponse.json({
+    pass: passType,
+    rule: { processed: ruleProcessed, errors: ruleErrors },
+    ai: { processed: aiProcessed, errors: aiErrors },
+    enrichment: { processed: enrichmentProcessed, errors: enrichmentErrors },
+    duration_ms,
+  })
+})

--- a/src/app/api/admin/material-master/review/[dolibarrId]/route.ts
+++ b/src/app/api/admin/material-master/review/[dolibarrId]/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { withApiContext } from '@/lib/api-utils'
+import { checkPermission } from '@/lib/permission-checker'
+import { logger } from '@/lib/logger'
+import prisma from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+
+// PATCH /api/admin/material-master/review/[dolibarrId]
+// Body: partial enrichment fields to update + approve
+export const PATCH = withApiContext(async (
+  req: NextRequest,
+  session,
+  context
+): Promise<NextResponse> => {
+  if (!(await checkPermission('inv.admin'))) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const dolibarrId = parseInt(context?.params?.dolibarrId ?? '', 10)
+  if (isNaN(dolibarrId)) {
+    return NextResponse.json({ error: 'Invalid dolibarr_id' }, { status: 400 })
+  }
+
+  const body = await req.json() as Record<string, unknown>
+
+  // Allowed fields for manual override
+  const allowed = [
+    'item_class', 'material_nature', 'material_category', 'grade', 'finish',
+    'unit_of_measure', 'profile_type', 'profile_designation', 'section_standard',
+    'fastener_standard', 'fastener_thread', 'fastener_grade', 'fastener_surface',
+    'aws_class', 'weld_process', 'weld_base_material', 'disburse_unit',
+    'manufacturer', 'review_notes',
+  ]
+
+  const updates: string[] = []
+  const values: unknown[] = []
+
+  for (const key of allowed) {
+    if (key in body) {
+      updates.push(`${key} = ?`)
+      values.push(body[key])
+    }
+  }
+
+  // Always set review metadata on PATCH
+  updates.push(
+    `classified_by = 'MANUAL'`,
+    `classification_conf = 1.0`,
+    `review_required = 0`,
+    `reviewed_by = ?`,
+    `reviewed_at = NOW()`
+  )
+  values.push(session!.userId)
+  values.push(dolibarrId)
+
+  try {
+    await prisma.$executeRawUnsafe(
+      `UPDATE dolibarr_products SET ${updates.join(', ')} WHERE dolibarr_id = ?`,
+      ...values
+    )
+    logger.info({ dolibarrId, reviewedBy: session!.userId }, 'Material master review approved')
+    return NextResponse.json({ success: true, dolibarr_id: dolibarrId })
+  } catch (err) {
+    logger.error({ err, dolibarrId }, 'Material master review update failed')
+    return NextResponse.json({ error: 'Update failed' }, { status: 500 })
+  }
+})

--- a/src/app/api/dolibarr/products/convert/route.ts
+++ b/src/app/api/dolibarr/products/convert/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { withApiContext } from '@/lib/api-utils'
+import { logger } from '@/lib/logger'
+import prisma from '@/lib/db'
+import { convertDisbursementUnits, UnitConversions } from '@/lib/material-master/unit-conversion'
+
+export const dynamic = 'force-dynamic'
+
+// GET /api/dolibarr/products/convert?id={dolibarr_id}&qty=5&unit=M2
+export const GET = withApiContext(async (req: NextRequest, _session): Promise<NextResponse> => {
+  const { searchParams } = new URL(req.url)
+  const id = parseInt(searchParams.get('id') ?? '', 10)
+  const qty = parseFloat(searchParams.get('qty') ?? '1')
+  const unit = (searchParams.get('unit') ?? 'KG').toUpperCase() as 'KG' | 'TON' | 'M2' | 'LM' | 'PC'
+
+  if (isNaN(id)) {
+    return NextResponse.json({ error: 'Missing product id' }, { status: 400 })
+  }
+
+  if (!['KG', 'TON', 'M2', 'LM', 'PC'].includes(unit)) {
+    return NextResponse.json({ error: 'Invalid unit. Use KG, TON, M2, LM, or PC' }, { status: 400 })
+  }
+
+  try {
+    const rows: Array<{
+      ref: string
+      material_category: string
+      unit_conversions_json: string | null
+      kg_per_m2: number | null
+      kg_per_lm: number | null
+      kg_per_unit: number | null
+      unit_area_m2: number | null
+    }> = await prisma.$queryRawUnsafe(
+      `SELECT ref, material_category, unit_conversions_json,
+              kg_per_m2, kg_per_lm, kg_per_unit, unit_area_m2
+       FROM dolibarr_products WHERE dolibarr_id = ?`,
+      id
+    )
+
+    const p = rows[0]
+    if (!p) return NextResponse.json({ error: 'Product not found' }, { status: 404 })
+
+    const isSheet = ['SHEET', 'PLATE', 'CHECKERED_PLATE'].includes(p.material_category)
+    const isProfile = ['PROFILE_H', 'PROFILE_I', 'PROFILE_C', 'PROFILE_ANGLE',
+                       'FLAT_BAR', 'ROUND_BAR', 'SQUARE_BAR'].includes(p.material_category)
+
+    let conversions: UnitConversions = {}
+    if (p.unit_conversions_json) {
+      const raw = typeof p.unit_conversions_json === 'string'
+        ? JSON.parse(p.unit_conversions_json)
+        : p.unit_conversions_json
+      if (isSheet) conversions = { sheet: raw }
+      else if (isProfile) conversions = { profile: raw }
+    }
+
+    const output = convertDisbursementUnits(qty, unit, conversions)
+
+    // Add PC equivalent if applicable
+    let pc: number | null = null
+    if (isSheet && conversions.sheet) {
+      const kgInput = output.KG
+      if (kgInput !== null && conversions.sheet.kg_per_sheet > 0) {
+        pc = Math.round(kgInput / conversions.sheet.kg_per_sheet * 100) / 100
+      }
+    } else if (isProfile && conversions.profile) {
+      const kgInput = output.KG
+      if (kgInput !== null && conversions.profile.kg_per_bar > 0) {
+        pc = Math.round(kgInput / conversions.profile.kg_per_bar * 100) / 100
+      }
+    }
+
+    return NextResponse.json({
+      product_ref: p.ref,
+      input: { qty, unit },
+      output: { ...output, PC: pc },
+      conversions: p.unit_conversions_json ? (typeof p.unit_conversions_json === 'string'
+        ? JSON.parse(p.unit_conversions_json)
+        : p.unit_conversions_json) : null,
+    })
+  } catch (err) {
+    logger.error({ err, id, qty, unit }, 'Unit conversion API failed')
+    return NextResponse.json({ error: 'Conversion failed' }, { status: 500 })
+  }
+})

--- a/src/app/api/dolibarr/products/route.ts
+++ b/src/app/api/dolibarr/products/route.ts
@@ -6,8 +6,10 @@ import prisma from '@/lib/db';
 export const dynamic = 'force-dynamic';
 
 /**
- * GET /api/dolibarr/products — List products with optional steel specs
- * Query params: search, profile_type, steel_grade, product_type, with_specs (1/0), page, limit
+ * GET /api/dolibarr/products — List products with optional steel specs and enrichment data
+ * Query params:
+ *   search, profile_type, steel_grade, product_type, with_specs (1/0), page, limit
+ *   item_class, material_category, review_required (1/0), enriched (1/0)
  */
 export async function GET(req: Request) {
   const store = await cookies();
@@ -26,9 +28,16 @@ export async function GET(req: Request) {
     const limit = Math.min(200, Math.max(1, parseInt(searchParams.get('limit') || '50', 10)));
     const offset = page * limit;
 
+    // Enrichment filters
+    const itemClass = searchParams.get('item_class') || '';
+    const materialCategory = searchParams.get('material_category') || '';
+    const enrichmentProfileType = searchParams.get('enrichment_profile_type') || '';
+    const reviewRequired = searchParams.get('review_required');
+    const enrichedOnly = searchParams.get('enriched') === '1';
+
     // Build WHERE conditions
     const conditions: string[] = ['p.is_active = 1'];
-    const params: any[] = [];
+    const params: unknown[] = [];
 
     if (search) {
       conditions.push('(p.ref LIKE ? OR p.label LIKE ? OR p.description LIKE ?)');
@@ -55,6 +64,32 @@ export async function GET(req: Request) {
       conditions.push('s.id IS NOT NULL');
     }
 
+    // Enrichment filters
+    if (itemClass) {
+      conditions.push('p.item_class = ?');
+      params.push(itemClass);
+    }
+
+    if (materialCategory) {
+      conditions.push('p.material_category = ?');
+      params.push(materialCategory);
+    }
+
+    if (enrichmentProfileType) {
+      conditions.push('p.profile_type = ?');
+      params.push(enrichmentProfileType);
+    }
+
+    if (reviewRequired === '1') {
+      conditions.push('p.review_required = 1');
+    } else if (reviewRequired === '0') {
+      conditions.push('p.review_required = 0');
+    }
+
+    if (enrichedOnly) {
+      conditions.push('p.classification_conf > 0');
+    }
+
     const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
 
     // Count total
@@ -64,31 +99,47 @@ export async function GET(req: Request) {
       LEFT JOIN steel_product_specs s ON s.dolibarr_product_id = p.dolibarr_id
       ${whereClause}
     `;
-    const countResult: any[] = await prisma.$queryRawUnsafe(countQuery, ...params);
-    const total = Number(countResult[0]?.total) || 0;
+    const countResult: unknown[] = await prisma.$queryRawUnsafe(countQuery, ...params);
+    const total = Number((countResult[0] as Record<string, unknown>)?.total) || 0;
 
-    // Fetch products with LEFT JOIN to steel specs
+    // Fetch products with LEFT JOIN to steel specs + enrichment columns
     const dataQuery = `
-      SELECT 
-        p.*,
+      SELECT
+        p.dolibarr_id, p.ref, p.label, p.description,
+        p.product_type, p.status_sell, p.status_buy,
+        p.price, p.price_ttc, p.tva_tx, p.pmp, p.weight,
+        p.barcode, p.is_active, p.created_at, p.updated_at,
         s.id as spec_id,
         s.steel_grade, s.grade_standard,
-        s.profile_type, s.profile_size,
+        s.profile_type as spec_profile_type, s.profile_size,
         s.thickness_mm, s.width_mm as spec_width_mm, s.height_mm as spec_height_mm,
         s.length_mm, s.weight_per_meter, s.weight_per_sqm,
         s.surface_finish, s.is_standard_stock,
-        s.lead_time_days, s.fabrication_notes, s.welding_notes
+        s.lead_time_days, s.fabrication_notes, s.welding_notes,
+        p.item_class, p.material_nature, p.material_category,
+        p.grade, p.finish, p.unit_of_measure,
+        p.profile_type, p.profile_designation, p.section_standard, p.bar_length_m,
+        p.dim_h_mm, p.dim_b_mm, p.dim_tf_mm, p.dim_tw_mm, p.dim_r_mm,
+        p.dim_width_mm, p.dim_length_mm, p.dim_thickness_mm,
+        p.weight_kg_per_m, p.area_cm2, p.Ix_cm4, p.Iy_cm4, p.Wx_cm3, p.Wy_cm3, p.ix_cm, p.iy_cm,
+        p.section_props_json,
+        p.fastener_standard, p.fastener_thread, p.fastener_length_mm, p.fastener_grade, p.fastener_surface,
+        p.aws_class, p.weld_process, p.weld_base_material, p.weld_diameter_mm,
+        p.density_kg_m3, p.kg_per_m2, p.kg_per_lm, p.unit_area_m2, p.kg_per_unit,
+        p.disburse_unit, p.unit_conversions_json,
+        p.manufacturer, p.manufacturer_ref, p.image_url, p.tds_url, p.technical_attrs_json,
+        p.classified_by, p.classification_conf, p.review_required, p.enriched_at
       FROM dolibarr_products p
       LEFT JOIN steel_product_specs s ON s.dolibarr_product_id = p.dolibarr_id
       ${whereClause}
       ORDER BY p.ref ASC
       LIMIT ? OFFSET ?
     `;
-    const products: any[] = await prisma.$queryRawUnsafe(dataQuery, ...params, limit, offset);
+    const products: unknown[] = await prisma.$queryRawUnsafe(dataQuery, ...params, limit, offset);
 
-    // Serialize BigInt and Date values
-    const serialized = products.map((p: any) => {
-      const obj: any = {};
+    // Serialize BigInt, Date, and JSON values
+    const serialized = (products as Record<string, unknown>[]).map((p) => {
+      const obj: Record<string, unknown> = {};
       for (const [key, value] of Object.entries(p)) {
         if (typeof value === 'bigint') {
           obj[key] = Number(value);
@@ -98,7 +149,97 @@ export async function GET(req: Request) {
           obj[key] = value;
         }
       }
-      return obj;
+
+      // Build enrichment sub-object
+      const enrichment = {
+        item_class: obj.item_class,
+        material_nature: obj.material_nature,
+        material_category: obj.material_category,
+        grade: obj.grade,
+        finish: obj.finish,
+        unit_of_measure: obj.unit_of_measure,
+        profile_type: obj.profile_type,
+        profile_designation: obj.profile_designation,
+        section_standard: obj.section_standard,
+        bar_length_m: obj.bar_length_m,
+        dimensions: {
+          h_mm: obj.dim_h_mm,
+          b_mm: obj.dim_b_mm,
+          tf_mm: obj.dim_tf_mm,
+          tw_mm: obj.dim_tw_mm,
+          r_mm: obj.dim_r_mm,
+          width_mm: obj.dim_width_mm,
+          length_mm: obj.dim_length_mm,
+          thickness_mm: obj.dim_thickness_mm,
+        },
+        section_props: {
+          weight_kg_per_m: obj.weight_kg_per_m,
+          area_cm2: obj.area_cm2,
+          Ix_cm4: obj.Ix_cm4,
+          Iy_cm4: obj.Iy_cm4,
+          Wx_cm3: obj.Wx_cm3,
+          Wy_cm3: obj.Wy_cm3,
+          ix_cm: obj.ix_cm,
+          iy_cm: obj.iy_cm,
+        },
+        section_props_json: obj.section_props_json,
+        welding: {
+          aws_class: obj.aws_class,
+          weld_process: obj.weld_process,
+          weld_base_material: obj.weld_base_material,
+          weld_diameter_mm: obj.weld_diameter_mm,
+        },
+        fastener: {
+          standard: obj.fastener_standard,
+          thread: obj.fastener_thread,
+          length_mm: obj.fastener_length_mm,
+          grade: obj.fastener_grade,
+          surface: obj.fastener_surface,
+        },
+        kg_per_m2: obj.kg_per_m2,
+        kg_per_lm: obj.kg_per_lm,
+        unit_area_m2: obj.unit_area_m2,
+        kg_per_unit: obj.kg_per_unit,
+        disburse_unit: obj.disburse_unit,
+        conversions: obj.unit_conversions_json,
+        manufacturer: obj.manufacturer,
+        manufacturer_ref: obj.manufacturer_ref,
+        image_url: obj.image_url,
+        tds_url: obj.tds_url,
+        technical_attrs_json: obj.technical_attrs_json,
+        classified_by: obj.classified_by,
+        classification_conf: obj.classification_conf ? Number(obj.classification_conf) : 0,
+        review_required: Boolean(obj.review_required),
+        enriched_at: obj.enriched_at,
+      };
+
+      return {
+        dolibarr_id: obj.dolibarr_id,
+        ref: obj.ref,
+        label: obj.label,
+        description: obj.description,
+        product_type: obj.product_type,
+        status_sell: obj.status_sell,
+        status_buy: obj.status_buy,
+        price: obj.price,
+        price_ttc: obj.price_ttc,
+        tva_tx: obj.tva_tx,
+        pmp: obj.pmp,
+        weight: obj.weight,
+        barcode: obj.barcode,
+        is_active: obj.is_active,
+        created_at: obj.created_at,
+        updated_at: obj.updated_at,
+        // Legacy steel specs
+        spec_id: obj.spec_id,
+        steel_grade: obj.steel_grade,
+        spec_profile_type: obj.spec_profile_type,
+        profile_size: obj.profile_size,
+        thickness_mm: obj.thickness_mm,
+        is_standard_stock: obj.is_standard_stock,
+        // Enrichment
+        enrichment,
+      };
     });
 
     return NextResponse.json({
@@ -110,8 +251,9 @@ export async function GET(req: Request) {
         totalPages: Math.ceil(total / limit),
       },
     });
-  } catch (error: any) {
-    console.error('[Dolibarr Products API] Error:', error);
-    return NextResponse.json({ error: error.message || 'Failed to fetch products' }, { status: 500 });
+  } catch (error: unknown) {
+    const err = error as Error;
+    console.error('[Dolibarr Products API] Error:', err);
+    return NextResponse.json({ error: err.message || 'Failed to fetch products' }, { status: 500 });
   }
 }

--- a/src/app/inv/material-master/page.tsx
+++ b/src/app/inv/material-master/page.tsx
@@ -1,0 +1,1560 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from '@/components/ui/sheet';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Separator } from '@/components/ui/separator';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Label } from '@/components/ui/label';
+import {
+  Database,
+  Package,
+  CheckCircle2,
+  AlertTriangle,
+  BarChart2,
+  ChevronLeft,
+  ChevronRight,
+  ExternalLink,
+  Loader2,
+  RefreshCw,
+  Bot,
+  Wand2,
+  Sparkles,
+  Eye,
+} from 'lucide-react';
+import { usePermissions } from '@/contexts/PermissionsContext';
+import { useToast } from '@/hooks/use-toast';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface Dimensions {
+  h_mm: number | null;
+  b_mm: number | null;
+  tf_mm: number | null;
+  tw_mm: number | null;
+  width_mm: number | null;
+  length_mm: number | null;
+  thickness_mm: number | null;
+}
+
+interface SectionProps {
+  weight_kg_per_m: number | null;
+  area_cm2: number | null;
+  Ix_cm4: number | null;
+  Iy_cm4: number | null;
+  Wx_cm3: number | null;
+  Wy_cm3: number | null;
+  ix_cm: number | null;
+  iy_cm: number | null;
+}
+
+interface Welding {
+  aws_class: string | null;
+  weld_process: string | null;
+  weld_base_material: string | null;
+  weld_diameter_mm: number | null;
+}
+
+interface Fastener {
+  standard: string | null;
+  thread: string | null;
+  length_mm: number | null;
+  grade: string | null;
+  surface: string | null;
+}
+
+interface Enrichment {
+  item_class: string;
+  material_nature: string;
+  material_category: string;
+  grade: string | null;
+  finish: string | null;
+  unit_of_measure: string;
+  profile_type: string | null;
+  profile_designation: string | null;
+  section_standard: string | null;
+  bar_length_m: number | null;
+  dimensions: Dimensions;
+  section_props: SectionProps;
+  section_props_json: unknown;
+  welding: Welding;
+  fastener: Fastener;
+  kg_per_m2: number | null;
+  kg_per_lm: number | null;
+  unit_area_m2: number | null;
+  kg_per_unit: number | null;
+  disburse_unit: string;
+  conversions: Record<string, number> | null;
+  manufacturer: string | null;
+  image_url: string | null;
+  tds_url: string | null;
+  technical_attrs_json: Record<string, unknown> | null;
+  classified_by: string;
+  classification_conf: number;
+  review_required: boolean;
+  enriched_at: string | null;
+}
+
+interface Product {
+  dolibarr_id: number;
+  ref: string;
+  label: string;
+  enrichment: Enrichment;
+}
+
+interface Pagination {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+}
+
+interface ApiResponse {
+  products: Product[];
+  pagination: Pagination;
+}
+
+type ClassifyPass = 'rule' | 'ai' | 'enrichment' | 'all';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function getItemClassColor(itemClass: string): string {
+  switch (itemClass) {
+    case 'RAW_MATERIAL':
+      return 'bg-emerald-100 text-emerald-800 border-emerald-200';
+    case 'CONSUMABLE':
+      return 'bg-amber-100 text-amber-800 border-amber-200';
+    case 'SERVICE':
+      return 'bg-sky-100 text-sky-800 border-sky-200';
+    default:
+      return 'bg-slate-100 text-slate-600 border-slate-200';
+  }
+}
+
+function getItemClassLabel(itemClass: string): string {
+  const labels: Record<string, string> = {
+    RAW_MATERIAL: 'Raw Material',
+    CONSUMABLE: 'Consumable',
+    SERVICE: 'Service',
+    TOOL: 'Tool',
+    SPARE_PART: 'Spare Part',
+    UNKNOWN: 'Unknown',
+  };
+  return labels[itemClass] ?? itemClass;
+}
+
+function getClassifiedByBadge(classifiedBy: string) {
+  switch (classifiedBy) {
+    case 'RULE_ENGINE':
+      return (
+        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-emerald-100 text-emerald-800 border border-emerald-200">
+          <span className="text-emerald-600">✓</span> Rule
+        </span>
+      );
+    case 'AI_BATCH':
+      return (
+        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800 border border-purple-200">
+          <span className="text-purple-600">✓</span> AI
+        </span>
+      );
+    case 'MANUAL':
+      return (
+        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 border border-blue-200">
+          <span className="text-blue-600">✓</span> Manual
+        </span>
+      );
+    default:
+      return (
+        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-amber-50 text-amber-700 border border-amber-300">
+          ⚠ Pending
+        </span>
+      );
+  }
+}
+
+function ConfidenceDot({ conf }: { conf: number }) {
+  if (conf <= 0) {
+    return <span className="inline-block w-2.5 h-2.5 rounded-full bg-slate-300" title="No data" />;
+  }
+  if (conf >= 0.95) {
+    return (
+      <span
+        className="inline-block w-2.5 h-2.5 rounded-full bg-emerald-500"
+        title={`${(conf * 100).toFixed(0)}%`}
+      />
+    );
+  }
+  if (conf >= 0.75) {
+    return (
+      <span
+        className="inline-block w-2.5 h-2.5 rounded-full bg-yellow-400"
+        title={`${(conf * 100).toFixed(0)}%`}
+      />
+    );
+  }
+  return (
+    <span
+      className="inline-block w-2.5 h-2.5 rounded-full bg-red-500"
+      title={`${(conf * 100).toFixed(0)}%`}
+    />
+  );
+}
+
+function getKeyDims(p: Product): string {
+  const e = p.enrichment;
+  const cat = e.material_category;
+  const d = e.dimensions;
+  const sp = e.section_props;
+
+  if (cat === 'SHEET' || cat === 'PLATE') {
+    if (d.thickness_mm) return `${d.thickness_mm}mm thick`;
+  }
+  if (
+    cat === 'PROFILE_H' ||
+    cat === 'PROFILE_I' ||
+    cat === 'PROFILE_HEA' ||
+    cat === 'PROFILE_HEB' ||
+    cat === 'PROFILE_IPE'
+  ) {
+    const dims = d.h_mm && d.b_mm ? `${d.h_mm}×${d.b_mm}mm` : null;
+    const weight = sp.weight_kg_per_m ? `${sp.weight_kg_per_m}kg/m` : null;
+    if (dims || weight) return [dims, weight].filter(Boolean).join(', ');
+  }
+  if (cat === 'BOLT' || cat === 'NUT') {
+    const thread = e.fastener.thread;
+    const length = e.fastener.length_mm;
+    if (thread) return length ? `${thread} L${length}mm` : thread;
+  }
+  if (cat === 'WELDING_ELECTRODE' || cat === 'WELDING_WIRE_FLUX') {
+    const aws = e.welding.aws_class;
+    const dia = e.welding.weld_diameter_mm;
+    if (aws) return dia ? `${aws} ∅${dia}mm` : aws;
+  }
+  return '—';
+}
+
+function getConversions(p: Product): string {
+  const e = p.enrichment;
+  const cat = e.material_category;
+
+  if (cat === 'SHEET' || cat === 'PLATE') {
+    const kgm2 = e.kg_per_m2;
+    if (!kgm2 || kgm2 <= 0) return '—';
+    const m2PerTon = (1000 / kgm2).toFixed(1);
+    return `${kgm2} kg/m² | ${m2PerTon} m²/t`;
+  }
+  if (
+    cat === 'PROFILE_H' ||
+    cat === 'PROFILE_I' ||
+    cat === 'PROFILE_HEA' ||
+    cat === 'PROFILE_HEB' ||
+    cat === 'PROFILE_IPE' ||
+    cat === 'FLAT_BAR' ||
+    cat === 'ROUND_BAR' ||
+    cat === 'PROFILE_C' ||
+    cat === 'PROFILE_ANGLE'
+  ) {
+    const kgLm = e.kg_per_lm ?? e.section_props.weight_kg_per_m;
+    if (!kgLm || kgLm <= 0) return '—';
+    const lmPerTon = (1000 / kgLm).toFixed(1);
+    return `${kgLm} kg/m | ${lmPerTon} m/t`;
+  }
+  return '—';
+}
+
+function fmt(n: number | null | undefined, decimals = 2): string {
+  if (n === null || n === undefined) return '—';
+  return n.toFixed(decimals);
+}
+
+// ─── Conversion Widget ────────────────────────────────────────────────────────
+
+type ConvUnit = 'KG' | 'TON' | 'M2' | 'LM' | 'PC';
+
+function ConversionWidget({ product }: { product: Product }) {
+  const e = product.enrichment;
+  const cat = e.material_category;
+  const [qty, setQty] = useState<string>('1');
+  const [fromUnit, setFromUnit] = useState<ConvUnit>('TON');
+
+  const isSheet = cat === 'SHEET' || cat === 'PLATE';
+  const isProfile =
+    cat === 'PROFILE_H' ||
+    cat === 'PROFILE_I' ||
+    cat === 'PROFILE_HEA' ||
+    cat === 'PROFILE_HEB' ||
+    cat === 'PROFILE_IPE' ||
+    cat === 'FLAT_BAR' ||
+    cat === 'ROUND_BAR' ||
+    cat === 'PROFILE_C' ||
+    cat === 'PROFILE_ANGLE';
+
+  const availableUnits: ConvUnit[] = isSheet
+    ? ['KG', 'TON', 'M2', 'PC']
+    : isProfile
+      ? ['KG', 'TON', 'LM', 'PC']
+      : ['KG', 'TON'];
+
+  // Convert input qty to KG first
+  function toKg(value: number, unit: ConvUnit): number | null {
+    switch (unit) {
+      case 'KG':
+        return value;
+      case 'TON':
+        return value * 1000;
+      case 'M2': {
+        const kpm2 = e.kg_per_m2;
+        if (!kpm2) return null;
+        return value * kpm2;
+      }
+      case 'LM': {
+        const kplm = e.kg_per_lm ?? e.section_props.weight_kg_per_m;
+        if (!kplm) return null;
+        return value * kplm;
+      }
+      case 'PC': {
+        if (!e.kg_per_unit) return null;
+        return value * e.kg_per_unit;
+      }
+    }
+  }
+
+  function fromKg(kg: number, unit: ConvUnit): number | null {
+    switch (unit) {
+      case 'KG':
+        return kg;
+      case 'TON':
+        return kg / 1000;
+      case 'M2': {
+        const kpm2 = e.kg_per_m2;
+        if (!kpm2) return null;
+        return kg / kpm2;
+      }
+      case 'LM': {
+        const kplm = e.kg_per_lm ?? e.section_props.weight_kg_per_m;
+        if (!kplm) return null;
+        return kg / kplm;
+      }
+      case 'PC': {
+        if (!e.kg_per_unit) return null;
+        return kg / e.kg_per_unit;
+      }
+    }
+  }
+
+  const inputVal = parseFloat(qty) || 0;
+  const kg = toKg(inputVal, fromUnit);
+
+  const results: { unit: ConvUnit; value: number | null }[] = availableUnits
+    .filter(u => u !== fromUnit)
+    .map(u => ({ unit: u, value: kg !== null ? fromKg(kg, u) : null }));
+
+  const summaryLine = (() => {
+    if (isSheet && e.kg_per_m2 && e.kg_per_m2 > 0) {
+      const m2pt = (1000 / e.kg_per_m2).toFixed(1);
+      const sheetsPerTon = e.kg_per_unit
+        ? (1000 / e.kg_per_unit).toFixed(1)
+        : null;
+      return `1 TON = ${m2pt} m²${sheetsPerTon ? ` = ${sheetsPerTon} sheets` : ''}`;
+    }
+    const kplm = e.kg_per_lm ?? e.section_props.weight_kg_per_m;
+    if (isProfile && kplm && kplm > 0) {
+      const lmpt = (1000 / kplm).toFixed(1);
+      const barLen = e.bar_length_m;
+      const barsPerTon = barLen && kplm ? (1000 / (kplm * barLen)).toFixed(1) : null;
+      return `1 TON = ${lmpt} m${barsPerTon ? ` = ${barsPerTon} bars` : ''}`;
+    }
+    return null;
+  })();
+
+  return (
+    <div className="space-y-4">
+      {summaryLine && (
+        <div className="rounded-lg bg-slate-50 border border-slate-200 px-4 py-2.5 text-sm font-medium text-slate-700">
+          {summaryLine}
+        </div>
+      )}
+
+      <div className="flex gap-3 items-end">
+        <div className="flex-1">
+          <Label className="text-xs text-slate-500 mb-1.5 block">Quantity</Label>
+          <Input
+            type="number"
+            value={qty}
+            onChange={e => setQty(e.target.value)}
+            className="font-mono"
+            min="0"
+            step="any"
+          />
+        </div>
+        <div className="w-32">
+          <Label className="text-xs text-slate-500 mb-1.5 block">From Unit</Label>
+          <Select value={fromUnit} onValueChange={v => setFromUnit(v as ConvUnit)}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {availableUnits.map(u => (
+                <SelectItem key={u} value={u}>
+                  {u}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-slate-200 overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow className="bg-slate-50">
+              <TableHead className="text-xs">Unit</TableHead>
+              <TableHead className="text-xs text-right">Value</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {results.map(r => (
+              <TableRow key={r.unit}>
+                <TableCell className="font-medium text-sm">{r.unit}</TableCell>
+                <TableCell className="text-right font-mono text-sm">
+                  {r.value !== null ? r.value.toLocaleString('en-SA-u-ca-gregory', { maximumFractionDigits: 4 }) : '—'}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}
+
+// ─── Review Form ──────────────────────────────────────────────────────────────
+
+interface ReviewFormProps {
+  product: Product;
+  onSuccess: (updated: Product) => void;
+}
+
+function ReviewForm({ product, onSuccess }: ReviewFormProps) {
+  const e = product.enrichment;
+  const { toast } = useToast();
+  const [saving, setSaving] = useState(false);
+  const [form, setForm] = useState({
+    item_class: e.item_class,
+    material_nature: e.material_nature ?? '',
+    material_category: e.material_category,
+    grade: e.grade ?? '',
+    unit_of_measure: e.unit_of_measure ?? '',
+    manufacturer: e.manufacturer ?? '',
+  });
+
+  async function handleSave() {
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/admin/material-master/review/${product.dolibarr_id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ...form,
+          review_required: false,
+        }),
+      });
+      if (!res.ok) throw new Error('Failed to save');
+      const updated: Product = {
+        ...product,
+        enrichment: {
+          ...product.enrichment,
+          ...form,
+          review_required: false,
+          classified_by: 'MANUAL',
+        },
+      };
+      toast({ title: 'Review saved', description: `${product.ref} marked as reviewed.` });
+      onSuccess(updated);
+    } catch {
+      toast({ title: 'Save failed', description: 'Could not save review. Try again.', variant: 'destructive' });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function field(label: string, key: keyof typeof form, node: React.ReactNode) {
+    return (
+      <div key={key} className="space-y-1.5">
+        <Label className="text-xs font-medium text-slate-600">{label}</Label>
+        {node}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      {e.review_required && (
+        <div className="flex items-center gap-2.5 rounded-lg bg-amber-50 border border-amber-200 px-4 py-3 text-sm text-amber-800">
+          <AlertTriangle className="h-4 w-4 shrink-0 text-amber-500" />
+          This product needs review — classification confidence is low or data is incomplete.
+        </div>
+      )}
+
+      <div className="grid grid-cols-2 gap-4">
+        {field(
+          'Item Class',
+          'item_class',
+          <Select value={form.item_class} onValueChange={v => setForm(f => ({ ...f, item_class: v }))}>
+            <SelectTrigger className="h-8 text-sm">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {['RAW_MATERIAL', 'CONSUMABLE', 'SERVICE', 'TOOL', 'SPARE_PART', 'UNKNOWN'].map(v => (
+                <SelectItem key={v} value={v} className="text-sm">
+                  {getItemClassLabel(v)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>,
+        )}
+        {field(
+          'Material Category',
+          'material_category',
+          <Select
+            value={form.material_category}
+            onValueChange={v => setForm(f => ({ ...f, material_category: v }))}
+          >
+            <SelectTrigger className="h-8 text-sm">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {[
+                'SHEET', 'PLATE', 'PROFILE_H', 'PROFILE_I', 'PROFILE_C', 'PROFILE_ANGLE',
+                'FLAT_BAR', 'ROUND_BAR', 'BOLT', 'NUT', 'WELDING_ELECTRODE',
+                'WELDING_WIRE_FLUX', 'WELDING_PPE', 'PAINT', 'GAS_CYLINDER', 'OTHER',
+              ].map(v => (
+                <SelectItem key={v} value={v} className="text-sm">
+                  {v.replace(/_/g, ' ')}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>,
+        )}
+        {field(
+          'Material Nature',
+          'material_nature',
+          <Input
+            value={form.material_nature}
+            onChange={ev => setForm(f => ({ ...f, material_nature: ev.target.value }))}
+            className="h-8 text-sm"
+            placeholder="e.g. Carbon Steel"
+          />,
+        )}
+        {field(
+          'Grade',
+          'grade',
+          <Input
+            value={form.grade}
+            onChange={ev => setForm(f => ({ ...f, grade: ev.target.value }))}
+            className="h-8 text-sm"
+            placeholder="e.g. S275"
+          />,
+        )}
+        {field(
+          'Unit of Measure',
+          'unit_of_measure',
+          <Input
+            value={form.unit_of_measure}
+            onChange={ev => setForm(f => ({ ...f, unit_of_measure: ev.target.value }))}
+            className="h-8 text-sm"
+            placeholder="e.g. KG"
+          />,
+        )}
+        {field(
+          'Manufacturer',
+          'manufacturer',
+          <Input
+            value={form.manufacturer}
+            onChange={ev => setForm(f => ({ ...f, manufacturer: ev.target.value }))}
+            className="h-8 text-sm"
+            placeholder="Manufacturer name"
+          />,
+        )}
+      </div>
+
+      <Separator />
+
+      <Button onClick={handleSave} disabled={saving} className="w-full active:scale-[0.97] transition-transform">
+        {saving ? (
+          <>
+            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+            Saving…
+          </>
+        ) : (
+          'Approve & Save'
+        )}
+      </Button>
+    </div>
+  );
+}
+
+// ─── Detail Panel ─────────────────────────────────────────────────────────────
+
+interface DetailPanelProps {
+  product: Product | null;
+  open: boolean;
+  onClose: () => void;
+  isAdmin: boolean;
+  onReviewSuccess: (updated: Product) => void;
+}
+
+function DetailPanel({ product, open, onClose, isAdmin, onReviewSuccess }: DetailPanelProps) {
+  if (!product) return null;
+  const e = product.enrichment;
+
+  function OverviewRow({ label, value }: { label: string; value: string | number | null | undefined }) {
+    if (!value && value !== 0) return null;
+    return (
+      <div className="flex items-start gap-2 py-2 border-b border-slate-100 last:border-0">
+        <span className="text-xs font-medium text-slate-500 w-36 shrink-0">{label}</span>
+        <span className="text-sm text-slate-800 break-words">{String(value)}</span>
+      </div>
+    );
+  }
+
+  const hasDimensions = (() => {
+    const d = e.dimensions;
+    const f = e.fastener;
+    const w = e.welding;
+    return (
+      d.h_mm ||
+      d.b_mm ||
+      d.width_mm ||
+      d.length_mm ||
+      d.thickness_mm ||
+      f.thread ||
+      f.standard ||
+      w.aws_class
+    );
+  })();
+
+  const hasSectionProps = e.section_props.weight_kg_per_m !== null;
+
+  return (
+    <Sheet open={open} onOpenChange={v => !v && onClose()}>
+      <SheetContent
+        side="right"
+        className="w-full max-w-2xl sm:max-w-2xl overflow-y-auto flex flex-col gap-0 p-0"
+        style={{ transition: 'transform 250ms ease-out' }}
+      >
+        {/* Header */}
+        <SheetHeader className="px-6 pt-6 pb-4 border-b border-slate-200">
+          <div className="flex items-start justify-between gap-3">
+            <div className="space-y-1 min-w-0">
+              <SheetTitle className="font-mono text-lg font-semibold tracking-tight text-slate-900">
+                {product.ref}
+              </SheetTitle>
+              <SheetDescription className="text-sm text-slate-600 leading-snug">
+                {product.label}
+              </SheetDescription>
+            </div>
+            <div className="flex flex-col gap-1.5 items-end shrink-0">
+              <span
+                className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border ${getItemClassColor(e.item_class)}`}
+              >
+                {getItemClassLabel(e.item_class)}
+              </span>
+              {getClassifiedByBadge(e.classified_by)}
+            </div>
+          </div>
+        </SheetHeader>
+
+        {/* Tabs */}
+        <div className="flex-1 px-6 py-4">
+          <Tabs defaultValue="overview">
+            <TabsList className="grid w-full grid-cols-6 mb-4 transition-all duration-150">
+              <TabsTrigger value="overview" className="text-xs">Overview</TabsTrigger>
+              <TabsTrigger value="dimensions" className="text-xs">Dims</TabsTrigger>
+              <TabsTrigger value="section-props" className="text-xs">Section</TabsTrigger>
+              <TabsTrigger value="conversions" className="text-xs">Convert</TabsTrigger>
+              <TabsTrigger value="tds" className="text-xs">TDS</TabsTrigger>
+              {isAdmin && <TabsTrigger value="review" className="text-xs">Review</TabsTrigger>}
+              {!isAdmin && <TabsTrigger value="review" className="text-xs" disabled>Review</TabsTrigger>}
+            </TabsList>
+
+            {/* TAB 1: Overview */}
+            <TabsContent value="overview" className="mt-0 space-y-0">
+              <div className="divide-y divide-slate-100 rounded-lg border border-slate-200 overflow-hidden">
+                <div className="px-4 py-2 bg-slate-50">
+                  <span className="text-xs font-semibold text-slate-500 uppercase tracking-wider">Classification</span>
+                </div>
+                <div className="px-4">
+                  <OverviewRow label="Item Class" value={getItemClassLabel(e.item_class)} />
+                  <OverviewRow label="Material Nature" value={e.material_nature} />
+                  <OverviewRow label="Category" value={e.material_category?.replace(/_/g, ' ')} />
+                  <OverviewRow label="Grade" value={e.grade} />
+                  <OverviewRow label="Finish" value={e.finish} />
+                  <OverviewRow label="Unit of Measure" value={e.unit_of_measure} />
+                  <OverviewRow label="Profile Type" value={e.profile_type} />
+                  <OverviewRow label="Profile Designation" value={e.profile_designation} />
+                  <OverviewRow label="Disburse Unit" value={e.disburse_unit} />
+                </div>
+                <div className="px-4 py-2 bg-slate-50">
+                  <span className="text-xs font-semibold text-slate-500 uppercase tracking-wider">Meta</span>
+                </div>
+                <div className="px-4">
+                  <OverviewRow label="Manufacturer" value={e.manufacturer} />
+                  <OverviewRow
+                    label="Classified By"
+                    value={e.classified_by?.replace(/_/g, ' ')}
+                  />
+                  <OverviewRow
+                    label="Confidence"
+                    value={e.classification_conf > 0 ? `${(e.classification_conf * 100).toFixed(0)}%` : null}
+                  />
+                  <OverviewRow
+                    label="Enriched At"
+                    value={
+                      e.enriched_at
+                        ? new Date(e.enriched_at).toLocaleString('en-SA-u-ca-gregory', {
+                            dateStyle: 'medium',
+                            timeStyle: 'short',
+                          })
+                        : null
+                    }
+                  />
+                </div>
+              </div>
+            </TabsContent>
+
+            {/* TAB 2: Dimensions */}
+            <TabsContent value="dimensions" className="mt-0">
+              {hasDimensions ? (
+                <div className="space-y-4">
+                  {/* Profile dims */}
+                  {(e.dimensions.h_mm || e.dimensions.b_mm || e.dimensions.tf_mm || e.dimensions.tw_mm) && (
+                    <div>
+                      <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">
+                        Profile Dimensions
+                      </p>
+                      <div className="rounded-lg border border-slate-200 overflow-hidden">
+                        <Table>
+                          <TableHeader>
+                            <TableRow className="bg-slate-50">
+                              <TableHead className="text-xs">H (mm)</TableHead>
+                              <TableHead className="text-xs">B (mm)</TableHead>
+                              <TableHead className="text-xs">tf (mm)</TableHead>
+                              <TableHead className="text-xs">tw (mm)</TableHead>
+                            </TableRow>
+                          </TableHeader>
+                          <TableBody>
+                            <TableRow>
+                              <TableCell className="font-mono text-sm">{fmt(e.dimensions.h_mm, 1)}</TableCell>
+                              <TableCell className="font-mono text-sm">{fmt(e.dimensions.b_mm, 1)}</TableCell>
+                              <TableCell className="font-mono text-sm">{fmt(e.dimensions.tf_mm, 1)}</TableCell>
+                              <TableCell className="font-mono text-sm">{fmt(e.dimensions.tw_mm, 1)}</TableCell>
+                            </TableRow>
+                          </TableBody>
+                        </Table>
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Sheet/Plate dims */}
+                  {(e.dimensions.width_mm || e.dimensions.length_mm || e.dimensions.thickness_mm) && (
+                    <div>
+                      <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">
+                        Sheet / Plate Dimensions
+                      </p>
+                      <div className="grid grid-cols-3 gap-3">
+                        {[
+                          { label: 'Width', value: e.dimensions.width_mm, unit: 'mm' },
+                          { label: 'Length', value: e.dimensions.length_mm, unit: 'mm' },
+                          { label: 'Thickness', value: e.dimensions.thickness_mm, unit: 'mm' },
+                        ].map(item => (
+                          <div key={item.label} className="rounded-lg bg-slate-50 border border-slate-200 px-3 py-2.5">
+                            <p className="text-xs text-slate-500">{item.label}</p>
+                            <p className="font-mono text-base font-semibold text-slate-800 mt-0.5">
+                              {item.value !== null ? `${item.value}` : '—'}
+                              {item.value !== null && (
+                                <span className="text-xs font-normal text-slate-500 ml-1">{item.unit}</span>
+                              )}
+                            </p>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Fastener */}
+                  {(e.fastener.thread || e.fastener.standard) && (
+                    <div>
+                      <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">
+                        Fastener Data
+                      </p>
+                      <div className="rounded-lg border border-slate-200 overflow-hidden">
+                        <Table>
+                          <TableHeader>
+                            <TableRow className="bg-slate-50">
+                              <TableHead className="text-xs">Standard</TableHead>
+                              <TableHead className="text-xs">Thread</TableHead>
+                              <TableHead className="text-xs">Length</TableHead>
+                              <TableHead className="text-xs">Grade</TableHead>
+                              <TableHead className="text-xs">Surface</TableHead>
+                            </TableRow>
+                          </TableHeader>
+                          <TableBody>
+                            <TableRow>
+                              <TableCell className="text-sm">{e.fastener.standard ?? '—'}</TableCell>
+                              <TableCell className="font-mono text-sm">{e.fastener.thread ?? '—'}</TableCell>
+                              <TableCell className="font-mono text-sm">
+                                {e.fastener.length_mm ? `${e.fastener.length_mm}mm` : '—'}
+                              </TableCell>
+                              <TableCell className="text-sm">{e.fastener.grade ?? '—'}</TableCell>
+                              <TableCell className="text-sm">{e.fastener.surface ?? '—'}</TableCell>
+                            </TableRow>
+                          </TableBody>
+                        </Table>
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Welding */}
+                  {e.welding.aws_class && (
+                    <div>
+                      <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">
+                        Welding Data
+                      </p>
+                      <div className="grid grid-cols-2 gap-3">
+                        {[
+                          { label: 'AWS Class', value: e.welding.aws_class },
+                          { label: 'Process', value: e.welding.weld_process },
+                          { label: 'Base Material', value: e.welding.weld_base_material },
+                          {
+                            label: 'Diameter',
+                            value: e.welding.weld_diameter_mm ? `${e.welding.weld_diameter_mm}mm` : null,
+                          },
+                        ].map(item => (
+                          <div key={item.label} className="rounded-lg bg-slate-50 border border-slate-200 px-3 py-2.5">
+                            <p className="text-xs text-slate-500">{item.label}</p>
+                            <p className="text-sm font-medium text-slate-800 mt-0.5">{item.value ?? '—'}</p>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <div className="py-12 text-center">
+                  <p className="text-slate-400 text-sm">No dimensional data available for this product.</p>
+                </div>
+              )}
+            </TabsContent>
+
+            {/* TAB 3: Section Properties */}
+            <TabsContent value="section-props" className="mt-0">
+              {hasSectionProps ? (
+                <div className="rounded-lg border border-slate-200 overflow-hidden">
+                  <Table>
+                    <TableHeader>
+                      <TableRow className="bg-slate-50">
+                        <TableHead className="text-xs font-semibold">Property</TableHead>
+                        <TableHead className="text-xs font-semibold text-right">Value</TableHead>
+                        <TableHead className="text-xs font-semibold text-right">Unit</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {[
+                        { prop: 'A (Area)', value: e.section_props.area_cm2, unit: 'cm²', decimals: 2 },
+                        { prop: 'G (Weight)', value: e.section_props.weight_kg_per_m, unit: 'kg/m', decimals: 2 },
+                        { prop: 'Ix', value: e.section_props.Ix_cm4, unit: 'cm⁴', decimals: 1 },
+                        { prop: 'Iy', value: e.section_props.Iy_cm4, unit: 'cm⁴', decimals: 1 },
+                        { prop: 'Wx', value: e.section_props.Wx_cm3, unit: 'cm³', decimals: 1 },
+                        { prop: 'Wy', value: e.section_props.Wy_cm3, unit: 'cm³', decimals: 1 },
+                        { prop: 'ix', value: e.section_props.ix_cm, unit: 'cm', decimals: 2 },
+                        { prop: 'iy', value: e.section_props.iy_cm, unit: 'cm', decimals: 2 },
+                        { prop: 'Standard', value: e.section_standard, unit: '—', decimals: 0, isString: true },
+                      ].map(row => (
+                        <TableRow key={row.prop}>
+                          <TableCell className="font-medium text-sm py-2">{row.prop}</TableCell>
+                          <TableCell className="text-right font-mono text-sm py-2">
+                            {'isString' in row && row.isString
+                              ? (row.value as string | null) ?? '—'
+                              : fmt(row.value as number | null, row.decimals)}
+                          </TableCell>
+                          <TableCell className="text-right text-xs text-slate-500 py-2">{row.unit}</TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              ) : (
+                <div className="py-12 text-center">
+                  <p className="text-slate-400 text-sm">No section properties available for this product.</p>
+                </div>
+              )}
+            </TabsContent>
+
+            {/* TAB 4: Conversions */}
+            <TabsContent value="conversions" className="mt-0">
+              <ConversionWidget product={product} />
+            </TabsContent>
+
+            {/* TAB 5: TDS & Media */}
+            <TabsContent value="tds" className="mt-0 space-y-4">
+              {!e.image_url && !e.tds_url && !e.technical_attrs_json && (
+                <div className="py-12 text-center">
+                  <p className="text-slate-400 text-sm">No TDS or media available for this product.</p>
+                </div>
+              )}
+              {e.image_url && (
+                <div>
+                  <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">Product Image</p>
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={e.image_url}
+                    alt={product.label}
+                    className="rounded-lg border border-slate-200 object-cover w-full max-h-64"
+                  />
+                </div>
+              )}
+              {e.tds_url && (
+                <a
+                  href={e.tds_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-slate-900 text-white text-sm font-medium hover:bg-slate-700 transition-colors active:scale-[0.97]"
+                >
+                  <ExternalLink className="h-4 w-4" />
+                  Download TDS
+                </a>
+              )}
+              {e.technical_attrs_json && Object.keys(e.technical_attrs_json).length > 0 && (
+                <div>
+                  <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">
+                    Technical Attributes
+                  </p>
+                  <div className="rounded-lg border border-slate-200 overflow-hidden">
+                    <Table>
+                      <TableBody>
+                        {Object.entries(e.technical_attrs_json).map(([key, val]) => (
+                          <TableRow key={key}>
+                            <TableCell className="text-xs font-medium text-slate-600 py-2 w-44">
+                              {key.replace(/_/g, ' ')}
+                            </TableCell>
+                            <TableCell className="text-sm py-2 font-mono">
+                              {typeof val === 'object' ? JSON.stringify(val) : String(val)}
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </div>
+                </div>
+              )}
+            </TabsContent>
+
+            {/* TAB 6: Review (admin only) */}
+            <TabsContent value="review" className="mt-0">
+              {isAdmin ? (
+                <ReviewForm product={product} onSuccess={onReviewSuccess} />
+              ) : (
+                <div className="py-12 text-center">
+                  <p className="text-slate-400 text-sm">Admin access required.</p>
+                </div>
+              )}
+            </TabsContent>
+          </Tabs>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+// ─── KPI Card ─────────────────────────────────────────────────────────────────
+
+interface KpiCardProps {
+  title: string;
+  value: string | number | null;
+  icon: React.ReactNode;
+  colorClass: string;
+  loading?: boolean;
+}
+
+function KpiCard({ title, value, icon, colorClass, loading }: KpiCardProps) {
+  return (
+    <Card className="border-slate-200">
+      <CardContent className="p-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-xs font-medium text-slate-500 uppercase tracking-wider">{title}</p>
+            {loading ? (
+              <Skeleton className="h-7 w-20 mt-1.5" />
+            ) : (
+              <p className={`text-2xl font-semibold tracking-tight mt-1 ${colorClass}`}>
+                {value === null ? '—' : value}
+              </p>
+            )}
+          </div>
+          <div className={`p-2.5 rounded-lg ${colorClass.includes('emerald') ? 'bg-emerald-50' : colorClass.includes('amber') ? 'bg-amber-50' : colorClass.includes('sky') ? 'bg-sky-50' : 'bg-slate-100'}`}>
+            {icon}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Main Page ────────────────────────────────────────────────────────────────
+
+export default function MaterialMasterPage() {
+  const { permissions } = usePermissions();
+  const isAdmin = permissions.includes('inv.admin');
+  const { toast } = useToast();
+
+  // ── Filters ──
+  const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [itemClass, setItemClass] = useState('ALL');
+  const [category, setCategory] = useState('ALL');
+  const [profileType, setProfileType] = useState('ALL');
+  const [needsReview, setNeedsReview] = useState(false);
+  const [enrichedOnly, setEnrichedOnly] = useState(false);
+  const [pageSize, setPageSize] = useState(50);
+  const [page, setPage] = useState(0);
+
+  // ── Data ──
+  const [products, setProducts] = useState<Product[]>([]);
+  const [pagination, setPagination] = useState<Pagination>({ page: 0, limit: 50, total: 0, totalPages: 0 });
+  const [loading, setLoading] = useState(true);
+
+  // ── Detail panel ──
+  const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
+  const [panelOpen, setPanelOpen] = useState(false);
+
+  // ── Classification running state ──
+  const [classifyStatus, setClassifyStatus] = useState<{
+    running: boolean;
+    pass: ClassifyPass | null;
+    result: string | null;
+  }>({ running: false, pass: null, result: null });
+
+  // ── Debounce search ──
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearch(search);
+      setPage(0);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  // ── Reset page on filter change ──
+  useEffect(() => {
+    setPage(0);
+  }, [itemClass, category, profileType, needsReview, enrichedOnly, pageSize]);
+
+  // ── Fetch products ──
+  const fetchProducts = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({
+        limit: String(pageSize),
+        page: String(page),
+        search: debouncedSearch,
+        item_class: itemClass === 'ALL' ? '' : itemClass,
+        material_category: category === 'ALL' ? '' : category,
+        enrichment_profile_type: profileType === 'ALL' ? '' : profileType,
+        review_required: needsReview ? 'true' : '',
+        enriched: enrichedOnly ? 'true' : '',
+      });
+      const res = await fetch(`/api/dolibarr/products?${params.toString()}`);
+      if (!res.ok) throw new Error('Fetch failed');
+      const data: ApiResponse = await res.json();
+      setProducts(data.products ?? []);
+      setPagination(data.pagination ?? { page: 0, limit: pageSize, total: 0, totalPages: 0 });
+    } catch {
+      setProducts([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [page, pageSize, debouncedSearch, itemClass, category, profileType, needsReview, enrichedOnly]);
+
+  useEffect(() => {
+    fetchProducts();
+  }, [fetchProducts]);
+
+  // ── Classify runner ──
+  const runClassify = useCallback(
+    async (pass: ClassifyPass, label: string) => {
+      if (classifyStatus.running) return;
+      setClassifyStatus({ running: true, pass, result: null });
+      try {
+        const res = await fetch('/api/admin/material-master/classify', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ pass }),
+        });
+        if (!res.ok) throw new Error('Classify failed');
+        const data = await res.json();
+        const resultText =
+          data?.message ??
+          (data?.classified !== undefined
+            ? `${data.classified} classified, ${data.pending ?? 0} pending`
+            : `${label} completed`);
+        setClassifyStatus({ running: false, pass: null, result: resultText });
+        await fetchProducts();
+        // Clear result after 8s
+        setTimeout(() => setClassifyStatus(s => ({ ...s, result: null })), 8000);
+      } catch {
+        setClassifyStatus({ running: false, pass: null, result: null });
+        toast({ title: 'Classification failed', description: 'Could not run classifier.', variant: 'destructive' });
+      }
+    },
+    [classifyStatus.running, fetchProducts, toast],
+  );
+
+  // ── KPIs (computed from current page + total) ──
+  const totalProducts = pagination.total;
+  const classifiedCount = products.filter(p => p.enrichment.classification_conf > 0).length;
+  const needsReviewCount = products.filter(p => p.enrichment.review_required).length;
+  const avgConf =
+    products.length > 0
+      ? products.reduce((acc, p) => acc + p.enrichment.classification_conf, 0) / products.length
+      : null;
+
+  // ── Detail panel handlers ──
+  function openProduct(p: Product) {
+    setSelectedProduct(p);
+    setPanelOpen(true);
+  }
+
+  function handleReviewSuccess(updated: Product) {
+    setProducts(prev => prev.map(p => (p.dolibarr_id === updated.dolibarr_id ? updated : p)));
+    if (selectedProduct?.dolibarr_id === updated.dolibarr_id) {
+      setSelectedProduct(updated);
+    }
+  }
+
+  // ── Classify pass button label map ──
+  const passButtons: { pass: ClassifyPass; label: string; icon: React.ReactNode }[] = [
+    { pass: 'rule', label: 'Run Rule Engine', icon: <Wand2 className="h-4 w-4" /> },
+    { pass: 'ai', label: 'Run AI Classifier', icon: <Bot className="h-4 w-4" /> },
+    { pass: 'enrichment', label: 'Enrich Consumables', icon: <Sparkles className="h-4 w-4" /> },
+  ];
+
+  return (
+    <div className="max-w-screen-2xl mx-auto px-4 md:px-6 py-6 space-y-6">
+      {/* ── SECTION 1: HERO ─────────────────────────────────────────────── */}
+      <div className="flex flex-col sm:flex-row sm:items-start gap-4 justify-between">
+        {/* Left */}
+        <div className="flex items-center gap-3">
+          <div className="p-2 rounded-lg bg-emerald-50 border border-emerald-200">
+            <Database className="h-8 w-8 text-emerald-600" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight text-slate-900">Material Master</h1>
+            <p className="text-sm text-slate-500 mt-0.5">
+              Product intelligence &amp; unit conversion engine for 5,000+ materials
+            </p>
+          </div>
+        </div>
+
+        {/* Right: admin actions */}
+        {isAdmin && (
+          <div className="flex flex-col items-end gap-2 shrink-0">
+            <div className="flex gap-2 flex-wrap justify-end">
+              {passButtons.map(btn => (
+                <Button
+                  key={btn.pass}
+                  variant="outline"
+                  size="sm"
+                  disabled={classifyStatus.running}
+                  onClick={() => runClassify(btn.pass, btn.label)}
+                  className="active:scale-[0.97] transition-transform gap-1.5 text-xs"
+                >
+                  {classifyStatus.running && classifyStatus.pass === btn.pass ? (
+                    <>
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      <span>
+                        Classifying
+                        <ClassifyDots />
+                      </span>
+                    </>
+                  ) : (
+                    <>
+                      {btn.icon}
+                      {btn.label}
+                    </>
+                  )}
+                </Button>
+              ))}
+            </div>
+            {classifyStatus.result && (
+              <p className="text-xs text-slate-500">
+                <span className="text-emerald-600 font-medium">Last run:</span> {classifyStatus.result}
+              </p>
+            )}
+            {classifyStatus.running && (
+              <p className="text-xs text-slate-500 flex items-center gap-1">
+                <Loader2 className="h-3 w-3 animate-spin text-slate-400" />
+                Classification in progress…
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* ── SECTION 2: KPI STRIP ──────────────────────────────────────────── */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <KpiCard
+          title="Total Products"
+          value={loading ? null : totalProducts.toLocaleString('en-SA-u-ca-gregory')}
+          icon={<Package className="h-5 w-5 text-slate-500" />}
+          colorClass="text-slate-800"
+          loading={loading}
+        />
+        <KpiCard
+          title="Classified"
+          value={loading ? null : classifiedCount.toLocaleString('en-SA-u-ca-gregory')}
+          icon={<CheckCircle2 className="h-5 w-5 text-emerald-600" />}
+          colorClass="text-emerald-700"
+          loading={loading}
+        />
+        <KpiCard
+          title="Needs Review"
+          value={loading ? null : needsReviewCount.toLocaleString('en-SA-u-ca-gregory')}
+          icon={<AlertTriangle className="h-5 w-5 text-amber-500" />}
+          colorClass="text-amber-700"
+          loading={loading}
+        />
+        <KpiCard
+          title="Avg Confidence"
+          value={loading ? null : avgConf !== null ? `${(avgConf * 100).toFixed(1)}%` : '—'}
+          icon={<BarChart2 className="h-5 w-5 text-sky-500" />}
+          colorClass="text-sky-700"
+          loading={loading}
+        />
+      </div>
+
+      {/* ── SECTION 3: FILTER BAR ─────────────────────────────────────────── */}
+      <Card className="border-slate-200">
+        <CardContent className="py-3 px-4">
+          <div className="flex flex-wrap gap-3 items-center">
+            {/* Search */}
+            <div className="relative flex-1 min-w-48">
+              <Input
+                placeholder="Search ref or label…"
+                value={search}
+                onChange={e => setSearch(e.target.value)}
+                className="pl-3 pr-3 h-9 text-sm"
+              />
+            </div>
+
+            {/* Item Class */}
+            <Select value={itemClass} onValueChange={setItemClass}>
+              <SelectTrigger className="h-9 w-40 text-sm">
+                <SelectValue placeholder="All Classes" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="ALL">All Classes</SelectItem>
+                <SelectItem value="RAW_MATERIAL">Raw Material</SelectItem>
+                <SelectItem value="CONSUMABLE">Consumable</SelectItem>
+                <SelectItem value="SERVICE">Service</SelectItem>
+                <SelectItem value="TOOL">Tool</SelectItem>
+                <SelectItem value="SPARE_PART">Spare Part</SelectItem>
+              </SelectContent>
+            </Select>
+
+            {/* Category */}
+            <Select value={category} onValueChange={setCategory}>
+              <SelectTrigger className="h-9 w-44 text-sm">
+                <SelectValue placeholder="All Categories" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="ALL">All Categories</SelectItem>
+                {[
+                  'SHEET', 'PLATE', 'PROFILE_H', 'PROFILE_I', 'PROFILE_C',
+                  'PROFILE_ANGLE', 'FLAT_BAR', 'ROUND_BAR', 'BOLT', 'NUT',
+                  'WELDING_ELECTRODE', 'WELDING_WIRE_FLUX', 'WELDING_PPE',
+                  'PAINT', 'GAS_CYLINDER', 'OTHER',
+                ].map(c => (
+                  <SelectItem key={c} value={c} className="text-sm">
+                    {c.replace(/_/g, ' ')}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            {/* Profile Type */}
+            <Select value={profileType} onValueChange={setProfileType}>
+              <SelectTrigger className="h-9 w-40 text-sm">
+                <SelectValue placeholder="All Profiles" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="ALL">All Profiles</SelectItem>
+                {['HEA', 'HEB', 'IPE', 'UPN', 'EQUAL_ANGLE', 'FLAT_BAR', 'ROUND_BAR'].map(pt => (
+                  <SelectItem key={pt} value={pt} className="text-sm">
+                    {pt}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            {/* Toggle: Needs Review */}
+            <Button
+              variant={needsReview ? 'default' : 'outline'}
+              size="sm"
+              onClick={() => setNeedsReview(v => !v)}
+              className={`h-9 text-xs gap-1.5 active:scale-[0.97] transition-transform ${needsReview ? 'bg-amber-500 hover:bg-amber-600 border-amber-500 text-white' : 'border-slate-200 text-slate-600'}`}
+            >
+              <AlertTriangle className="h-3.5 w-3.5" />
+              Needs Review
+            </Button>
+
+            {/* Toggle: Enriched Only */}
+            <Button
+              variant={enrichedOnly ? 'default' : 'outline'}
+              size="sm"
+              onClick={() => setEnrichedOnly(v => !v)}
+              className={`h-9 text-xs gap-1.5 active:scale-[0.97] transition-transform ${enrichedOnly ? 'bg-emerald-600 hover:bg-emerald-700 border-emerald-600 text-white' : 'border-slate-200 text-slate-600'}`}
+            >
+              <CheckCircle2 className="h-3.5 w-3.5" />
+              Enriched Only
+            </Button>
+
+            {/* Spacer */}
+            <div className="flex-1" />
+
+            {/* Page size */}
+            <Select value={String(pageSize)} onValueChange={v => setPageSize(Number(v))}>
+              <SelectTrigger className="h-9 w-20 text-sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="25">25</SelectItem>
+                <SelectItem value="50">50</SelectItem>
+                <SelectItem value="100">100</SelectItem>
+              </SelectContent>
+            </Select>
+
+            {/* Refresh */}
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={fetchProducts}
+              disabled={loading}
+              className="h-9 px-2 active:scale-[0.97] transition-transform"
+            >
+              <RefreshCw className={`h-4 w-4 text-slate-500 ${loading ? 'animate-spin' : ''}`} />
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* ── SECTION 4: PRODUCT TABLE ──────────────────────────────────────── */}
+      <Card className="border-slate-200">
+        <CardHeader className="py-3 px-4 border-b border-slate-100">
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-sm font-semibold text-slate-700">
+              Products
+              {!loading && (
+                <span className="ml-2 text-xs font-normal text-slate-400">
+                  {pagination.total.toLocaleString('en-SA-u-ca-gregory')} total
+                </span>
+              )}
+            </CardTitle>
+          </div>
+        </CardHeader>
+        <CardContent className="p-0">
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow className="bg-slate-50 hover:bg-slate-50">
+                  <TableHead className="text-xs font-semibold text-slate-600 w-32">REF</TableHead>
+                  <TableHead className="text-xs font-semibold text-slate-600">Label</TableHead>
+                  <TableHead className="text-xs font-semibold text-slate-600 w-36">Category</TableHead>
+                  <TableHead className="text-xs font-semibold text-slate-600 w-24">Grade</TableHead>
+                  <TableHead className="text-xs font-semibold text-slate-600 w-28">Classified By</TableHead>
+                  <TableHead className="text-xs font-semibold text-slate-600 w-12 text-center">Conf</TableHead>
+                  <TableHead className="text-xs font-semibold text-slate-600 w-44">Key Dims</TableHead>
+                  <TableHead className="text-xs font-semibold text-slate-600 w-44">Conversions</TableHead>
+                  <TableHead className="text-xs font-semibold text-slate-600 w-16 text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {loading ? (
+                  Array.from({ length: 5 }).map((_, i) => (
+                    <TableRow key={i}>
+                      {Array.from({ length: 9 }).map((_, j) => (
+                        <TableCell key={j} className="py-3">
+                          <Skeleton className="h-5 w-full" />
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  ))
+                ) : products.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={9} className="py-16 text-center text-slate-400 text-sm">
+                      No products found — adjust filters
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  products.map((product, idx) => (
+                    <TableRow
+                      key={product.dolibarr_id}
+                      onClick={() => openProduct(product)}
+                      className={`cursor-pointer transition-colors hover:bg-slate-50 ${idx % 2 === 0 ? 'bg-white' : 'bg-slate-50/50'}`}
+                    >
+                      {/* REF */}
+                      <TableCell className="py-2.5">
+                        <span className="font-mono text-xs font-medium text-slate-800 hover:text-emerald-700 transition-colors">
+                          {product.ref}
+                        </span>
+                      </TableCell>
+
+                      {/* Label */}
+                      <TableCell className="py-2.5">
+                        <span className="text-sm text-slate-700 truncate block max-w-xs" title={product.label}>
+                          {product.label.length > 45 ? `${product.label.slice(0, 45)}…` : product.label}
+                        </span>
+                      </TableCell>
+
+                      {/* Category */}
+                      <TableCell className="py-2.5">
+                        <span
+                          className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border transition-all hover:brightness-95 ${getItemClassColor(product.enrichment.item_class)}`}
+                        >
+                          {product.enrichment.material_category?.replace(/_/g, ' ') || getItemClassLabel(product.enrichment.item_class)}
+                        </span>
+                      </TableCell>
+
+                      {/* Grade */}
+                      <TableCell className="py-2.5">
+                        <span className="text-xs text-slate-500 font-mono">
+                          {product.enrichment.grade || '—'}
+                        </span>
+                      </TableCell>
+
+                      {/* Classified By */}
+                      <TableCell className="py-2.5">
+                        {getClassifiedByBadge(product.enrichment.classified_by)}
+                      </TableCell>
+
+                      {/* Confidence */}
+                      <TableCell className="py-2.5 text-center">
+                        <ConfidenceDot conf={product.enrichment.classification_conf} />
+                      </TableCell>
+
+                      {/* Key Dims */}
+                      <TableCell className="py-2.5">
+                        <span className="text-xs text-slate-600 font-mono">{getKeyDims(product)}</span>
+                      </TableCell>
+
+                      {/* Conversions */}
+                      <TableCell className="py-2.5">
+                        <span className="text-xs text-slate-600 font-mono">{getConversions(product)}</span>
+                      </TableCell>
+
+                      {/* Actions */}
+                      <TableCell className="py-2.5 text-right">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={e => {
+                            e.stopPropagation();
+                            openProduct(product);
+                          }}
+                          className="h-7 px-2 text-xs text-slate-500 hover:text-slate-800 active:scale-[0.97] transition-transform gap-1"
+                        >
+                          <Eye className="h-3.5 w-3.5" />
+                          View
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* ── SECTION 5: PAGINATION ─────────────────────────────────────────── */}
+      {!loading && pagination.totalPages > 1 && (
+        <div className="flex items-center justify-center gap-3">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page === 0}
+            onClick={() => setPage(p => p - 1)}
+            className="gap-1.5 active:scale-[0.97] transition-transform"
+          >
+            <ChevronLeft className="h-4 w-4" />
+            Previous
+          </Button>
+          <span className="text-sm text-slate-600 font-medium px-2">
+            Page {page + 1} of {pagination.totalPages}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page >= pagination.totalPages - 1}
+            onClick={() => setPage(p => p + 1)}
+            className="gap-1.5 active:scale-[0.97] transition-transform"
+          >
+            Next
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
+      )}
+
+      {/* ── SECTION 6: DETAIL SIDE PANEL ─────────────────────────────────── */}
+      <DetailPanel
+        product={selectedProduct}
+        open={panelOpen}
+        onClose={() => setPanelOpen(false)}
+        isAdmin={isAdmin}
+        onReviewSuccess={handleReviewSuccess}
+      />
+    </div>
+  );
+}
+
+// ── Animated dots for "Classifying..." ────────────────────────────────────────
+
+function ClassifyDots() {
+  const [dots, setDots] = useState('');
+  const ref = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    ref.current = setInterval(() => {
+      setDots(d => (d.length >= 3 ? '' : d + '.'));
+    }, 400);
+    return () => {
+      if (ref.current) clearInterval(ref.current);
+    };
+  }, []);
+
+  return <span className="inline-block w-4 text-left">{dots}</span>;
+}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -339,8 +339,9 @@ const navigationSections: NavigationSection[] = [
       { name: 'Stock Levels',    href: '/inv/stock',     icon: Package,         newSince: '2026-05-24' },
       { name: 'Material Issues', href: '/inv/mir-out',   icon: ArrowRightLeft,  newSince: '2026-05-24' },
       { name: 'Returns',         href: '/inv/returns',   icon: Undo2,           newSince: '2026-05-24' },
-      { name: 'Ledger',          href: '/inv/ledger',    icon: BookOpen,        newSince: '2026-05-24' },
-      { name: 'Settings',        href: '/inv/settings',  icon: Settings,        newSince: '2026-05-24' },
+      { name: 'Ledger',           href: '/inv/ledger',            icon: BookOpen,  newSince: '2026-05-24' },
+      { name: 'Material Master',  href: '/inv/material-master',   icon: Database,  newSince: '2026-05-25' },
+      { name: 'Settings',         href: '/inv/settings',          icon: Settings,  newSince: '2026-05-24' },
     ],
   },
   {

--- a/src/lib/dolibarr/sync-service.ts
+++ b/src/lib/dolibarr/sync-service.ts
@@ -153,7 +153,19 @@ export class DolibarrSyncService {
             continue;
           }
 
-          // Update changed record
+          // ENRICHMENT GUARD: The following columns are OTS-owned and must NEVER be updated
+          // by the sync job. They are intentionally excluded from the UPDATE list:
+          //   item_class, material_nature, material_category, grade, finish,
+          //   profile_type, profile_designation, section_standard, bar_length_m,
+          //   all dim_* columns, all section property columns (weight_kg_per_m, area_cm2,
+          //   Ix_cm4, Iy_cm4, Wx_cm3, Wy_cm3, ix_cm, iy_cm, section_props_json),
+          //   all fastener_* columns, all weld_* columns,
+          //   density_kg_m3, kg_per_m2, kg_per_lm, unit_area_m2, kg_per_unit,
+          //   disburse_unit, unit_conversions_json,
+          //   manufacturer, manufacturer_ref, image_url, tds_url, technical_attrs_json,
+          //   classified_by, classification_conf, review_required, review_notes,
+          //   reviewed_by, reviewed_at, enriched_at
+          // Update changed record (Dolibarr mirror columns only)
           await prisma.$executeRawUnsafe(`
             UPDATE dolibarr_products SET
               ref = ?, label = ?, description = ?, product_type = ?, status_sell = ?, status_buy = ?,

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -22,6 +22,9 @@ interface EnvConfig {
 
   // Optional — may be undefined
   OPENAI_API_KEY: string | undefined;
+  ANTHROPIC_API_KEY: string | undefined;
+  GEMINI_API_KEY: string | undefined;
+  XAI_API_KEY: string | undefined;
   DOLIBARR_API_URL: string | undefined;
   DOLIBARR_API_KEY: string | undefined;
   DOLIBARR_API_TIMEOUT: string | undefined;
@@ -104,6 +107,9 @@ function validateEnv(): EnvConfig {
     LOG_LEVEL: process.env.LOG_LEVEL ?? (process.env.NODE_ENV === 'production' ? 'info' : 'debug'),
 
     OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+    ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+    GEMINI_API_KEY: process.env.GEMINI_API_KEY,
+    XAI_API_KEY: process.env.XAI_API_KEY,
     DOLIBARR_API_URL: process.env.DOLIBARR_API_URL,
     DOLIBARR_API_KEY: process.env.DOLIBARR_API_KEY,
     DOLIBARR_API_TIMEOUT: process.env.DOLIBARR_API_TIMEOUT,

--- a/src/lib/material-master/ai-classifier.ts
+++ b/src/lib/material-master/ai-classifier.ts
@@ -1,0 +1,128 @@
+import Anthropic from '@anthropic-ai/sdk'
+import { logger } from '@/lib/logger'
+
+const client = new Anthropic() // reads ANTHROPIC_API_KEY from environment
+
+export interface AIClassificationInput {
+  dolibarr_id: number
+  ref: string
+  label: string
+}
+
+export interface AIClassificationOutput {
+  dolibarr_id: number
+  item_class: string
+  material_nature: string
+  material_category: string
+  grade: string | null
+  profile_type: string | null
+  profile_designation: string | null
+  unit_of_measure: string
+  aws_class: string | null
+  fastener_thread: string | null
+  fastener_grade: string | null
+  manufacturer: string | null
+  confidence: number
+  notes: string | null
+}
+
+const SYSTEM_PROMPT = `You are a material classification expert for a structural steel fabrication company in Saudi Arabia.
+Classify each product using ONLY these exact enum values.
+
+item_class: RAW_MATERIAL | CONSUMABLE | SPARE_PART | SERVICE | TOOL | UNKNOWN
+material_nature: CARBON_STEEL | STAINLESS_STEEL | ALUMINUM | GALVANIZED_STEEL | HARDWARE | WELDING_CONSUMABLE | CHEMICAL | PPE | GAS | ELECTRICAL | SERVICE | OTHER | UNKNOWN
+material_category: SHEET | PLATE | CHECKERED_PLATE | PROFILE_H | PROFILE_I | PROFILE_C | PROFILE_ANGLE | FLAT_BAR | ROUND_BAR | SQUARE_BAR | PIPE_ROUND | PIPE_SQUARE | PIPE_RECTANGULAR | BOLT | NUT | WASHER | ANCHOR | STUD | WELDING_ELECTRODE | WELDING_WIRE_SOLID | WELDING_WIRE_FLUX | WELDING_FLUX_SAW | WELDING_PPE | WELDING_ACCESSORY | PAINT | PRIMER | THINNER | ABRASIVE | GAS_CYLINDER | SAFETY_PPE | ELECTRICAL | OTHER | UNKNOWN
+unit_of_measure: KG | TON | M | LM | M2 | PC | SET | BOX | L | ROLL
+
+Rules:
+- Sheets and plates: unit_of_measure = KG (sold by weight, disbursed by m² or kg)
+- Profiles/bars/pipes: unit_of_measure = KG
+- Bolts/fasteners: unit_of_measure = PC
+- Welding consumables (electrodes, wire): unit_of_measure = KG
+- Gases: unit_of_measure = PC (cylinder)
+- PPE/safety: unit_of_measure = PC
+- confidence: 1.0 if certain, 0.75-0.95 if reasonably sure, below 0.75 if guessing
+
+Respond ONLY with a valid JSON array. No markdown, no explanation. Format:
+[{"dolibarr_id": N, "item_class": "...", "material_nature": "...", "material_category": "...", "grade": null, "profile_type": null, "profile_designation": null, "unit_of_measure": "...", "aws_class": null, "fastener_thread": null, "fastener_grade": null, "manufacturer": null, "confidence": 0.9, "notes": null}]`
+
+export async function classifyBatch(
+  products: AIClassificationInput[]
+): Promise<AIClassificationOutput[]> {
+  const userContent = products.map(p =>
+    `{"id": ${p.dolibarr_id}, "ref": "${p.ref}", "label": "${p.label}"}`
+  ).join('\n')
+
+  const response = await client.messages.create({
+    model: 'claude-sonnet-4-6',
+    max_tokens: 8192,
+    messages: [
+      { role: 'user', content: `Classify these products:\n${userContent}` }
+    ],
+    system: SYSTEM_PROMPT,
+  })
+
+  const text = response.content
+    .filter(b => b.type === 'text')
+    .map(b => (b as Anthropic.TextBlock).text)
+    .join('')
+
+  const clean = text.replace(/```json|```/g, '').trim()
+  const parsed: AIClassificationOutput[] = JSON.parse(clean)
+  return parsed
+}
+
+export async function runAIBatchClassification(
+  db: { query: (sql: string, params?: unknown[]) => Promise<unknown[][]> },
+  batchSize = 80
+): Promise<{ processed: number; errors: number }> {
+  const [rows] = await db.query(
+    `SELECT dolibarr_id, ref, label FROM dolibarr_products
+     WHERE classified_by = 'UNCLASSIFIED' OR classified_by IS NULL
+     ORDER BY dolibarr_id`
+  ) as [AIClassificationInput[]]
+
+  const unclassified = rows as unknown as AIClassificationInput[]
+
+  let processed = 0, errors = 0
+
+  for (let i = 0; i < unclassified.length; i += batchSize) {
+    const batch = unclassified.slice(i, i + batchSize)
+    try {
+      const results = await classifyBatch(batch)
+      for (const r of results) {
+        await db.query(
+          `UPDATE dolibarr_products SET
+            item_class = ?, material_nature = ?, material_category = ?,
+            grade = COALESCE(?, grade), profile_type = ?, profile_designation = ?,
+            unit_of_measure = ?, aws_class = ?, fastener_thread = ?,
+            fastener_grade = ?, manufacturer = ?,
+            classified_by = 'AI_BATCH',
+            classification_conf = ?,
+            review_required = ?,
+            enriched_at = NOW()
+          WHERE dolibarr_id = ?`,
+          [
+            r.item_class, r.material_nature, r.material_category,
+            r.grade, r.profile_type, r.profile_designation,
+            r.unit_of_measure, r.aws_class, r.fastener_thread,
+            r.fastener_grade, r.manufacturer,
+            r.confidence,
+            r.confidence < 0.75 ? 1 : 0,
+            r.dolibarr_id
+          ]
+        )
+        processed++
+      }
+      logger.info({ batch: Math.floor(i/batchSize)+1, classified: batch.length }, 'AI classification batch complete')
+      if (i + batchSize < unclassified.length) {
+        await new Promise(res => setTimeout(res, 500))
+      }
+    } catch (err) {
+      logger.error({ err, batch: Math.floor(i/batchSize)+1 }, 'AI classification batch failed')
+      errors++
+    }
+  }
+
+  return { processed, errors }
+}

--- a/src/lib/material-master/classifier.ts
+++ b/src/lib/material-master/classifier.ts
@@ -1,0 +1,334 @@
+import { lookupSection } from './section-library'
+import {
+  computeSheetConversions,
+  computeProfileConversions,
+  computeBarKgPerLm,
+  DENSITY
+} from './unit-conversion'
+
+export interface ClassificationResult {
+  item_class: string
+  material_nature: string
+  material_category: string
+  grade: string | null
+  finish: string | null
+  unit_of_measure: string
+  bar_length_m: number | null
+  profile_type: string | null
+  profile_designation: string | null
+  section_standard: string | null
+  // Dimensional
+  dim_h_mm: number | null
+  dim_b_mm: number | null
+  dim_tf_mm: number | null
+  dim_tw_mm: number | null
+  dim_r_mm: number | null
+  dim_width_mm: number | null
+  dim_length_mm: number | null
+  dim_thickness_mm: number | null
+  // Section props (from library)
+  weight_kg_per_m: number | null
+  area_cm2: number | null
+  Ix_cm4: number | null
+  Iy_cm4: number | null
+  Wx_cm3: number | null
+  Wy_cm3: number | null
+  ix_cm: number | null
+  iy_cm: number | null
+  section_props_json: object | null
+  // Fastener
+  fastener_standard: string | null
+  fastener_thread: string | null
+  fastener_length_mm: number | null
+  fastener_grade: string | null
+  fastener_surface: string | null
+  // Welding
+  aws_class: string | null
+  weld_process: string | null
+  weld_base_material: string | null
+  weld_diameter_mm: number | null
+  // Conversion engine
+  density_kg_m3: number
+  kg_per_m2: number | null
+  kg_per_lm: number | null
+  unit_area_m2: number | null
+  kg_per_unit: number | null
+  disburse_unit: string
+  unit_conversions_json: object | null
+  // Manufacturer (from ref suffix)
+  manufacturer: string | null
+  manufacturer_ref: string | null
+  // Meta
+  classified_by: string
+  classification_conf: number
+  review_required: boolean
+}
+
+const EMPTY: ClassificationResult = {
+  item_class: 'UNKNOWN', material_nature: 'UNKNOWN', material_category: 'UNKNOWN',
+  grade: null, finish: null, unit_of_measure: 'PC', bar_length_m: null,
+  profile_type: null, profile_designation: null, section_standard: null,
+  dim_h_mm: null, dim_b_mm: null, dim_tf_mm: null, dim_tw_mm: null, dim_r_mm: null,
+  dim_width_mm: null, dim_length_mm: null, dim_thickness_mm: null,
+  weight_kg_per_m: null, area_cm2: null, Ix_cm4: null, Iy_cm4: null,
+  Wx_cm3: null, Wy_cm3: null, ix_cm: null, iy_cm: null, section_props_json: null,
+  fastener_standard: null, fastener_thread: null, fastener_length_mm: null,
+  fastener_grade: null, fastener_surface: null,
+  aws_class: null, weld_process: null, weld_base_material: null, weld_diameter_mm: null,
+  density_kg_m3: 7850, kg_per_m2: null, kg_per_lm: null,
+  unit_area_m2: null, kg_per_unit: null, disburse_unit: 'KG',
+  unit_conversions_json: null,
+  manufacturer: null, manufacturer_ref: null,
+  classified_by: 'RULE_ENGINE', classification_conf: 0, review_required: true,
+}
+
+function parseGrade(gradeStr: string | undefined): string | null {
+  if (!gradeStr) return null
+  return gradeStr.replace(/-/g, '-').toUpperCase() || null
+}
+
+function densityFor(nature: string): number {
+  if (nature === 'STAINLESS_STEEL')   return DENSITY.STAINLESS_STEEL
+  if (nature === 'ALUMINUM')          return DENSITY.ALUMINUM
+  if (nature === 'GALVANIZED_STEEL')  return DENSITY.GALVANIZED_STEEL
+  return DENSITY.CARBON_STEEL
+}
+
+export function classifyProduct(ref: string, label: string): ClassificationResult {
+  const r = ref.trim().toUpperCase()
+  const l = label.trim()
+
+  // ── PATTERN 1: Sheets ────────────────────────────────────────────────────
+  {
+    const m = r.match(/^SHE(\d+(?:\.\d+)?)X(\d+(?:\.\d+)?)X(\d+(?:\.\d+)?)(-G50|-A572-G50|-A572-S355|-S355)?$/)
+    if (m) {
+      const w = parseFloat(m[1]), len = parseFloat(m[2]), t = parseFloat(m[3])
+      const gradeStr = m[4]
+      const nature = 'CARBON_STEEL'
+      const grade = gradeStr ? (gradeStr.includes('G50') ? 'A572-G50' : gradeStr.replace(/^-/,'')) : 'A36'
+      const density = densityFor(nature)
+      const sc = computeSheetConversions(w, len, t, density)
+      return {
+        ...EMPTY,
+        item_class: 'RAW_MATERIAL', material_nature: nature,
+        material_category: t >= 6 ? 'PLATE' : 'SHEET',
+        grade, finish: 'Black Steel', unit_of_measure: 'KG',
+        profile_type: t >= 6 ? 'PLATE' : 'SHEET',
+        dim_width_mm: w, dim_length_mm: len, dim_thickness_mm: t,
+        density_kg_m3: density,
+        kg_per_m2: sc.kg_per_m2, unit_area_m2: sc.unit_area_m2,
+        kg_per_unit: sc.kg_per_sheet,
+        disburse_unit: 'KG',
+        unit_conversions_json: sc,
+        classified_by: 'RULE_ENGINE', classification_conf: 1.0, review_required: false,
+      }
+    }
+  }
+
+  // ── PATTERN 2: H/I Profiles from section library ─────────────────────────
+  {
+    const m = r.match(/^(HEA|HEB|HEM|IPE|IPO|IPN|UPN|UPE)(\d+)-(\d+(?:\.\d+)?)-(.+)$/)
+    if (m) {
+      const profileType = m[1], size = m[2], barLen = parseFloat(m[3])
+      const grade = parseGrade(m[4])
+      const designation = `${profileType} ${size}`
+      const section = lookupSection(profileType, designation)
+      let result: ClassificationResult = {
+        ...EMPTY,
+        item_class: 'RAW_MATERIAL', material_nature: 'CARBON_STEEL',
+        material_category: ['HEA','HEB','HEM'].includes(profileType) ? 'PROFILE_H' :
+                           ['IPE','IPO','IPN'].includes(profileType) ? 'PROFILE_I' : 'PROFILE_C',
+        grade, finish: 'Black Steel', unit_of_measure: 'KG',
+        profile_type: profileType as ClassificationResult['profile_type'],
+        profile_designation: designation,
+        section_standard: 'EN10365',
+        bar_length_m: barLen,
+        density_kg_m3: DENSITY.CARBON_STEEL,
+        classified_by: 'RULE_ENGINE', classification_conf: 0.95, review_required: false,
+      }
+      if (section) {
+        const pc = computeProfileConversions(section.weight_kg_per_m, barLen)
+        result = {
+          ...result,
+          dim_h_mm: section.h_mm, dim_b_mm: section.b_mm,
+          dim_tf_mm: section.tf_mm, dim_tw_mm: section.tw_mm, dim_r_mm: section.r_mm,
+          weight_kg_per_m: section.weight_kg_per_m, area_cm2: section.area_cm2,
+          Ix_cm4: section.Ix_cm4, Iy_cm4: section.Iy_cm4,
+          Wx_cm3: section.Wx_cm3, Wy_cm3: section.Wy_cm3,
+          ix_cm: section.ix_cm, iy_cm: section.iy_cm,
+          section_props_json: section,
+          kg_per_lm: section.weight_kg_per_m, kg_per_unit: pc.kg_per_bar,
+          disburse_unit: 'KG',
+          unit_conversions_json: pc,
+          classification_conf: 1.0,
+        }
+      }
+      return result
+    }
+  }
+
+  // ── PATTERN 3: Heavy Hex Bolts ────────────────────────────────────────────
+  {
+    const m = r.match(/^HHB-(BS|GS|HDG|ZN)-?(M\d+(?:\.\d+)?)-(\d+(?:\.\d+)?)MM-G?(\d+(?:\.\d+)?)$/)
+    if (m) {
+      const finishCode = m[1], thread = m[2], length = parseFloat(m[3]), grade = m[4]
+      const finishMap: Record<string,string> = { BS:'Black Steel', GS:'Galvanized', HDG:'Hot-Dip Galvanized', ZN:'Zinc Plated' }
+      return {
+        ...EMPTY,
+        item_class: 'CONSUMABLE', material_nature: 'HARDWARE',
+        material_category: 'BOLT',
+        grade, finish: finishMap[finishCode] ?? finishCode, unit_of_measure: 'PC',
+        fastener_standard: 'DIN 6914', fastener_thread: thread,
+        fastener_length_mm: length, fastener_grade: grade,
+        fastener_surface: finishMap[finishCode] ?? finishCode,
+        disburse_unit: 'PC',
+        classified_by: 'RULE_ENGINE', classification_conf: 1.0, review_required: false,
+      }
+    }
+  }
+
+  // ── PATTERN 4: Heavy Hex Nuts ─────────────────────────────────────────────
+  {
+    const m = r.match(/^HHN-(BS|GS|HDG|ZN)-?(M\d+(?:\.\d+)?)-(.+)$/)
+    if (m) {
+      const thread = m[2], standard = m[3].replace(/GR\./g,'Grade ')
+      return {
+        ...EMPTY,
+        item_class: 'CONSUMABLE', material_nature: 'HARDWARE',
+        material_category: 'NUT', unit_of_measure: 'PC',
+        fastener_standard: standard, fastener_thread: thread,
+        fastener_grade: standard.includes('2H') ? '2H' : null,
+        fastener_surface: 'Black Steel',
+        disburse_unit: 'PC',
+        classified_by: 'RULE_ENGINE', classification_conf: 1.0, review_required: false,
+      }
+    }
+  }
+
+  // ── PATTERN 5: Self-Drilling Screws ──────────────────────────────────────
+  {
+    const m = r.match(/^SS\w+-?(GS|BS|HDG|ZN)-M?(\d+(?:\.\d+)?)-(\d+(?:\.\d+)?)MM?$/)
+    if (m) {
+      return {
+        ...EMPTY,
+        item_class: 'CONSUMABLE', material_nature: 'HARDWARE',
+        material_category: 'BOLT', unit_of_measure: 'PC',
+        fastener_thread: `M${m[2]}`, fastener_length_mm: parseFloat(m[3]),
+        fastener_surface: m[1] === 'GS' ? 'Galvanized' : 'Black Steel',
+        disburse_unit: 'PC',
+        classified_by: 'RULE_ENGINE', classification_conf: 0.90, review_required: false,
+      }
+    }
+  }
+
+  // ── PATTERN 6: Welding Electrodes (SMAW) ──────────────────────────────────
+  {
+    const m = r.match(/^WE(\w+)-E-(MS|SS|LA|AL)(\d+(?:\.\d+)?)(\w+)$/)
+    if (m) {
+      const awsBase = m[1], matCode = m[2], diam = parseFloat(m[3])
+      const matMap: Record<string,string> = { MS:'MILD_STEEL', SS:'STAINLESS', LA:'LOW_ALLOY', AL:'ALUMINUM' }
+      const awsClass = `E${awsBase}`
+      const brandFromLabel = l.split(' - ').pop()?.split('-').pop()?.trim() ?? null
+      return {
+        ...EMPTY,
+        item_class: 'CONSUMABLE', material_nature: 'WELDING_CONSUMABLE',
+        material_category: 'WELDING_ELECTRODE', unit_of_measure: 'KG',
+        aws_class: awsClass,
+        weld_process: 'SMAW',
+        weld_base_material: matMap[matCode] as ClassificationResult['weld_base_material'],
+        weld_diameter_mm: diam,
+        manufacturer: brandFromLabel,
+        manufacturer_ref: awsClass,
+        disburse_unit: 'KG',
+        classified_by: 'RULE_ENGINE', classification_conf: 1.0, review_required: false,
+      }
+    }
+  }
+
+  // ── PATTERN 7: Welding Flux-Cored Wire ────────────────────────────────────
+  {
+    const m = r.match(/^WE(\w+)-FW-(MS|SS|CS|LA)(\d+(?:\.\d+)?)(\w+)$/)
+    if (m) {
+      const awsBase = m[1], diam = parseFloat(m[3])
+      return {
+        ...EMPTY,
+        item_class: 'CONSUMABLE', material_nature: 'WELDING_CONSUMABLE',
+        material_category: 'WELDING_WIRE_FLUX', unit_of_measure: 'KG',
+        aws_class: `E${awsBase}`,
+        weld_process: 'FCAW',
+        weld_base_material: 'MILD_STEEL',
+        weld_diameter_mm: diam,
+        disburse_unit: 'KG',
+        classified_by: 'RULE_ENGINE', classification_conf: 1.0, review_required: false,
+      }
+    }
+  }
+
+  // ── PATTERN 8: SAW Flux Wire ──────────────────────────────────────────────
+  {
+    const m = r.match(/^WFLUX[\w.]+-FW-(CS|MS)(\d+(?:\.\d+)?)(\w+)$/)
+    if (m) {
+      return {
+        ...EMPTY,
+        item_class: 'CONSUMABLE', material_nature: 'WELDING_CONSUMABLE',
+        material_category: 'WELDING_WIRE_SOLID', unit_of_measure: 'KG',
+        weld_process: 'SAW', weld_base_material: 'MILD_STEEL',
+        weld_diameter_mm: parseFloat(m[2]),
+        disburse_unit: 'KG',
+        classified_by: 'RULE_ENGINE', classification_conf: 0.95, review_required: false,
+      }
+    }
+  }
+
+  // ── PATTERN 9: HX-D PPE & Accessories ────────────────────────────────────
+  {
+    const m = r.match(/^HX-D-(\w+)-(\w+)-(.+)$/)
+    if (m) {
+      const typeCode = m[1], brand = m[3]
+      const weldingPPECodes = ['WG','WH','WJ','WN','WS']
+      const isWeldingPPE = weldingPPECodes.includes(typeCode.toUpperCase())
+      return {
+        ...EMPTY,
+        item_class: 'CONSUMABLE',
+        material_nature: isWeldingPPE ? 'WELDING_CONSUMABLE' : 'PPE',
+        material_category: isWeldingPPE ? 'WELDING_PPE' : 'SAFETY_PPE',
+        unit_of_measure: 'PC',
+        manufacturer: brand,
+        disburse_unit: 'PC',
+        classified_by: 'RULE_ENGINE', classification_conf: 0.9, review_required: false,
+      }
+    }
+  }
+
+  // ── PATTERN 10: Stainless Sheets ─────────────────────────────────────────
+  {
+    if (/STAINLESS|304SS|316SS|SS304|SS316/.test(r) && /SHE|SHEET|PLATE|PL/.test(r)) {
+      const dimMatch = l.match(/(\d+(?:\.\d+)?)\s*[Xx]\s*(\d+(?:\.\d+)?)\s*[Xx]\s*(\d+(?:\.\d+)?)/)
+      if (dimMatch) {
+        const w = parseFloat(dimMatch[1]), len = parseFloat(dimMatch[2]), t = parseFloat(dimMatch[3])
+        const sc = computeSheetConversions(w, len, t, DENSITY.STAINLESS_STEEL)
+        return {
+          ...EMPTY,
+          item_class: 'RAW_MATERIAL', material_nature: 'STAINLESS_STEEL',
+          material_category: t >= 6 ? 'PLATE' : 'SHEET',
+          grade: r.includes('304') ? '304SS' : r.includes('316') ? '316SS' : null,
+          unit_of_measure: 'KG',
+          dim_width_mm: w, dim_length_mm: len, dim_thickness_mm: t,
+          density_kg_m3: DENSITY.STAINLESS_STEEL,
+          kg_per_m2: sc.kg_per_m2, unit_area_m2: sc.unit_area_m2,
+          kg_per_unit: sc.kg_per_sheet, unit_conversions_json: sc,
+          disburse_unit: 'KG',
+          classified_by: 'RULE_ENGINE', classification_conf: 0.95, review_required: false,
+        }
+      }
+    }
+  }
+
+  // ── FALLBACK: unmatched → queue for AI batch ──────────────────────────────
+  return {
+    ...EMPTY,
+    classified_by: 'UNCLASSIFIED',
+    classification_conf: 0,
+    review_required: true,
+  }
+}

--- a/src/lib/material-master/disbursement.ts
+++ b/src/lib/material-master/disbursement.ts
@@ -1,0 +1,65 @@
+import { convertDisbursementUnits, UnitConversions } from './unit-conversion'
+import prisma from '@/lib/db'
+
+export interface DisbursementOptions {
+  product_ref: string
+  label: string
+  disburse_unit: string
+  available_units: string[]
+  conversions: UnitConversions | null
+}
+
+export async function getDisbursementOptions(
+  dolibarrProductId: number
+): Promise<DisbursementOptions> {
+  const rows: Array<{
+    ref: string
+    label: string
+    item_class: string
+    material_category: string
+    disburse_unit: string
+    unit_conversions_json: string | null
+    kg_per_m2: string | null
+    kg_per_lm: string | null
+    unit_area_m2: string | null
+  }> = await prisma.$queryRawUnsafe(
+    `SELECT ref, label, item_class, material_category,
+            disburse_unit, unit_conversions_json,
+            kg_per_m2, kg_per_lm, unit_area_m2
+     FROM dolibarr_products WHERE dolibarr_id = ?`,
+    dolibarrProductId
+  )
+
+  const p = rows[0]
+  if (!p) throw new Error(`Product ${dolibarrProductId} not found`)
+
+  const isSheet = ['SHEET','PLATE','CHECKERED_PLATE'].includes(p.material_category)
+  const isProfile = ['PROFILE_H','PROFILE_I','PROFILE_C','PROFILE_ANGLE',
+                     'FLAT_BAR','ROUND_BAR','SQUARE_BAR'].includes(p.material_category)
+
+  const available_units: string[] = ['KG', 'TON']
+  if (isSheet)   available_units.push('M2', 'PC')
+  if (isProfile) available_units.push('LM', 'PC')
+
+  let conversions: UnitConversions | null = null
+  if (p.unit_conversions_json) {
+    try {
+      const raw = typeof p.unit_conversions_json === 'string'
+        ? JSON.parse(p.unit_conversions_json)
+        : p.unit_conversions_json
+      conversions = isSheet ? { sheet: raw } : { profile: raw }
+    } catch {
+      conversions = null
+    }
+  }
+
+  return {
+    product_ref: p.ref,
+    label: p.label,
+    disburse_unit: p.disburse_unit,
+    available_units,
+    conversions,
+  }
+}
+
+export { convertDisbursementUnits }

--- a/src/lib/material-master/run-classification.ts
+++ b/src/lib/material-master/run-classification.ts
@@ -1,0 +1,155 @@
+/**
+ * Material Master Classification Runner
+ *
+ * Orchestrates all classification passes in sequence:
+ * Pass 1: Rule-Based Classification (fast, deterministic)
+ * Pass 2: AI Batch Classification (Claude — handles ~80 products/call)
+ * Pass 3: Web Enrichment (Gemini — images + TDS URLs for consumables)
+ *
+ * This script can be invoked from the admin API route or run directly.
+ */
+
+import mysql from 'mysql2/promise'
+import { classifyProduct, ClassificationResult } from './classifier'
+import { runAIBatchClassification } from './ai-classifier'
+import { enrichConsumable } from './web-enrichment'
+
+interface DbPool {
+  query: <T = unknown[]>(sql: string, params?: unknown[]) => Promise<[T]>
+  execute: (sql: string, params?: unknown[]) => Promise<[unknown]>
+  end: () => Promise<void>
+}
+
+export async function runFullClassification(db?: DbPool): Promise<{
+  rule: { classified: number; skipped: number }
+  ai: { processed: number; errors: number }
+  enrichment: { enriched: number; errors: number }
+}> {
+  const pool = db ?? (await mysql.createPool({
+    host: process.env.DB_HOST,
+    user: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME,
+    waitForConnections: true,
+    connectionLimit: 5,
+  }) as unknown as DbPool)
+
+  console.log('── PASS 1: Rule-Based Classification ──')
+  const [products] = await pool.query<Array<{ dolibarr_id: number; ref: string; label: string }>>(
+    'SELECT dolibarr_id, ref, label FROM dolibarr_products ORDER BY dolibarr_id'
+  )
+
+  let ruleClassified = 0, ruleSkipped = 0
+
+  for (const p of products) {
+    const result: ClassificationResult = classifyProduct(p.ref, p.label)
+    if (result.classification_conf > 0) {
+      await pool.execute(
+        `UPDATE dolibarr_products SET
+          item_class=?, material_nature=?, material_category=?, grade=?,
+          finish=?, unit_of_measure=?, bar_length_m=?,
+          profile_type=?, profile_designation=?, section_standard=?,
+          dim_h_mm=?, dim_b_mm=?, dim_tf_mm=?, dim_tw_mm=?, dim_r_mm=?,
+          dim_width_mm=?, dim_length_mm=?, dim_thickness_mm=?,
+          weight_kg_per_m=?, area_cm2=?, Ix_cm4=?, Iy_cm4=?, Wx_cm3=?, Wy_cm3=?,
+          ix_cm=?, iy_cm=?, section_props_json=?,
+          fastener_standard=?, fastener_thread=?, fastener_length_mm=?,
+          fastener_grade=?, fastener_surface=?,
+          aws_class=?, weld_process=?, weld_base_material=?, weld_diameter_mm=?,
+          density_kg_m3=?, kg_per_m2=?, kg_per_lm=?, unit_area_m2=?,
+          kg_per_unit=?, disburse_unit=?, unit_conversions_json=?,
+          manufacturer=?,
+          classified_by=?, classification_conf=?, review_required=?, enriched_at=NOW()
+        WHERE dolibarr_id=?`,
+        [
+          result.item_class, result.material_nature, result.material_category, result.grade,
+          result.finish, result.unit_of_measure, result.bar_length_m,
+          result.profile_type, result.profile_designation, result.section_standard,
+          result.dim_h_mm, result.dim_b_mm, result.dim_tf_mm, result.dim_tw_mm, result.dim_r_mm,
+          result.dim_width_mm, result.dim_length_mm, result.dim_thickness_mm,
+          result.weight_kg_per_m, result.area_cm2, result.Ix_cm4, result.Iy_cm4,
+          result.Wx_cm3, result.Wy_cm3, result.ix_cm, result.iy_cm,
+          result.section_props_json ? JSON.stringify(result.section_props_json) : null,
+          result.fastener_standard, result.fastener_thread, result.fastener_length_mm,
+          result.fastener_grade, result.fastener_surface,
+          result.aws_class, result.weld_process, result.weld_base_material, result.weld_diameter_mm,
+          result.density_kg_m3, result.kg_per_m2, result.kg_per_lm, result.unit_area_m2,
+          result.kg_per_unit, result.disburse_unit,
+          result.unit_conversions_json ? JSON.stringify(result.unit_conversions_json) : null,
+          result.manufacturer,
+          result.classified_by, result.classification_conf, result.review_required ? 1 : 0,
+          p.dolibarr_id,
+        ]
+      )
+      ruleClassified++
+    } else {
+      ruleSkipped++
+    }
+  }
+  console.log(`Pass 1 complete: ${ruleClassified} classified, ${ruleSkipped} queued for AI`)
+
+  console.log('── PASS 2: AI Batch Classification ──')
+  const dbInterface = {
+    query: async (sql: string, params?: unknown[]) => {
+      const result = await pool.query(sql, params)
+      return result as unknown as unknown[][]
+    }
+  }
+  const { processed: aiProcessed, errors: aiErrors } = await runAIBatchClassification(dbInterface)
+  console.log(`Pass 2 complete: ${aiProcessed} processed, ${aiErrors} batch errors`)
+
+  console.log('── PASS 3: Web Enrichment (Consumables) ──')
+  const [consumables] = await pool.query<Array<{
+    dolibarr_id: number
+    ref: string
+    label: string
+    aws_class: string | null
+    material_category: string
+  }>>(
+    `SELECT dolibarr_id, ref, label, aws_class, material_category
+     FROM dolibarr_products
+     WHERE item_class = 'CONSUMABLE'
+     AND image_url IS NULL
+     LIMIT 200`
+  )
+
+  let enriched = 0, enrichmentErrors = 0
+  for (const c of consumables) {
+    try {
+      const result = await enrichConsumable(c.dolibarr_id, c.ref, c.label, c.aws_class, c.material_category)
+      await pool.execute(
+        `UPDATE dolibarr_products SET
+          image_url=?, tds_url=?, technical_attrs_json=?,
+          manufacturer=COALESCE(manufacturer, ?)
+        WHERE dolibarr_id=?`,
+        [
+          result.image_url, result.tds_url,
+          result.technical_attrs_json ? JSON.stringify(result.technical_attrs_json) : null,
+          result.manufacturer, c.dolibarr_id
+        ]
+      )
+      enriched++
+      await new Promise(r => setTimeout(r, 300))
+    } catch (err) {
+      console.error(`Enrichment failed for ${c.dolibarr_id}:`, err)
+      enrichmentErrors++
+    }
+  }
+  console.log(`Pass 3 complete: ${enriched} consumables enriched, ${enrichmentErrors} errors`)
+
+  if (!db) {
+    await pool.end()
+  }
+
+  console.log('── Classification pipeline complete ──')
+  return {
+    rule: { classified: ruleClassified, skipped: ruleSkipped },
+    ai: { processed: aiProcessed, errors: aiErrors },
+    enrichment: { enriched, errors: enrichmentErrors },
+  }
+}
+
+// Allow running directly: npx ts-node src/lib/material-master/run-classification.ts
+if (require.main === module) {
+  runFullClassification().catch(console.error)
+}

--- a/src/lib/material-master/section-library.ts
+++ b/src/lib/material-master/section-library.ts
@@ -1,0 +1,627 @@
+// ============================================================
+// Section Library — Static reference data for structural steel
+// profiles per EN 10365 (HEA/HEB/IPE/UPN) and DIN (Angles)
+// ============================================================
+
+export interface SectionProps {
+  designation: string;       // e.g. 'HEA 100'
+  profileType: string;       // e.g. 'HEA'
+  standard: string;          // e.g. 'EN10365'
+  h_mm: number;              // Total height
+  b_mm: number;              // Flange width
+  tf_mm: number;             // Flange thickness
+  tw_mm: number;             // Web thickness
+  r_mm: number;              // Root fillet radius
+  weight_kg_per_m: number;   // kg/m
+  area_cm2: number;          // Cross-section area
+  Ix_cm4: number;            // Second moment of area — major axis
+  Iy_cm4: number;            // Second moment of area — minor axis
+  Wx_cm3: number;            // Section modulus — major axis
+  Wy_cm3: number;            // Section modulus — minor axis
+  ix_cm: number;             // Radius of gyration — major axis
+  iy_cm: number;             // Radius of gyration — minor axis
+}
+
+// ── HEA Sections (EN 10365) ──────────────────────────────────────────────
+export const HEA_SECTIONS: SectionProps[] = [
+  {
+    designation: 'HEA 100', profileType: 'HEA', standard: 'EN10365',
+    h_mm: 96,   b_mm: 100,  tf_mm: 8.0,  tw_mm: 5.0,  r_mm: 12,
+    weight_kg_per_m: 16.7,  area_cm2: 21.2,
+    Ix_cm4: 349,   Iy_cm4: 134,   Wx_cm3: 72.8,  Wy_cm3: 26.8,  ix_cm: 4.06, iy_cm: 2.51,
+  },
+  {
+    designation: 'HEA 120', profileType: 'HEA', standard: 'EN10365',
+    h_mm: 114,  b_mm: 120,  tf_mm: 8.0,  tw_mm: 5.0,  r_mm: 12,
+    weight_kg_per_m: 19.9,  area_cm2: 25.3,
+    Ix_cm4: 606,   Iy_cm4: 231,   Wx_cm3: 106,   Wy_cm3: 38.5,  ix_cm: 4.89, iy_cm: 3.02,
+  },
+  {
+    designation: 'HEA 140', profileType: 'HEA', standard: 'EN10365',
+    h_mm: 133,  b_mm: 140,  tf_mm: 8.5,  tw_mm: 5.5,  r_mm: 12,
+    weight_kg_per_m: 24.7,  area_cm2: 31.4,
+    Ix_cm4: 1033,  Iy_cm4: 389,   Wx_cm3: 155,   Wy_cm3: 55.6,  ix_cm: 5.73, iy_cm: 3.52,
+  },
+  {
+    designation: 'HEA 160', profileType: 'HEA', standard: 'EN10365',
+    h_mm: 152,  b_mm: 160,  tf_mm: 9.0,  tw_mm: 6.0,  r_mm: 15,
+    weight_kg_per_m: 30.4,  area_cm2: 38.8,
+    Ix_cm4: 1673,  Iy_cm4: 616,   Wx_cm3: 220,   Wy_cm3: 77.0,  ix_cm: 6.57, iy_cm: 3.98,
+  },
+  {
+    designation: 'HEA 180', profileType: 'HEA', standard: 'EN10365',
+    h_mm: 171,  b_mm: 180,  tf_mm: 9.5,  tw_mm: 6.0,  r_mm: 15,
+    weight_kg_per_m: 35.5,  area_cm2: 45.3,
+    Ix_cm4: 2510,  Iy_cm4: 925,   Wx_cm3: 294,   Wy_cm3: 103,   ix_cm: 7.45, iy_cm: 4.52,
+  },
+  {
+    designation: 'HEA 200', profileType: 'HEA', standard: 'EN10365',
+    h_mm: 190,  b_mm: 200,  tf_mm: 10.0, tw_mm: 6.5,  r_mm: 18,
+    weight_kg_per_m: 42.3,  area_cm2: 53.8,
+    Ix_cm4: 3692,  Iy_cm4: 1336,  Wx_cm3: 389,   Wy_cm3: 134,   ix_cm: 8.28, iy_cm: 4.98,
+  },
+  {
+    designation: 'HEA 220', profileType: 'HEA', standard: 'EN10365',
+    h_mm: 210,  b_mm: 220,  tf_mm: 11.0, tw_mm: 7.0,  r_mm: 18,
+    weight_kg_per_m: 50.5,  area_cm2: 64.3,
+    Ix_cm4: 5410,  Iy_cm4: 1955,  Wx_cm3: 515,   Wy_cm3: 178,   ix_cm: 9.17, iy_cm: 5.51,
+  },
+  {
+    designation: 'HEA 240', profileType: 'HEA', standard: 'EN10365',
+    h_mm: 230,  b_mm: 240,  tf_mm: 12.0, tw_mm: 7.5,  r_mm: 21,
+    weight_kg_per_m: 60.3,  area_cm2: 76.8,
+    Ix_cm4: 7763,  Iy_cm4: 2769,  Wx_cm3: 675,   Wy_cm3: 231,   ix_cm: 10.1, iy_cm: 6.00,
+  },
+  {
+    designation: 'HEA 260', profileType: 'HEA', standard: 'EN10365',
+    h_mm: 250,  b_mm: 260,  tf_mm: 12.5, tw_mm: 7.5,  r_mm: 24,
+    weight_kg_per_m: 68.2,  area_cm2: 86.8,
+    Ix_cm4: 10450, Iy_cm4: 3668,  Wx_cm3: 836,   Wy_cm3: 282,   ix_cm: 10.97,iy_cm: 6.50,
+  },
+  {
+    designation: 'HEA 280', profileType: 'HEA', standard: 'EN10365',
+    h_mm: 270,  b_mm: 280,  tf_mm: 13.0, tw_mm: 8.0,  r_mm: 24,
+    weight_kg_per_m: 76.4,  area_cm2: 97.3,
+    Ix_cm4: 13670, Iy_cm4: 4763,  Wx_cm3: 1013,  Wy_cm3: 340,   ix_cm: 11.86,iy_cm: 6.99,
+  },
+  {
+    designation: 'HEA 300', profileType: 'HEA', standard: 'EN10365',
+    h_mm: 290,  b_mm: 300,  tf_mm: 14.0, tw_mm: 8.5,  r_mm: 27,
+    weight_kg_per_m: 88.3,  area_cm2: 112.5,
+    Ix_cm4: 18260, Iy_cm4: 6310,  Wx_cm3: 1260,  Wy_cm3: 421,   ix_cm: 12.74,iy_cm: 7.49,
+  },
+  {
+    designation: 'HEA 320', profileType: 'HEA', standard: 'EN10365',
+    h_mm: 310,  b_mm: 300,  tf_mm: 15.5, tw_mm: 9.0,  r_mm: 27,
+    weight_kg_per_m: 97.6,  area_cm2: 124.4,
+    Ix_cm4: 22930, Iy_cm4: 6985,  Wx_cm3: 1479,  Wy_cm3: 466,   ix_cm: 13.58,iy_cm: 7.50,
+  },
+  {
+    designation: 'HEA 340', profileType: 'HEA', standard: 'EN10365',
+    h_mm: 330,  b_mm: 300,  tf_mm: 16.5, tw_mm: 9.5,  r_mm: 27,
+    weight_kg_per_m: 105.0, area_cm2: 133.5,
+    Ix_cm4: 27690, Iy_cm4: 7436,  Wx_cm3: 1678,  Wy_cm3: 496,   ix_cm: 14.40,iy_cm: 7.46,
+  },
+  {
+    designation: 'HEA 360', profileType: 'HEA', standard: 'EN10365',
+    h_mm: 350,  b_mm: 300,  tf_mm: 17.5, tw_mm: 10.0, r_mm: 27,
+    weight_kg_per_m: 112.0, area_cm2: 142.8,
+    Ix_cm4: 33090, Iy_cm4: 7887,  Wx_cm3: 1891,  Wy_cm3: 526,   ix_cm: 15.22,iy_cm: 7.43,
+  },
+  {
+    designation: 'HEA 400', profileType: 'HEA', standard: 'EN10365',
+    h_mm: 390,  b_mm: 300,  tf_mm: 19.0, tw_mm: 11.0, r_mm: 27,
+    weight_kg_per_m: 125.0, area_cm2: 159.0,
+    Ix_cm4: 45070, Iy_cm4: 8564,  Wx_cm3: 2311,  Wy_cm3: 571,   ix_cm: 16.84,iy_cm: 7.34,
+  },
+  {
+    designation: 'HEA 450', profileType: 'HEA', standard: 'EN10365',
+    h_mm: 440,  b_mm: 300,  tf_mm: 21.0, tw_mm: 11.5, r_mm: 27,
+    weight_kg_per_m: 140.0, area_cm2: 178.0,
+    Ix_cm4: 63720, Iy_cm4: 9465,  Wx_cm3: 2896,  Wy_cm3: 631,   ix_cm: 18.93,iy_cm: 7.29,
+  },
+  {
+    designation: 'HEA 500', profileType: 'HEA', standard: 'EN10365',
+    h_mm: 490,  b_mm: 300,  tf_mm: 23.0, tw_mm: 12.0, r_mm: 27,
+    weight_kg_per_m: 155.0, area_cm2: 197.5,
+    Ix_cm4: 86970, Iy_cm4: 10370, Wx_cm3: 3550,  Wy_cm3: 691,   ix_cm: 20.98,iy_cm: 7.24,
+  },
+  {
+    designation: 'HEA 550', profileType: 'HEA', standard: 'EN10365',
+    h_mm: 540,  b_mm: 300,  tf_mm: 24.0, tw_mm: 12.5, r_mm: 27,
+    weight_kg_per_m: 166.0, area_cm2: 211.8,
+    Ix_cm4: 111900,Iy_cm4: 10820, Wx_cm3: 4146,  Wy_cm3: 721,   ix_cm: 22.99,iy_cm: 7.15,
+  },
+  {
+    designation: 'HEA 600', profileType: 'HEA', standard: 'EN10365',
+    h_mm: 590,  b_mm: 300,  tf_mm: 25.0, tw_mm: 13.0, r_mm: 27,
+    weight_kg_per_m: 178.0, area_cm2: 226.5,
+    Ix_cm4: 141200,Iy_cm4: 11270, Wx_cm3: 4787,  Wy_cm3: 751,   ix_cm: 24.98,iy_cm: 7.05,
+  },
+  {
+    designation: 'HEA 650', profileType: 'HEA', standard: 'EN10365',
+    h_mm: 640,  b_mm: 300,  tf_mm: 26.0, tw_mm: 13.5, r_mm: 27,
+    weight_kg_per_m: 190.0, area_cm2: 241.6,
+    Ix_cm4: 175200,Iy_cm4: 11720, Wx_cm3: 5474,  Wy_cm3: 781,   ix_cm: 26.93,iy_cm: 6.97,
+  },
+  {
+    designation: 'HEA 700', profileType: 'HEA', standard: 'EN10365',
+    h_mm: 690,  b_mm: 300,  tf_mm: 27.0, tw_mm: 14.5, r_mm: 27,
+    weight_kg_per_m: 204.0, area_cm2: 260.5,
+    Ix_cm4: 215300,Iy_cm4: 12180, Wx_cm3: 6241,  Wy_cm3: 812,   ix_cm: 28.75,iy_cm: 6.84,
+  },
+  {
+    designation: 'HEA 800', profileType: 'HEA', standard: 'EN10365',
+    h_mm: 790,  b_mm: 300,  tf_mm: 28.0, tw_mm: 15.0, r_mm: 30,
+    weight_kg_per_m: 224.0, area_cm2: 285.8,
+    Ix_cm4: 303400,Iy_cm4: 12640, Wx_cm3: 7682,  Wy_cm3: 843,   ix_cm: 32.58,iy_cm: 6.65,
+  },
+  {
+    designation: 'HEA 900', profileType: 'HEA', standard: 'EN10365',
+    h_mm: 890,  b_mm: 300,  tf_mm: 30.0, tw_mm: 16.0, r_mm: 30,
+    weight_kg_per_m: 252.0, area_cm2: 320.5,
+    Ix_cm4: 422100,Iy_cm4: 13550, Wx_cm3: 9485,  Wy_cm3: 903,   ix_cm: 36.28,iy_cm: 6.50,
+  },
+  {
+    designation: 'HEA 1000', profileType: 'HEA', standard: 'EN10365',
+    h_mm: 990,  b_mm: 300,  tf_mm: 31.0, tw_mm: 16.5, r_mm: 30,
+    weight_kg_per_m: 272.0, area_cm2: 346.8,
+    Ix_cm4: 553800,Iy_cm4: 13980, Wx_cm3: 11190, Wy_cm3: 932,   ix_cm: 39.97,iy_cm: 6.35,
+  },
+];
+
+// ── HEB Sections (EN 10365) ──────────────────────────────────────────────
+export const HEB_SECTIONS: SectionProps[] = [
+  {
+    designation: 'HEB 100', profileType: 'HEB', standard: 'EN10365',
+    h_mm: 100,  b_mm: 100,  tf_mm: 10.0, tw_mm: 6.0,  r_mm: 12,
+    weight_kg_per_m: 20.4,  area_cm2: 26.0,
+    Ix_cm4: 450,   Iy_cm4: 167,   Wx_cm3: 89.9,  Wy_cm3: 33.5,  ix_cm: 4.16, iy_cm: 2.53,
+  },
+  {
+    designation: 'HEB 120', profileType: 'HEB', standard: 'EN10365',
+    h_mm: 120,  b_mm: 120,  tf_mm: 11.0, tw_mm: 6.5,  r_mm: 12,
+    weight_kg_per_m: 26.7,  area_cm2: 34.0,
+    Ix_cm4: 864,   Iy_cm4: 318,   Wx_cm3: 144,   Wy_cm3: 52.9,  ix_cm: 5.04, iy_cm: 3.06,
+  },
+  {
+    designation: 'HEB 140', profileType: 'HEB', standard: 'EN10365',
+    h_mm: 140,  b_mm: 140,  tf_mm: 12.0, tw_mm: 7.0,  r_mm: 12,
+    weight_kg_per_m: 33.7,  area_cm2: 43.0,
+    Ix_cm4: 1509,  Iy_cm4: 550,   Wx_cm3: 216,   Wy_cm3: 78.5,  ix_cm: 5.93, iy_cm: 3.58,
+  },
+  {
+    designation: 'HEB 160', profileType: 'HEB', standard: 'EN10365',
+    h_mm: 160,  b_mm: 160,  tf_mm: 13.0, tw_mm: 8.0,  r_mm: 15,
+    weight_kg_per_m: 42.6,  area_cm2: 54.3,
+    Ix_cm4: 2492,  Iy_cm4: 889,   Wx_cm3: 311,   Wy_cm3: 111,   ix_cm: 6.78, iy_cm: 4.05,
+  },
+  {
+    designation: 'HEB 180', profileType: 'HEB', standard: 'EN10365',
+    h_mm: 180,  b_mm: 180,  tf_mm: 14.0, tw_mm: 8.5,  r_mm: 15,
+    weight_kg_per_m: 51.2,  area_cm2: 65.3,
+    Ix_cm4: 3831,  Iy_cm4: 1363,  Wx_cm3: 426,   Wy_cm3: 151,   ix_cm: 7.66, iy_cm: 4.57,
+  },
+  {
+    designation: 'HEB 200', profileType: 'HEB', standard: 'EN10365',
+    h_mm: 200,  b_mm: 200,  tf_mm: 15.0, tw_mm: 9.0,  r_mm: 18,
+    weight_kg_per_m: 61.3,  area_cm2: 78.1,
+    Ix_cm4: 5696,  Iy_cm4: 2003,  Wx_cm3: 570,   Wy_cm3: 200,   ix_cm: 8.54, iy_cm: 5.07,
+  },
+  {
+    designation: 'HEB 220', profileType: 'HEB', standard: 'EN10365',
+    h_mm: 220,  b_mm: 220,  tf_mm: 16.0, tw_mm: 9.5,  r_mm: 18,
+    weight_kg_per_m: 71.5,  area_cm2: 91.0,
+    Ix_cm4: 8091,  Iy_cm4: 2843,  Wx_cm3: 736,   Wy_cm3: 258,   ix_cm: 9.43, iy_cm: 5.59,
+  },
+  {
+    designation: 'HEB 240', profileType: 'HEB', standard: 'EN10365',
+    h_mm: 240,  b_mm: 240,  tf_mm: 17.0, tw_mm: 10.0, r_mm: 21,
+    weight_kg_per_m: 83.2,  area_cm2: 106.0,
+    Ix_cm4: 11260, Iy_cm4: 3923,  Wx_cm3: 938,   Wy_cm3: 327,   ix_cm: 10.31,iy_cm: 6.08,
+  },
+  {
+    designation: 'HEB 260', profileType: 'HEB', standard: 'EN10365',
+    h_mm: 260,  b_mm: 260,  tf_mm: 17.5, tw_mm: 10.0, r_mm: 24,
+    weight_kg_per_m: 93.0,  area_cm2: 118.4,
+    Ix_cm4: 14920, Iy_cm4: 5135,  Wx_cm3: 1148,  Wy_cm3: 395,   ix_cm: 11.22,iy_cm: 6.58,
+  },
+  {
+    designation: 'HEB 280', profileType: 'HEB', standard: 'EN10365',
+    h_mm: 280,  b_mm: 280,  tf_mm: 18.0, tw_mm: 10.5, r_mm: 24,
+    weight_kg_per_m: 103.0, area_cm2: 131.4,
+    Ix_cm4: 19270, Iy_cm4: 6595,  Wx_cm3: 1376,  Wy_cm3: 471,   ix_cm: 12.11,iy_cm: 7.09,
+  },
+  {
+    designation: 'HEB 300', profileType: 'HEB', standard: 'EN10365',
+    h_mm: 300,  b_mm: 300,  tf_mm: 19.0, tw_mm: 11.0, r_mm: 27,
+    weight_kg_per_m: 117.0, area_cm2: 149.1,
+    Ix_cm4: 25170, Iy_cm4: 8563,  Wx_cm3: 1678,  Wy_cm3: 571,   ix_cm: 12.99,iy_cm: 7.58,
+  },
+  {
+    designation: 'HEB 320', profileType: 'HEB', standard: 'EN10365',
+    h_mm: 320,  b_mm: 300,  tf_mm: 20.5, tw_mm: 11.5, r_mm: 27,
+    weight_kg_per_m: 127.0, area_cm2: 161.3,
+    Ix_cm4: 30820, Iy_cm4: 9239,  Wx_cm3: 1926,  Wy_cm3: 616,   ix_cm: 13.82,iy_cm: 7.57,
+  },
+  {
+    designation: 'HEB 340', profileType: 'HEB', standard: 'EN10365',
+    h_mm: 340,  b_mm: 300,  tf_mm: 21.5, tw_mm: 12.0, r_mm: 27,
+    weight_kg_per_m: 134.0, area_cm2: 170.9,
+    Ix_cm4: 36660, Iy_cm4: 9690,  Wx_cm3: 2156,  Wy_cm3: 646,   ix_cm: 14.65,iy_cm: 7.53,
+  },
+  {
+    designation: 'HEB 360', profileType: 'HEB', standard: 'EN10365',
+    h_mm: 360,  b_mm: 300,  tf_mm: 22.5, tw_mm: 12.5, r_mm: 27,
+    weight_kg_per_m: 142.0, area_cm2: 180.6,
+    Ix_cm4: 43190, Iy_cm4: 10140, Wx_cm3: 2400,  Wy_cm3: 676,   ix_cm: 15.46,iy_cm: 7.49,
+  },
+  {
+    designation: 'HEB 400', profileType: 'HEB', standard: 'EN10365',
+    h_mm: 400,  b_mm: 300,  tf_mm: 24.0, tw_mm: 13.5, r_mm: 27,
+    weight_kg_per_m: 155.0, area_cm2: 197.8,
+    Ix_cm4: 57680, Iy_cm4: 10820, Wx_cm3: 2884,  Wy_cm3: 721,   ix_cm: 17.08,iy_cm: 7.40,
+  },
+  {
+    designation: 'HEB 450', profileType: 'HEB', standard: 'EN10365',
+    h_mm: 450,  b_mm: 300,  tf_mm: 26.0, tw_mm: 14.0, r_mm: 27,
+    weight_kg_per_m: 171.0, area_cm2: 218.0,
+    Ix_cm4: 79890, Iy_cm4: 11720, Wx_cm3: 3551,  Wy_cm3: 781,   ix_cm: 19.13,iy_cm: 7.33,
+  },
+  {
+    designation: 'HEB 500', profileType: 'HEB', standard: 'EN10365',
+    h_mm: 500,  b_mm: 300,  tf_mm: 28.0, tw_mm: 14.5, r_mm: 27,
+    weight_kg_per_m: 187.0, area_cm2: 238.6,
+    Ix_cm4: 107200,Iy_cm4: 12620, Wx_cm3: 4287,  Wy_cm3: 841,   ix_cm: 21.21,iy_cm: 7.27,
+  },
+  {
+    designation: 'HEB 550', profileType: 'HEB', standard: 'EN10365',
+    h_mm: 550,  b_mm: 300,  tf_mm: 29.0, tw_mm: 15.0, r_mm: 27,
+    weight_kg_per_m: 199.0, area_cm2: 254.1,
+    Ix_cm4: 136700,Iy_cm4: 13080, Wx_cm3: 4971,  Wy_cm3: 872,   ix_cm: 23.20,iy_cm: 7.17,
+  },
+  {
+    designation: 'HEB 600', profileType: 'HEB', standard: 'EN10365',
+    h_mm: 600,  b_mm: 300,  tf_mm: 30.0, tw_mm: 15.5, r_mm: 27,
+    weight_kg_per_m: 212.0, area_cm2: 270.0,
+    Ix_cm4: 171000,Iy_cm4: 13530, Wx_cm3: 5701,  Wy_cm3: 902,   ix_cm: 25.17,iy_cm: 7.08,
+  },
+  {
+    designation: 'HEB 650', profileType: 'HEB', standard: 'EN10365',
+    h_mm: 650,  b_mm: 300,  tf_mm: 31.0, tw_mm: 16.0, r_mm: 27,
+    weight_kg_per_m: 225.0, area_cm2: 286.3,
+    Ix_cm4: 210600,Iy_cm4: 13980, Wx_cm3: 6480,  Wy_cm3: 932,   ix_cm: 27.13,iy_cm: 6.99,
+  },
+  {
+    designation: 'HEB 700', profileType: 'HEB', standard: 'EN10365',
+    h_mm: 700,  b_mm: 300,  tf_mm: 32.0, tw_mm: 17.0, r_mm: 27,
+    weight_kg_per_m: 241.0, area_cm2: 306.4,
+    Ix_cm4: 256900,Iy_cm4: 14440, Wx_cm3: 7340,  Wy_cm3: 963,   ix_cm: 28.96,iy_cm: 6.87,
+  },
+  {
+    designation: 'HEB 800', profileType: 'HEB', standard: 'EN10365',
+    h_mm: 800,  b_mm: 300,  tf_mm: 33.0, tw_mm: 17.5, r_mm: 30,
+    weight_kg_per_m: 262.0, area_cm2: 334.2,
+    Ix_cm4: 359100,Iy_cm4: 14900, Wx_cm3: 8977,  Wy_cm3: 993,   ix_cm: 32.78,iy_cm: 6.68,
+  },
+  {
+    designation: 'HEB 900', profileType: 'HEB', standard: 'EN10365',
+    h_mm: 900,  b_mm: 300,  tf_mm: 35.0, tw_mm: 18.5, r_mm: 30,
+    weight_kg_per_m: 291.0, area_cm2: 371.3,
+    Ix_cm4: 494100,Iy_cm4: 15820, Wx_cm3: 10980, Wy_cm3: 1053,  ix_cm: 36.48,iy_cm: 6.53,
+  },
+  {
+    designation: 'HEB 1000', profileType: 'HEB', standard: 'EN10365',
+    h_mm: 1000, b_mm: 300,  tf_mm: 36.0, tw_mm: 19.0, r_mm: 30,
+    weight_kg_per_m: 314.0, area_cm2: 400.0,
+    Ix_cm4: 644700,Iy_cm4: 16270, Wx_cm3: 12890, Wy_cm3: 1085,  ix_cm: 40.17,iy_cm: 6.38,
+  },
+];
+
+// ── IPE Sections (EN 10365) ──────────────────────────────────────────────
+export const IPE_SECTIONS: SectionProps[] = [
+  {
+    designation: 'IPE 80', profileType: 'IPE', standard: 'EN10365',
+    h_mm: 80,   b_mm: 46,   tf_mm: 5.2,  tw_mm: 3.8,  r_mm: 5,
+    weight_kg_per_m: 6.0,   area_cm2: 7.64,
+    Ix_cm4: 80.1,  Iy_cm4: 8.49,  Wx_cm3: 20.0,  Wy_cm3: 3.69,  ix_cm: 3.24, iy_cm: 1.05,
+  },
+  {
+    designation: 'IPE 100', profileType: 'IPE', standard: 'EN10365',
+    h_mm: 100,  b_mm: 55,   tf_mm: 5.7,  tw_mm: 4.1,  r_mm: 7,
+    weight_kg_per_m: 8.1,   area_cm2: 10.3,
+    Ix_cm4: 171,   Iy_cm4: 15.9,  Wx_cm3: 34.2,  Wy_cm3: 5.79,  ix_cm: 4.07, iy_cm: 1.24,
+  },
+  {
+    designation: 'IPE 120', profileType: 'IPE', standard: 'EN10365',
+    h_mm: 120,  b_mm: 64,   tf_mm: 6.3,  tw_mm: 4.4,  r_mm: 7,
+    weight_kg_per_m: 10.4,  area_cm2: 13.2,
+    Ix_cm4: 318,   Iy_cm4: 27.7,  Wx_cm3: 53.0,  Wy_cm3: 8.65,  ix_cm: 4.90, iy_cm: 1.45,
+  },
+  {
+    designation: 'IPE 140', profileType: 'IPE', standard: 'EN10365',
+    h_mm: 140,  b_mm: 73,   tf_mm: 6.9,  tw_mm: 4.7,  r_mm: 7,
+    weight_kg_per_m: 12.9,  area_cm2: 16.4,
+    Ix_cm4: 541,   Iy_cm4: 44.9,  Wx_cm3: 77.3,  Wy_cm3: 12.3,  ix_cm: 5.74, iy_cm: 1.65,
+  },
+  {
+    designation: 'IPE 160', profileType: 'IPE', standard: 'EN10365',
+    h_mm: 160,  b_mm: 82,   tf_mm: 7.4,  tw_mm: 5.0,  r_mm: 9,
+    weight_kg_per_m: 15.8,  area_cm2: 20.1,
+    Ix_cm4: 869,   Iy_cm4: 68.3,  Wx_cm3: 109,   Wy_cm3: 16.7,  ix_cm: 6.58, iy_cm: 1.84,
+  },
+  {
+    designation: 'IPE 180', profileType: 'IPE', standard: 'EN10365',
+    h_mm: 180,  b_mm: 91,   tf_mm: 8.0,  tw_mm: 5.3,  r_mm: 9,
+    weight_kg_per_m: 18.8,  area_cm2: 23.9,
+    Ix_cm4: 1317,  Iy_cm4: 101,   Wx_cm3: 146,   Wy_cm3: 22.2,  ix_cm: 7.42, iy_cm: 2.05,
+  },
+  {
+    designation: 'IPE 200', profileType: 'IPE', standard: 'EN10365',
+    h_mm: 200,  b_mm: 100,  tf_mm: 8.5,  tw_mm: 5.6,  r_mm: 12,
+    weight_kg_per_m: 22.4,  area_cm2: 28.5,
+    Ix_cm4: 1943,  Iy_cm4: 142,   Wx_cm3: 194,   Wy_cm3: 28.5,  ix_cm: 8.26, iy_cm: 2.24,
+  },
+  {
+    designation: 'IPE 220', profileType: 'IPE', standard: 'EN10365',
+    h_mm: 220,  b_mm: 110,  tf_mm: 9.2,  tw_mm: 5.9,  r_mm: 12,
+    weight_kg_per_m: 26.2,  area_cm2: 33.4,
+    Ix_cm4: 2772,  Iy_cm4: 205,   Wx_cm3: 252,   Wy_cm3: 37.3,  ix_cm: 9.11, iy_cm: 2.48,
+  },
+  {
+    designation: 'IPE 240', profileType: 'IPE', standard: 'EN10365',
+    h_mm: 240,  b_mm: 120,  tf_mm: 9.8,  tw_mm: 6.2,  r_mm: 15,
+    weight_kg_per_m: 30.7,  area_cm2: 39.1,
+    Ix_cm4: 3892,  Iy_cm4: 284,   Wx_cm3: 324,   Wy_cm3: 47.3,  ix_cm: 9.97, iy_cm: 2.69,
+  },
+  {
+    designation: 'IPE 270', profileType: 'IPE', standard: 'EN10365',
+    h_mm: 270,  b_mm: 135,  tf_mm: 10.2, tw_mm: 6.6,  r_mm: 15,
+    weight_kg_per_m: 36.1,  area_cm2: 45.9,
+    Ix_cm4: 5790,  Iy_cm4: 420,   Wx_cm3: 429,   Wy_cm3: 62.2,  ix_cm: 11.23,iy_cm: 3.02,
+  },
+  {
+    designation: 'IPE 300', profileType: 'IPE', standard: 'EN10365',
+    h_mm: 300,  b_mm: 150,  tf_mm: 10.7, tw_mm: 7.1,  r_mm: 15,
+    weight_kg_per_m: 42.2,  area_cm2: 53.8,
+    Ix_cm4: 8356,  Iy_cm4: 604,   Wx_cm3: 557,   Wy_cm3: 80.5,  ix_cm: 12.46,iy_cm: 3.35,
+  },
+  {
+    designation: 'IPE 330', profileType: 'IPE', standard: 'EN10365',
+    h_mm: 330,  b_mm: 160,  tf_mm: 11.5, tw_mm: 7.5,  r_mm: 18,
+    weight_kg_per_m: 49.1,  area_cm2: 62.6,
+    Ix_cm4: 11770, Iy_cm4: 788,   Wx_cm3: 713,   Wy_cm3: 98.5,  ix_cm: 13.71,iy_cm: 3.55,
+  },
+  {
+    designation: 'IPE 360', profileType: 'IPE', standard: 'EN10365',
+    h_mm: 360,  b_mm: 170,  tf_mm: 12.7, tw_mm: 8.0,  r_mm: 18,
+    weight_kg_per_m: 57.1,  area_cm2: 72.7,
+    Ix_cm4: 16270, Iy_cm4: 1043,  Wx_cm3: 904,   Wy_cm3: 123,   ix_cm: 14.95,iy_cm: 3.79,
+  },
+  {
+    designation: 'IPE 400', profileType: 'IPE', standard: 'EN10365',
+    h_mm: 400,  b_mm: 180,  tf_mm: 13.5, tw_mm: 8.6,  r_mm: 21,
+    weight_kg_per_m: 66.3,  area_cm2: 84.5,
+    Ix_cm4: 23130, Iy_cm4: 1318,  Wx_cm3: 1156,  Wy_cm3: 146,   ix_cm: 16.53,iy_cm: 3.95,
+  },
+  {
+    designation: 'IPE 450', profileType: 'IPE', standard: 'EN10365',
+    h_mm: 450,  b_mm: 190,  tf_mm: 14.6, tw_mm: 9.4,  r_mm: 21,
+    weight_kg_per_m: 77.6,  area_cm2: 98.8,
+    Ix_cm4: 33740, Iy_cm4: 1676,  Wx_cm3: 1500,  Wy_cm3: 176,   ix_cm: 18.48,iy_cm: 4.12,
+  },
+  {
+    designation: 'IPE 500', profileType: 'IPE', standard: 'EN10365',
+    h_mm: 500,  b_mm: 200,  tf_mm: 16.0, tw_mm: 10.2, r_mm: 21,
+    weight_kg_per_m: 90.7,  area_cm2: 115.5,
+    Ix_cm4: 48200, Iy_cm4: 2142,  Wx_cm3: 1928,  Wy_cm3: 214,   ix_cm: 20.43,iy_cm: 4.31,
+  },
+  {
+    designation: 'IPE 550', profileType: 'IPE', standard: 'EN10365',
+    h_mm: 550,  b_mm: 210,  tf_mm: 17.2, tw_mm: 11.1, r_mm: 24,
+    weight_kg_per_m: 106.0, area_cm2: 134.4,
+    Ix_cm4: 67120, Iy_cm4: 2668,  Wx_cm3: 2441,  Wy_cm3: 254,   ix_cm: 22.35,iy_cm: 4.45,
+  },
+  {
+    designation: 'IPE 600', profileType: 'IPE', standard: 'EN10365',
+    h_mm: 600,  b_mm: 220,  tf_mm: 19.0, tw_mm: 12.0, r_mm: 24,
+    weight_kg_per_m: 122.0, area_cm2: 156.0,
+    Ix_cm4: 92080, Iy_cm4: 3387,  Wx_cm3: 3069,  Wy_cm3: 308,   ix_cm: 24.30,iy_cm: 4.66,
+  },
+];
+
+// ── UPN Sections (EN 10365) ──────────────────────────────────────────────
+export const UPN_SECTIONS: SectionProps[] = [
+  {
+    designation: 'UPN 80', profileType: 'UPN', standard: 'EN10365',
+    h_mm: 80,   b_mm: 45,   tf_mm: 8.0,  tw_mm: 6.0,  r_mm: 8,
+    weight_kg_per_m: 8.64,  area_cm2: 11.0,
+    Ix_cm4: 106,   Iy_cm4: 19.4,  Wx_cm3: 26.5,  Wy_cm3: 6.36,  ix_cm: 3.10, iy_cm: 1.33,
+  },
+  {
+    designation: 'UPN 100', profileType: 'UPN', standard: 'EN10365',
+    h_mm: 100,  b_mm: 50,   tf_mm: 8.5,  tw_mm: 6.0,  r_mm: 8,
+    weight_kg_per_m: 10.6,  area_cm2: 13.5,
+    Ix_cm4: 206,   Iy_cm4: 29.3,  Wx_cm3: 41.2,  Wy_cm3: 8.49,  ix_cm: 3.91, iy_cm: 1.47,
+  },
+  {
+    designation: 'UPN 120', profileType: 'UPN', standard: 'EN10365',
+    h_mm: 120,  b_mm: 55,   tf_mm: 9.0,  tw_mm: 7.0,  r_mm: 9,
+    weight_kg_per_m: 13.4,  area_cm2: 17.0,
+    Ix_cm4: 364,   Iy_cm4: 43.2,  Wx_cm3: 60.7,  Wy_cm3: 11.1,  ix_cm: 4.63, iy_cm: 1.59,
+  },
+  {
+    designation: 'UPN 140', profileType: 'UPN', standard: 'EN10365',
+    h_mm: 140,  b_mm: 60,   tf_mm: 10.0, tw_mm: 7.0,  r_mm: 10,
+    weight_kg_per_m: 16.0,  area_cm2: 20.4,
+    Ix_cm4: 605,   Iy_cm4: 62.7,  Wx_cm3: 86.4,  Wy_cm3: 14.8,  ix_cm: 5.45, iy_cm: 1.75,
+  },
+  {
+    designation: 'UPN 160', profileType: 'UPN', standard: 'EN10365',
+    h_mm: 160,  b_mm: 65,   tf_mm: 10.5, tw_mm: 7.5,  r_mm: 10,
+    weight_kg_per_m: 18.8,  area_cm2: 24.0,
+    Ix_cm4: 925,   Iy_cm4: 85.3,  Wx_cm3: 116,   Wy_cm3: 18.3,  ix_cm: 6.21, iy_cm: 1.89,
+  },
+  {
+    designation: 'UPN 180', profileType: 'UPN', standard: 'EN10365',
+    h_mm: 180,  b_mm: 70,   tf_mm: 11.0, tw_mm: 8.0,  r_mm: 11,
+    weight_kg_per_m: 22.0,  area_cm2: 28.0,
+    Ix_cm4: 1350,  Iy_cm4: 114,   Wx_cm3: 150,   Wy_cm3: 22.4,  ix_cm: 6.95, iy_cm: 2.02,
+  },
+  {
+    designation: 'UPN 200', profileType: 'UPN', standard: 'EN10365',
+    h_mm: 200,  b_mm: 75,   tf_mm: 11.5, tw_mm: 8.5,  r_mm: 11,
+    weight_kg_per_m: 25.3,  area_cm2: 32.2,
+    Ix_cm4: 1910,  Iy_cm4: 148,   Wx_cm3: 191,   Wy_cm3: 27.0,  ix_cm: 7.70, iy_cm: 2.14,
+  },
+  {
+    designation: 'UPN 220', profileType: 'UPN', standard: 'EN10365',
+    h_mm: 220,  b_mm: 80,   tf_mm: 12.5, tw_mm: 9.0,  r_mm: 12,
+    weight_kg_per_m: 29.4,  area_cm2: 37.4,
+    Ix_cm4: 2690,  Iy_cm4: 197,   Wx_cm3: 245,   Wy_cm3: 33.6,  ix_cm: 8.48, iy_cm: 2.30,
+  },
+  {
+    designation: 'UPN 240', profileType: 'UPN', standard: 'EN10365',
+    h_mm: 240,  b_mm: 85,   tf_mm: 13.0, tw_mm: 9.5,  r_mm: 13,
+    weight_kg_per_m: 33.2,  area_cm2: 42.3,
+    Ix_cm4: 3600,  Iy_cm4: 248,   Wx_cm3: 300,   Wy_cm3: 39.6,  ix_cm: 9.22, iy_cm: 2.42,
+  },
+  {
+    designation: 'UPN 260', profileType: 'UPN', standard: 'EN10365',
+    h_mm: 260,  b_mm: 90,   tf_mm: 14.0, tw_mm: 10.0, r_mm: 13,
+    weight_kg_per_m: 37.9,  area_cm2: 48.3,
+    Ix_cm4: 4820,  Iy_cm4: 317,   Wx_cm3: 371,   Wy_cm3: 47.7,  ix_cm: 9.99, iy_cm: 2.56,
+  },
+  {
+    designation: 'UPN 280', profileType: 'UPN', standard: 'EN10365',
+    h_mm: 280,  b_mm: 95,   tf_mm: 15.0, tw_mm: 10.0, r_mm: 13,
+    weight_kg_per_m: 41.8,  area_cm2: 53.3,
+    Ix_cm4: 6280,  Iy_cm4: 399,   Wx_cm3: 448,   Wy_cm3: 57.2,  ix_cm: 10.86,iy_cm: 2.74,
+  },
+  {
+    designation: 'UPN 300', profileType: 'UPN', standard: 'EN10365',
+    h_mm: 300,  b_mm: 100,  tf_mm: 16.0, tw_mm: 10.0, r_mm: 14,
+    weight_kg_per_m: 46.2,  area_cm2: 58.8,
+    Ix_cm4: 8030,  Iy_cm4: 495,   Wx_cm3: 535,   Wy_cm3: 67.8,  ix_cm: 11.69,iy_cm: 2.90,
+  },
+  {
+    designation: 'UPN 320', profileType: 'UPN', standard: 'EN10365',
+    h_mm: 320,  b_mm: 100,  tf_mm: 17.5, tw_mm: 10.0, r_mm: 15,
+    weight_kg_per_m: 59.5,  area_cm2: 75.8,
+    Ix_cm4: 10870, Iy_cm4: 597,   Wx_cm3: 679,   Wy_cm3: 80.6,  ix_cm: 11.98,iy_cm: 2.81,
+  },
+  {
+    designation: 'UPN 350', profileType: 'UPN', standard: 'EN10365',
+    h_mm: 350,  b_mm: 100,  tf_mm: 16.0, tw_mm: 14.0, r_mm: 16,
+    weight_kg_per_m: 60.6,  area_cm2: 77.3,
+    Ix_cm4: 12840, Iy_cm4: 570,   Wx_cm3: 734,   Wy_cm3: 78.3,  ix_cm: 12.89,iy_cm: 2.72,
+  },
+  {
+    designation: 'UPN 380', profileType: 'UPN', standard: 'EN10365',
+    h_mm: 380,  b_mm: 102,  tf_mm: 16.0, tw_mm: 13.5, r_mm: 16,
+    weight_kg_per_m: 63.1,  area_cm2: 80.4,
+    Ix_cm4: 15760, Iy_cm4: 615,   Wx_cm3: 829,   Wy_cm3: 83.4,  ix_cm: 14.00,iy_cm: 2.77,
+  },
+  {
+    designation: 'UPN 400', profileType: 'UPN', standard: 'EN10365',
+    h_mm: 400,  b_mm: 110,  tf_mm: 18.0, tw_mm: 14.0, r_mm: 18,
+    weight_kg_per_m: 71.8,  area_cm2: 91.5,
+    Ix_cm4: 20350, Iy_cm4: 846,   Wx_cm3: 1017,  Wy_cm3: 102,   ix_cm: 14.92,iy_cm: 3.04,
+  },
+];
+
+// ── Equal Angle Sections (DIN 1028 / EN 10056) ───────────────────────────
+// For angles: h_mm = b_mm = leg length, tf_mm = tw_mm = leg thickness
+// Iy_cm4 = Iz (minor), ix_cm = iy_cm for equal legs (symmetry)
+export const ANGLE_EQUAL_SECTIONS: SectionProps[] = [
+  {
+    designation: 'L 40x40x4', profileType: 'EQUAL_ANGLE', standard: 'EN10056',
+    h_mm: 40,   b_mm: 40,   tf_mm: 4.0,  tw_mm: 4.0,  r_mm: 4,
+    weight_kg_per_m: 2.42,  area_cm2: 3.08,
+    Ix_cm4: 1.77,  Iy_cm4: 1.77,  Wx_cm3: 0.635, Wy_cm3: 0.635, ix_cm: 0.757,iy_cm: 0.757,
+  },
+  {
+    designation: 'L 50x50x5', profileType: 'EQUAL_ANGLE', standard: 'EN10056',
+    h_mm: 50,   b_mm: 50,   tf_mm: 5.0,  tw_mm: 5.0,  r_mm: 5,
+    weight_kg_per_m: 3.77,  area_cm2: 4.80,
+    Ix_cm4: 4.26,  Iy_cm4: 4.26,  Wx_cm3: 1.21,  Wy_cm3: 1.21,  ix_cm: 0.942,iy_cm: 0.942,
+  },
+  {
+    designation: 'L 60x60x6', profileType: 'EQUAL_ANGLE', standard: 'EN10056',
+    h_mm: 60,   b_mm: 60,   tf_mm: 6.0,  tw_mm: 6.0,  r_mm: 6,
+    weight_kg_per_m: 5.42,  area_cm2: 6.91,
+    Ix_cm4: 8.69,  Iy_cm4: 8.69,  Wx_cm3: 2.08,  Wy_cm3: 2.08,  ix_cm: 1.16, iy_cm: 1.16,
+  },
+  {
+    designation: 'L 70x70x7', profileType: 'EQUAL_ANGLE', standard: 'EN10056',
+    h_mm: 70,   b_mm: 70,   tf_mm: 7.0,  tw_mm: 7.0,  r_mm: 7,
+    weight_kg_per_m: 7.38,  area_cm2: 9.40,
+    Ix_cm4: 17.4,  Iy_cm4: 17.4,  Wx_cm3: 3.57,  Wy_cm3: 3.57,  ix_cm: 1.36, iy_cm: 1.36,
+  },
+  {
+    designation: 'L 80x80x8', profileType: 'EQUAL_ANGLE', standard: 'EN10056',
+    h_mm: 80,   b_mm: 80,   tf_mm: 8.0,  tw_mm: 8.0,  r_mm: 8,
+    weight_kg_per_m: 9.63,  area_cm2: 12.3,
+    Ix_cm4: 29.2,  Iy_cm4: 29.2,  Wx_cm3: 5.27,  Wy_cm3: 5.27,  ix_cm: 1.55, iy_cm: 1.55,
+  },
+  {
+    designation: 'L 90x90x9', profileType: 'EQUAL_ANGLE', standard: 'EN10056',
+    h_mm: 90,   b_mm: 90,   tf_mm: 9.0,  tw_mm: 9.0,  r_mm: 9,
+    weight_kg_per_m: 12.2,  area_cm2: 15.5,
+    Ix_cm4: 46.7,  Iy_cm4: 46.7,  Wx_cm3: 7.42,  Wy_cm3: 7.42,  ix_cm: 1.74, iy_cm: 1.74,
+  },
+  {
+    designation: 'L 100x100x10', profileType: 'EQUAL_ANGLE', standard: 'EN10056',
+    h_mm: 100,  b_mm: 100,  tf_mm: 10.0, tw_mm: 10.0, r_mm: 10,
+    weight_kg_per_m: 15.0,  area_cm2: 19.2,
+    Ix_cm4: 70.5,  Iy_cm4: 70.5,  Wx_cm3: 10.1,  Wy_cm3: 10.1,  ix_cm: 1.92, iy_cm: 1.92,
+  },
+  {
+    designation: 'L 120x120x12', profileType: 'EQUAL_ANGLE', standard: 'EN10056',
+    h_mm: 120,  b_mm: 120,  tf_mm: 12.0, tw_mm: 12.0, r_mm: 11,
+    weight_kg_per_m: 21.6,  area_cm2: 27.5,
+    Ix_cm4: 144,   Iy_cm4: 144,   Wx_cm3: 17.3,  Wy_cm3: 17.3,  ix_cm: 2.29, iy_cm: 2.29,
+  },
+  {
+    designation: 'L 150x150x15', profileType: 'EQUAL_ANGLE', standard: 'EN10056',
+    h_mm: 150,  b_mm: 150,  tf_mm: 15.0, tw_mm: 15.0, r_mm: 13,
+    weight_kg_per_m: 33.8,  area_cm2: 43.0,
+    Ix_cm4: 346,   Iy_cm4: 346,   Wx_cm3: 33.2,  Wy_cm3: 33.2,  ix_cm: 2.84, iy_cm: 2.84,
+  },
+  {
+    designation: 'L 200x200x20', profileType: 'EQUAL_ANGLE', standard: 'EN10056',
+    h_mm: 200,  b_mm: 200,  tf_mm: 20.0, tw_mm: 20.0, r_mm: 18,
+    weight_kg_per_m: 60.0,  area_cm2: 76.4,
+    Ix_cm4: 1094,  Iy_cm4: 1094,  Wx_cm3: 78.6,  Wy_cm3: 78.6,  ix_cm: 3.79, iy_cm: 3.79,
+  },
+];
+
+// ── All sections combined ─────────────────────────────────────────────────
+export const ALL_SECTIONS: SectionProps[] = [
+  ...HEA_SECTIONS,
+  ...HEB_SECTIONS,
+  ...IPE_SECTIONS,
+  ...UPN_SECTIONS,
+  ...ANGLE_EQUAL_SECTIONS,
+];
+
+/**
+ * Look up a section by profileType + designation.
+ * Returns undefined if not found.
+ *
+ * @example
+ *   lookupSection('HEA', 'HEA 200')  // returns HEA 200 props
+ *   lookupSection('IPE', 'IPE 300')  // returns IPE 300 props
+ */
+export function lookupSection(
+  profileType: string,
+  designation: string,
+): SectionProps | undefined {
+  const type = profileType.toUpperCase().trim();
+  const desig = designation.toUpperCase().trim();
+  return ALL_SECTIONS.find(
+    (s) =>
+      s.profileType.toUpperCase() === type &&
+      s.designation.toUpperCase() === desig,
+  );
+}

--- a/src/lib/material-master/unit-conversion.ts
+++ b/src/lib/material-master/unit-conversion.ts
@@ -1,0 +1,193 @@
+// ============================================================
+// Unit Conversion Engine — Material Master Enrichment
+// Pure math, no side effects, no DB access.
+// All inputs in mm unless noted. Density in kg/m³.
+// ============================================================
+
+// ── Density constants (kg/m³) ────────────────────────────────────────────
+export const DENSITY = {
+  CARBON_STEEL:     7850,
+  STAINLESS_STEEL:  7930,
+  ALUMINUM:         2700,
+  GALVANIZED_STEEL: 7870,
+  DEFAULT:          7850,
+} as const
+
+export type MaterialNature =
+  | keyof typeof DENSITY
+  | 'HARDWARE'
+  | 'WELDING_CONSUMABLE'
+  | 'CHEMICAL'
+  | 'PPE'
+  | 'GAS'
+  | 'ELECTRICAL'
+  | 'SERVICE'
+  | 'OTHER'
+  | 'UNKNOWN'
+
+// ── Sheet / Plate Conversions ────────────────────────────────────────────
+export interface SheetConversions {
+  /** kg per 1 m² of this sheet */
+  kg_per_m2: number
+  /** m² per metric ton */
+  m2_per_ton: number
+  /** kg for one standard unit (width × length) */
+  kg_per_sheet: number
+  /** how many sheets per ton */
+  sheets_per_ton: number
+  /** area of one sheet in m² */
+  unit_area_m2: number
+}
+
+/**
+ * Compute sheet conversions from physical dimensions.
+ *
+ * @param widthMm      - Sheet width in mm
+ * @param lengthMm     - Sheet length in mm
+ * @param thicknessMm  - Sheet thickness in mm
+ * @param densityKgM3  - Material density kg/m³ (default 7850 carbon steel)
+ *
+ * Formulas:
+ *   kg_per_m2    = density × (thickness / 1000)
+ *   unit_area_m2 = (width / 1000) × (length / 1000)
+ *   kg_per_sheet = unit_area_m2 × kg_per_m2
+ *   m2_per_ton   = 1000 / kg_per_m2
+ *   sheets_per_ton = 1000 / kg_per_sheet
+ */
+export function computeSheetConversions(
+  widthMm: number,
+  lengthMm: number,
+  thicknessMm: number,
+  densityKgM3: number = DENSITY.CARBON_STEEL,
+): SheetConversions {
+  const thicknessM = thicknessMm / 1000
+  const widthM     = widthMm / 1000
+  const lengthM    = lengthMm / 1000
+
+  const kg_per_m2    = thicknessM * densityKgM3
+  const unit_area_m2 = widthM * lengthM
+  const kg_per_sheet = unit_area_m2 * kg_per_m2
+  const m2_per_ton   = 1000 / kg_per_m2
+  const sheets_per_ton = 1000 / kg_per_sheet
+
+  return {
+    kg_per_m2:     round4(kg_per_m2),
+    m2_per_ton:    round4(m2_per_ton),
+    kg_per_sheet:  round4(kg_per_sheet),
+    sheets_per_ton: round4(sheets_per_ton),
+    unit_area_m2:  round6(unit_area_m2),
+  }
+}
+
+// ── Profile / Bar Conversions ────────────────────────────────────────────
+export interface ProfileConversions {
+  /** kg per linear meter */
+  kg_per_lm: number
+  /** linear meters per metric ton */
+  lm_per_ton: number
+  /** kg for one standard bar length */
+  kg_per_bar: number
+  /** how many bars per ton */
+  bars_per_ton: number
+}
+
+/**
+ * Compute profile conversions from section weight and bar length.
+ *
+ * @param kgPerLm     - Weight per linear meter (G_kg_per_m from section library)
+ * @param barLengthM  - Standard bar/beam length in meters (6 or 12)
+ */
+export function computeProfileConversions(
+  kgPerLm: number,
+  barLengthM: number,
+): ProfileConversions {
+  const kg_per_bar  = kgPerLm * barLengthM
+  const lm_per_ton  = 1000 / kgPerLm
+  const bars_per_ton = 1000 / kg_per_bar
+
+  return {
+    kg_per_lm:   round4(kgPerLm),
+    lm_per_ton:  round4(lm_per_ton),
+    kg_per_bar:  round4(kg_per_bar),
+    bars_per_ton: round4(bars_per_ton),
+  }
+}
+
+/**
+ * Compute kg/m for solid bars (no section library needed).
+ * Cross-section area × density.
+ *
+ * @param shape    - 'FLAT' | 'ROUND' | 'SQUARE'
+ * @param dim1Mm   - Width for FLAT, diameter for ROUND, side for SQUARE (mm)
+ * @param dim2Mm   - Thickness for FLAT (mm) — ignored for ROUND/SQUARE
+ * @param densityKgM3 - Material density kg/m³
+ */
+export function computeBarKgPerLm(
+  shape: 'FLAT' | 'ROUND' | 'SQUARE',
+  dim1Mm: number,
+  dim2Mm: number,
+  densityKgM3: number = DENSITY.CARBON_STEEL,
+): number {
+  let areaM2: number
+  if (shape === 'FLAT') {
+    areaM2 = (dim1Mm / 1000) * (dim2Mm / 1000)
+  } else if (shape === 'ROUND') {
+    areaM2 = Math.PI / 4 * Math.pow(dim1Mm / 1000, 2)
+  } else {
+    // SQUARE
+    areaM2 = Math.pow(dim1Mm / 1000, 2)
+  }
+  return round4(areaM2 * densityKgM3)
+}
+
+// ── Combined type for stored conversions JSON ────────────────────────────
+export interface UnitConversions {
+  sheet?: SheetConversions
+  profile?: ProfileConversions
+}
+
+/**
+ * Reverse lookup: given a quantity in one unit, convert to all others.
+ * Used in production disbursement UI and the /convert API endpoint.
+ *
+ * @param qty         - Input quantity
+ * @param fromUnit    - Input unit
+ * @param conversions - Pre-computed conversion rates (from unit_conversions_json)
+ */
+export function convertDisbursementUnits(
+  qty: number,
+  fromUnit: 'KG' | 'TON' | 'M2' | 'LM' | 'PC',
+  conversions: UnitConversions,
+): Record<string, number | null> {
+  const c = conversions
+
+  // First normalize to KG
+  let kg: number | null = null
+  if (fromUnit === 'KG')  kg = qty
+  if (fromUnit === 'TON') kg = qty * 1000
+  if (fromUnit === 'M2'  && c.sheet)   kg = qty * c.sheet.kg_per_m2
+  if (fromUnit === 'LM'  && c.profile) kg = qty * c.profile.kg_per_lm
+  if (fromUnit === 'PC'  && c.sheet)   kg = qty * c.sheet.kg_per_sheet
+  if (fromUnit === 'PC'  && c.profile) kg = qty * c.profile.kg_per_bar
+
+  if (kg === null) return { KG: null, TON: null, M2: null, LM: null }
+
+  return {
+    KG:  round4(kg),
+    TON: round6(kg / 1000),
+    M2:  c.sheet   ? round4(kg / c.sheet.kg_per_m2)   : null,
+    LM:  c.profile ? round4(kg / c.profile.kg_per_lm) : null,
+  }
+}
+
+// ── Internal helpers ─────────────────────────────────────────────────────
+
+/** Round to 4 decimal places */
+function round4(value: number): number {
+  return Math.round(value * 10_000) / 10_000
+}
+
+/** Round to 6 decimal places (for area_m2 values) */
+function round6(value: number): number {
+  return Math.round(value * 1_000_000) / 1_000_000
+}

--- a/src/lib/material-master/web-enrichment.ts
+++ b/src/lib/material-master/web-enrichment.ts
@@ -1,0 +1,89 @@
+import { GoogleGenerativeAI } from '@google/generative-ai'
+import { logger } from '@/lib/logger'
+
+const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY || '')
+
+export interface EnrichmentResult {
+  dolibarr_id: number
+  image_url: string | null
+  tds_url: string | null
+  technical_attrs_json: object | null
+  manufacturer: string | null
+}
+
+export async function enrichConsumable(
+  dolibarr_id: number,
+  ref: string,
+  label: string,
+  aws_class: string | null,
+  material_category: string
+): Promise<EnrichmentResult> {
+  const empty: EnrichmentResult = {
+    dolibarr_id, image_url: null, tds_url: null,
+    technical_attrs_json: null, manufacturer: null
+  }
+
+  if (!process.env.GEMINI_API_KEY) {
+    logger.info({ dolibarr_id }, 'GEMINI_API_KEY not set — skipping web enrichment')
+    return empty
+  }
+
+  const searchTerm = aws_class
+    ? `${aws_class} welding electrode technical datasheet specifications`
+    : `${label} technical datasheet specifications`
+
+  const prompt = `Search for product information about: "${label}" (ref: ${ref})
+${aws_class ? `AWS Classification: ${aws_class}` : ''}
+Category: ${material_category}
+
+Find:
+1. A direct URL to the product image (from manufacturer or distributor site)
+2. A direct URL to the technical data sheet (TDS) PDF
+3. Key technical attributes: tensile strength, yield strength, elongation, current type, diameter, applicable standards
+
+Return ONLY valid JSON (no markdown, no explanation):
+{
+  "image_url": "https://... or null",
+  "tds_url": "https://... or null",
+  "technical_attrs": {
+    "tensile_strength_mpa": null,
+    "yield_strength_mpa": null,
+    "elongation_pct": null,
+    "current_type": null,
+    "standards": null,
+    "notes": null
+  },
+  "manufacturer": "name or null"
+}`
+
+  try {
+    const model = genAI.getGenerativeModel({
+      model: 'gemini-2.0-flash',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      tools: [{ googleSearch: {} } as any],
+    })
+
+    const result = await model.generateContent([
+      { text: `Search the web for: ${searchTerm}\n\n${prompt}` }
+    ])
+
+    const text = result.response.text()
+    const clean = text.replace(/```json|```/g, '').trim()
+
+    // Extract JSON from response
+    const jsonMatch = clean.match(/\{[\s\S]*\}/)
+    if (!jsonMatch) return empty
+
+    const parsed = JSON.parse(jsonMatch[0])
+    return {
+      dolibarr_id,
+      image_url: parsed.image_url ?? null,
+      tds_url: parsed.tds_url ?? null,
+      technical_attrs_json: parsed.technical_attrs ?? null,
+      manufacturer: parsed.manufacturer ?? null,
+    }
+  } catch (err) {
+    logger.error({ err, dolibarr_id, ref }, 'Web enrichment failed — returning empty result')
+    return empty
+  }
+}

--- a/src/lib/navigation-permissions.ts
+++ b/src/lib/navigation-permissions.ts
@@ -320,6 +320,7 @@ export const NAVIGATION_PERMISSIONS: NavigationPermissionMap = {
   '/inv/returns': ['inv.view', 'inv.request', 'inv.approve', 'inv.issue', 'inv.adjust', 'inv.admin'],
   '/inv/returns/new': ['inv.request'],
   '/inv/ledger': ['inv.view', 'inv.request', 'inv.approve', 'inv.issue', 'inv.adjust', 'inv.admin'],
+  '/inv/material-master': ['inv.view', 'inv.admin'],
   '/inv/settings': ['inv.view', 'inv.request', 'inv.approve', 'inv.issue', 'inv.adjust', 'inv.admin'],
 };
 


### PR DESCRIPTION
Adds a complete product classification and enrichment pipeline for ~5,000 Dolibarr products:

## Schema (v36_1)
- 40+ new columns on dolibarr_products: classification, section properties,
  fastener, welding, unit conversions, web enrichment, review metadata
- 5 indexes for fast filtering by item_class, category, profile_type, etc.
- Fully idempotent migration using ADD COLUMN IF NOT EXISTS

## Steel Section Library (static embedded data)
- HEA (24 sizes), HEB (24 sizes), IPE (18 sizes), UPN (16 sizes),
  Equal Angle L (10 sizes) — all EN 10365
- lookupSection() for fast profile property lookup

## Unit Conversion Engine
- computeSheetConversions(): kg/m², m²/ton, sheets/ton for any plate
- computeProfileConversions(): kg/m, lm/ton, bars/ton for any profile
- computeBarKgPerLm(): solid bar weight from cross-section geometry
- convertDisbursementUnits(): reverse lookup (KG↔TON↔M2↔LM↔PC)

## Classification Pipeline (3 passes)
1. Rule engine: 10 regex patterns → instant classification with physics math
   - SHE{W}x{L}x{T}: sheets/plates with stored kg/m² + unit_area
   - HEA/HEB/IPE/UPN {N}-{L}-{GRADE}: profiles with section library lookup
   - HHB/HHN: bolts and nuts with fastener metadata
   - WE{AWS}-E-{MAT}{DIA}: welding electrodes (SMAW/FCAW/SAW)
   - HX-D-{TYPE}: PPE and accessories
2. AI batch classifier: Claude claude-sonnet-4-6, 80 products/call
3. Web enrichment: Google Gemini 2.0 Flash with grounding for TDS + images

## Sync Guard
- Added ENRICHMENT GUARD comment block to sync-service.ts ensuring
  resync never overwrites classification/enrichment columns

## API Routes
- POST /api/admin/material-master/classify — trigger rule/ai/enrichment/all passes
- PATCH /api/admin/material-master/review/[dolibarrId] — manual review + approve
- GET /api/dolibarr/products/convert — unit conversion (qty + unit → all units)
- Updated /api/dolibarr/products — enrichment query params + enrichment sub-object

## Material Master UI (/inv/material-master)
- Hero with admin action buttons (Run Rule Engine / Run AI / Enrich Consumables)
- KPI strip: Total | Classified | Needs Review | Avg Confidence
- Filter bar: search (debounced 300ms), item class, category, profile type,
  review toggle, enriched-only toggle
- Product table: 9 columns with context-aware dim display and conversion preview
- Detail side panel (Sheet): 6 tabs — Overview, Dimensions, Section Props,
  Converter Widget, TDS & Media, Review Form
- Unit Converter Widget: client-side math from stored conversions JSON
- Review queue: approve + save form for low-confidence items
- Emil design principles: scale(0.97) active states, 250ms ease-out transitions,
  colored confidence dots, category badges, monospace refs

## Navigation
- Added 'Material Master' to Inventory sidebar (newSince: 2026-05-25)
- Added /inv/material-master to navigation-permissions (inv.view + inv.admin)
- Added GEMINI_API_KEY + XAI_API_KEY to env.ts and .env.example

Verification:
- SHE1000X2000X0.28 → kg_per_m2=2.198, m2_per_ton=454.96, sheets_per_ton=227.48 ✓
- HEA200-12-A36 → weight_kg_per_m=42.3, kg_per_bar=507.6, lm_per_ton=23.64 ✓
- HHB-BS-M12-40mm-G10.9 → CONSUMABLE, fastener_thread=M12, grade=10.9 ✓
- WE6013-E-MS1.2FIR → aws_class=E6013, weld_process=SMAW, weld_diameter_mm=1.2 ✓
- HX-D-WG-PAK-Volta → CONSUMABLE, material_category=WELDING_PPE ✓
- TypeScript: zero errors in all new files ✓

https://claude.ai/code/session_01K9KNRSkijBtvCPkXZRnWfo