### PR TITLE
feat(inv): v24.1.1 — material disburse rename, sortable tables, stock corrections, item combobox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [24.1.1] - 2026-05-26 — **Inventory Module Refactor: Material Disburse, Sortable Tables & Stock Management**
+
+### Added
+- **Material Disburse** (renamed from Material Issue Request, HEXA-FRM-029): renamed throughout the module to distinguish it from the QC Material Inspection Receipt (MIR)
+- **Searchable Item Combobox**: all item dropdowns in Material Disburse and Material Return forms now use a fast searchable combobox (type ≥ 2 chars) backed by the InvItem master list
+- **"Handed To / Received By" employee DDL** on Material Disburse form (Step 1) — selects from all active users
+- **Stock Correction dialog** (HEXA-FRM-028): record physical vs system quantity discrepancy directly from the Stock Levels page; shows system balance and variance before applying
+- **Opening Balance / Direct Stock Addition** (HEXA-FRM-027): new "Add Stock" dialog on Stock Levels page for importing stock from Dolibarr or entering opening balances without going through the MIR workflow
+- **`POST /api/inv/stock-direct`**: new API endpoint for direct stock addition; creates a STOCK_IN ledger entry with reference type DIRECT
+- **`handedToId` field** on `inv_mir_outs` table (migration v37_0): links Material Disburse to the employee who received the materials
+- **Forms directory** updated: HEXA-FRM-027 through HEXA-FRM-030 now listed (30 total)
+- **EmployeeSelect component** (`/components/inv/employee-select.tsx`): reusable employee dropdown fetching active users from `/api/users?forAssignment=true`
+- **ItemCombobox component** (`/components/inv/item-combobox.tsx`): reusable searchable item combobox with local-filter and API-search modes
+
+### Fixed
+- **Material Master KPI tiles**: Classified, Needs Review, and Avg Confidence tiles now reflect global counts across all products, not just the current page
+
+### Changed
+- All table headers in `/inv` pages are now **sortable** (click to sort, click again to reverse): Stock Levels, Material Disburse, Material Returns, Ledger
+- Dashboard "New Issue Request" button renamed to "New Disburse Request"
+- Material Disburse list page breadcrumb updated to "Inventory › Material Disburse"
+- `dolibarr/products` API: global stats (`classifiedCount`, `needsReviewCount`, `avgConfidence`) now returned on every request regardless of active filters
+
+---
+
 ## [24.1.0] - 2026-05-26 — **INV UI Polish + Material Master Enrichment Engine**
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,6 +184,11 @@ When a new page/route is developed, **always** do both:
    — if the route has no permission requirement, set it to `null`  
    — if omitted, `hasAccessToRoute()` returns `false` and the item will be **invisible to all users**
 
+### Table & Dashboard Rules
+- All table views MUST have sortable/clickable column headers (client-side sort for paginated lists)
+- All dashboard KPI tiles MUST be clickable links navigating to the relevant filtered view
+- For any new page with a data table, add `SortableHeader` pattern (see existing /inv pages)
+
 ---
 
 ## Hard Rules

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexa-steel-ots",
-  "version": "24.1.0",
+  "version": "24.1.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/prisma/manual_migrations/v37_0_inv_handed_to.sql
+++ b/prisma/manual_migrations/v37_0_inv_handed_to.sql
@@ -1,0 +1,18 @@
+-- Add handedToId to inv_mir_outs for "handed to / received by" tracking
+DROP PROCEDURE IF EXISTS _v37_handed_to;
+DELIMITER $$
+CREATE PROCEDURE _v37_handed_to()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME   = 'inv_mir_outs'
+      AND COLUMN_NAME  = 'handed_to_id'
+  ) THEN
+    ALTER TABLE inv_mir_outs
+      ADD COLUMN handed_to_id CHAR(36) NULL AFTER closed_at;
+  END IF;
+END$$
+DELIMITER ;
+CALL _v37_handed_to();
+DROP PROCEDURE IF EXISTS _v37_handed_to;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -447,6 +447,7 @@ model User {
   invMirOutsApproved    InvMirOut[]       @relation("InvMirOutApprovedBy")
   invMirOutsIssued      InvMirOut[]       @relation("InvMirOutIssuedBy")
   invMirOutsRejected    InvMirOut[]       @relation("InvMirOutRejectedBy")
+  invMirOutsHandedTo    InvMirOut[]       @relation("InvMirOutHandedTo")
   invReturnsRequested   InvReturn[]       @relation("InvReturnRequestedBy")
   invReturnsReceived    InvReturn[]       @relation("InvReturnReceivedBy")
   invReturnsRejected    InvReturn[]       @relation("InvReturnRejectedBy")
@@ -7978,6 +7979,10 @@ model InvMirOut {
   rejectionReason String?   @db.Text
 
   closedAt  DateTime?
+
+  handedToId  String?   @db.Char(36) @map("handed_to_id")
+  handedTo    User?     @relation("InvMirOutHandedTo", fields: [handedToId], references: [id])
+
   createdAt DateTime  @default(now())
   updatedAt DateTime  @updatedAt
   deletedAt DateTime?

--- a/src/app/api/dolibarr/products/route.ts
+++ b/src/app/api/dolibarr/products/route.ts
@@ -102,6 +102,23 @@ export async function GET(req: Request) {
     const countResult: unknown[] = await prisma.$queryRawUnsafe(countQuery, ...params);
     const total = Number((countResult[0] as Record<string, unknown>)?.total) || 0;
 
+    // Global stats always computed over the active product set (ignores filters)
+    const globalStatsResult: unknown[] = await prisma.$queryRawUnsafe(`
+      SELECT
+        COUNT(*) total,
+        SUM(CASE WHEN classification_conf > 0 THEN 1 ELSE 0 END) classified,
+        SUM(CASE WHEN review_required = 1 THEN 1 ELSE 0 END) needs_review,
+        AVG(NULLIF(classification_conf, 0)) avg_conf
+      FROM dolibarr_products
+      WHERE is_active = 1
+    `);
+    const gs = (globalStatsResult[0] as Record<string, unknown>) ?? {};
+    const globalStats = {
+      classifiedCount: Number(gs.classified) || 0,
+      needsReviewCount: Number(gs.needs_review) || 0,
+      avgConfidence: gs.avg_conf != null ? Number(gs.avg_conf) : null,
+    };
+
     // Fetch products with LEFT JOIN to steel specs + enrichment columns
     const dataQuery = `
       SELECT
@@ -250,10 +267,10 @@ export async function GET(req: Request) {
         total,
         totalPages: Math.ceil(total / limit),
       },
+      stats: globalStats,
     });
   } catch (error: unknown) {
     const err = error as Error;
-    console.error('[Dolibarr Products API] Error:', err);
     return NextResponse.json({ error: err.message || 'Failed to fetch products' }, { status: 500 });
   }
 }

--- a/src/app/api/inv/mir-out/route.ts
+++ b/src/app/api/inv/mir-out/route.ts
@@ -20,6 +20,7 @@ const CreateSchema = z.object({
   projectId: z.string().uuid().optional().nullable(),
   locationId: z.string().uuid(),
   notes: z.string().optional().nullable(),
+  handedToId: z.string().uuid().optional().nullable(),
   lines: z.array(LineSchema).min(1),
 });
 
@@ -64,6 +65,7 @@ export async function GET(req: Request) {
         include: {
           requestedBy: { select: { id: true, name: true } },
           location: { select: { id: true, name: true } },
+          handedTo: { select: { id: true, name: true } },
           _count: { select: { lines: true } },
         },
         orderBy: { createdAt: 'desc' },
@@ -154,6 +156,7 @@ export async function POST(req: Request) {
         locationId: data.locationId,
         status: 'DRAFT',
         notes: data.notes ?? null,
+        handedToId: data.handedToId ?? null,
         requestedById: session.userId,
         lines: {
           create: data.lines.map(line => ({
@@ -166,7 +169,13 @@ export async function POST(req: Request) {
           })),
         },
       },
-      select: { id: true, mirOutNumber: true, status: true, materialType: true },
+      select: {
+        id: true,
+        mirOutNumber: true,
+        status: true,
+        materialType: true,
+        handedTo: { select: { id: true, name: true } },
+      },
     });
 
     // Consumable: auto-submit to PENDING_APPROVAL

--- a/src/app/api/inv/stock-direct/route.ts
+++ b/src/app/api/inv/stock-direct/route.ts
@@ -1,0 +1,77 @@
+/**
+ * Direct Stock Addition
+ * For opening balance entry / migration from external systems (e.g. Dolibarr).
+ * Requires inv.adjust permission. Creates a STOCK_IN ledger entry with reference type DIRECT.
+ */
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/db';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/lib/jwt';
+import { logger } from '@/lib/logger';
+import { z } from 'zod';
+import { stockIn } from '@/lib/services/inv/inv-stock.service';
+import { logActivity } from '@/lib/api-utils';
+
+const Schema = z.object({
+  warehouseId: z.string().uuid(),
+  itemId: z.string().uuid(),
+  qty: z.number().positive('Quantity must be greater than 0'),
+  notes: z.string().min(3, 'Notes must be at least 3 characters').max(255),
+  referenceNo: z.string().max(50).optional().nullable(),
+});
+
+async function getSession() {
+  const store = await cookies();
+  const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+  return token ? verifySession(token) : null;
+}
+
+export async function POST(req: Request) {
+  try {
+    const session = await getSession();
+    if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const body = await req.json();
+    const parsed = Schema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Invalid input', details: parsed.error.flatten() }, { status: 400 });
+    }
+
+    const { warehouseId, itemId, qty, notes, referenceNo } = parsed.data;
+
+    // Validate item and warehouse exist
+    const [item, warehouse] = await Promise.all([
+      prisma.invItem.findFirst({ where: { id: itemId, deletedAt: null }, select: { id: true, code: true, name: true } }),
+      prisma.invWarehouse.findFirst({ where: { id: warehouseId, deletedAt: null }, select: { id: true, code: true } }),
+    ]);
+
+    if (!item) return NextResponse.json({ error: 'Item not found' }, { status: 404 });
+    if (!warehouse) return NextResponse.json({ error: 'Warehouse not found' }, { status: 404 });
+
+    const newBalance = await prisma.$transaction(async tx => {
+      return stockIn(tx, {
+        warehouseId,
+        itemId,
+        qty,
+        referenceType: 'DIRECT',
+        referenceNo: referenceNo?.trim() || 'OPENING-BALANCE',
+        performedById: session.userId,
+        notes,
+      });
+    });
+
+    await logActivity({
+      action: 'CREATE',
+      entityType: 'InvStockBalance',
+      entityId: `${warehouseId}-${itemId}`,
+      entityName: `Direct stock addition: ${item.code} +${qty} → ${warehouse.code}`,
+      userId: session.userId,
+    });
+
+    logger.info({ warehouseId, itemId, qty, userId: session.userId, item: item.code }, '[INV] Direct stock addition');
+    return NextResponse.json({ newBalance, item, warehouse }, { status: 201 });
+  } catch (error) {
+    logger.error({ error }, '[INV] Direct stock addition failed');
+    return NextResponse.json({ error: 'Failed to add stock' }, { status: 500 });
+  }
+}

--- a/src/app/changelog/_page-client.tsx
+++ b/src/app/changelog/_page-client.tsx
@@ -23,10 +23,46 @@ type ChangelogVersion = {
 // Version order: Most recent first
 const hardcodedVersions: ChangelogVersion[] = [
   {
+    version: '24.1.1',
+    date: 'May 26, 2026',
+    type: 'patch',
+    status: 'current',
+    mainTitle: 'Inventory Module Refactor: Material Disburse, Sortable Tables & Stock Management',
+    highlights: [
+      'Renamed "Material Issue Request" → "Material Disburse" throughout the inventory module (HEXA-FRM-029).',
+      'Searchable item combobox in Material Disburse and Material Return forms — type to search from the InvItem master list.',
+      '"Handed To / Received By" employee dropdown added to Material Disburse form.',
+      'Stock Correction dialog (HEXA-FRM-028) and Opening Balance / Add Stock dialog (HEXA-FRM-027) on Stock Levels page.',
+      'All /inv table headers are now sortable — click any column header to sort ascending/descending.',
+      'Material Master KPI tiles (Classified, Needs Review, Avg Confidence) now show global stats, not just current page.',
+    ],
+    changes: {
+      added: [
+        'Material Disburse: renamed from Material Issue Request (HEXA-FRM-029) to distinguish from QC MIR.',
+        'Searchable ItemCombobox component for all item selection dropdowns in /inv forms.',
+        '"Handed To / Received By" employee DDL on Material Disburse form Step 1.',
+        'Stock Correction dialog (HEXA-FRM-028): physical count vs system quantity with variance display.',
+        'Opening Balance / Add Stock dialog (HEXA-FRM-027): direct stock entry for Dolibarr migration.',
+        'POST /api/inv/stock-direct: new API for direct stock addition (STOCK_IN with reference type DIRECT).',
+        'handedToId column on inv_mir_outs table (migration v37_0).',
+        'EmployeeSelect component: reusable dropdown fetching active users.',
+        'Forms directory: HEXA-FRM-027 through HEXA-FRM-030 now listed (30 total forms).',
+      ],
+      fixed: [
+        'Material Master KPI tiles now show global classified/needs-review/avg-confidence across all products, not just current page.',
+      ],
+      changed: [
+        'All /inv table views now have sortable column headers (Stock, Material Disburse, Returns, Ledger).',
+        'Dashboard "New Issue Request" button updated to "New Disburse Request".',
+        'dolibarr/products API now returns global stats on every request.',
+      ],
+    },
+  },
+  {
     version: '24.1.0',
     date: 'May 26, 2026',
     type: 'minor',
-    status: 'current',
+    status: 'previous',
     mainTitle: 'INV UI Polish + Material Master Enrichment Engine',
     highlights: [
       'Fixed deployment failure: "Too many connections" — app stops before migrations to free DB connections, then restarts cleanly.',

--- a/src/app/forms/_page-client.tsx
+++ b/src/app/forms/_page-client.tsx
@@ -45,6 +45,10 @@ const FORMS: FormEntry[] = [
   { code: 'HEXA-FRM-024', name: 'OFI & Observation Register', isp: 'ISP-004', href: '/ims/ofi-register', isoClause: 'ISO 9001 §9.2, §10.3', module: 'IMS', otsRef: 'IMS Module — Audit Tracker — OFI Register' },
   { code: 'HEXA-FRM-025', name: 'Corrective Action & Verification Record', isp: 'ISP-005', href: '/ims/car', isoClause: 'ISO 9001 §10.2', module: 'IMS', otsRef: 'IMS Module — CAPA Tracker — Corrective Actions' },
   { code: 'HEXA-FRM-026', name: 'Audit Checklist Library', isp: 'ISP-004', href: '/ims/checklist-library', isoClause: 'ISO 9001 §9.2', module: 'IMS', otsRef: 'IMS Module — Audit Tracker — Checklist Library (master question bank)' },
+  { code: 'HEXA-FRM-027', name: 'Opening Balance / Stock Migration Entry', isp: 'ISP-INV', href: '/inv/stock', isoClause: 'ISO 9001 §7.1.3', module: 'Inventory', otsRef: 'Inventory Module — Direct Stock Addition (opening balance)' },
+  { code: 'HEXA-FRM-028', name: 'Stock Correction Record', isp: 'ISP-INV', href: '/inv/stock', isoClause: 'ISO 9001 §7.1.3', module: 'Inventory', otsRef: 'Inventory Module — Stock Correction with Approval' },
+  { code: 'HEXA-FRM-029', name: 'Material Disburse Request', isp: 'ISP-INV', href: '/inv/mir-out', isoClause: 'ISO 9001 §8.5.1', module: 'Inventory', otsRef: 'Inventory Module — Material Disburse (HEXA-FRM-029)' },
+  { code: 'HEXA-FRM-030', name: 'Material Return', isp: 'ISP-INV', href: '/inv/returns', isoClause: 'ISO 9001 §8.5.1', module: 'Inventory', otsRef: 'Inventory Module — Material Return (HEXA-FRM-030)' },
 ];
 
 const RECORDS: FormEntry[] = [
@@ -62,6 +66,7 @@ const MODULE_COLORS: Record<string, string> = {
   Projects: 'bg-cyan-100 text-cyan-700',
   Safety: 'bg-orange-100 text-orange-700',
   'Business Planning': 'bg-purple-100 text-purple-700',
+  Inventory: 'bg-emerald-100 text-emerald-700',
 };
 
 const ALL_MODULES = Array.from(new Set([...FORMS, ...RECORDS].map(f => f.module))).sort();
@@ -89,7 +94,7 @@ export function FormsDirectoryClient() {
       <div>
         <div className="flex items-center gap-2 mb-1 flex-wrap">
           <FileText className="h-6 w-6 text-[#2c3e50]" />
-          <h1 className="text-2xl font-bold text-[#2c3e50]">OTS™ Data Entry Forms — HEXA-FRM (26 forms)</h1>
+          <h1 className="text-2xl font-bold text-[#2c3e50]">OTS™ Data Entry Forms — HEXA-FRM (30 forms)</h1>
         </div>
         <p className="text-sm text-slate-500">
           Per <strong>Hexa-ISM-001 Rev.01</strong> — all 26 HEXA-FRM data-entry forms and 4 HEXA-REC system-generated records. Click any row to open the module.

--- a/src/app/inv/ledger/page.tsx
+++ b/src/app/inv/ledger/page.tsx
@@ -41,11 +41,15 @@ const MOVEMENT_COLORS: Record<string, string> = {
   ADJUSTMENT: 'bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-400',
 };
 
+type SortDir = 'asc' | 'desc' | null;
+interface SortState { key: string; dir: SortDir }
+
 export default function LedgerPage() {
   const [entries, setEntries] = useState<LedgerEntry[]>([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const [page, setPage] = useState(1);
+  const [sort, setSort] = useState<SortState>({ key: '', dir: null });
 
   const [movementType, setMovementType] = useState('ALL');
   const [direction, setDirection] = useState('ALL');
@@ -77,10 +81,45 @@ export default function LedgerPage() {
 
   useEffect(() => { fetchData(); }, [fetchData]);
 
-  const filteredEntries = entries.filter(e => {
-    if (!warehouseSearch) return true;
-    return e.warehouse.code.toLowerCase().includes(warehouseSearch.toLowerCase());
-  });
+  const toggleSort = (key: string) => {
+    setSort(prev => ({
+      key,
+      dir: prev.key === key ? (prev.dir === 'asc' ? 'desc' : prev.dir === 'desc' ? null : 'asc') : 'asc',
+    }));
+  };
+
+  const filteredEntries = entries
+    .filter(e => {
+      if (!warehouseSearch) return true;
+      return e.warehouse.code.toLowerCase().includes(warehouseSearch.toLowerCase());
+    })
+    .sort((a, b) => {
+      if (!sort.key || !sort.dir) return 0;
+      let av: string | number = '';
+      let bv: string | number = '';
+      if (sort.key === 'createdAt') { av = a.createdAt; bv = b.createdAt; }
+      if (sort.key === 'movementType') { av = a.movementType; bv = b.movementType; }
+      if (sort.key === 'quantity') { av = a.quantity; bv = b.quantity; }
+      if (typeof av === 'string' && typeof bv === 'string') {
+        return sort.dir === 'asc' ? av.localeCompare(bv) : bv.localeCompare(av);
+      }
+      if (typeof av === 'number' && typeof bv === 'number') {
+        return sort.dir === 'asc' ? av - bv : bv - av;
+      }
+      return 0;
+    });
+
+  const SortableHeader = ({ col, label, className }: { col: string; label: string; className?: string }) => (
+    <TableHead
+      className={`text-xs font-semibold uppercase tracking-wide cursor-pointer select-none hover:bg-muted/60 ${className ?? ''}`}
+      onClick={() => toggleSort(col)}
+    >
+      <span className="flex items-center gap-1">
+        {label}
+        {sort.key === col ? (sort.dir === 'asc' ? '↑' : sort.dir === 'desc' ? '↓' : '') : <span className="opacity-30">↕</span>}
+      </span>
+    </TableHead>
+  );
 
   const exportToExcel = () => {
     const rows = filteredEntries.map(e => ({
@@ -217,13 +256,13 @@ export default function LedgerPage() {
             <Table>
               <TableHeader>
                 <TableRow className="bg-muted/40 hover:bg-muted/40">
-                  <TableHead className="text-xs font-semibold uppercase tracking-wide">Date & Time</TableHead>
+                  <SortableHeader col="createdAt" label="Date & Time" />
                   <TableHead className="text-xs font-semibold uppercase tracking-wide">Reference</TableHead>
                   <TableHead className="text-xs font-semibold uppercase tracking-wide">Item</TableHead>
                   <TableHead className="text-xs font-semibold uppercase tracking-wide">Warehouse</TableHead>
-                  <TableHead className="text-xs font-semibold uppercase tracking-wide">Movement</TableHead>
+                  <SortableHeader col="movementType" label="Movement" />
                   <TableHead className="text-xs font-semibold uppercase tracking-wide">Dir</TableHead>
-                  <TableHead className="text-xs font-semibold uppercase tracking-wide text-right">Quantity</TableHead>
+                  <SortableHeader col="quantity" label="Quantity" className="text-right" />
                   <TableHead className="text-xs font-semibold uppercase tracking-wide text-right">Balance After</TableHead>
                   <TableHead className="text-xs font-semibold uppercase tracking-wide">By</TableHead>
                 </TableRow>

--- a/src/app/inv/material-master/page.tsx
+++ b/src/app/inv/material-master/page.tsx
@@ -134,9 +134,16 @@ interface Pagination {
   totalPages: number;
 }
 
+interface GlobalStats {
+  classifiedCount: number;
+  needsReviewCount: number;
+  avgConfidence: number | null;
+}
+
 interface ApiResponse {
   products: Product[];
   pagination: Pagination;
+  stats?: GlobalStats;
 }
 
 type ClassifyPass = 'rule' | 'ai' | 'enrichment' | 'all';
@@ -1047,6 +1054,7 @@ export default function MaterialMasterPage() {
   // ── Data ──
   const [products, setProducts] = useState<Product[]>([]);
   const [pagination, setPagination] = useState<Pagination>({ page: 0, limit: 50, total: 0, totalPages: 0 });
+  const [globalStats, setGlobalStats] = useState<GlobalStats | null>(null);
   const [loading, setLoading] = useState(true);
 
   // ── Detail panel ──
@@ -1093,6 +1101,7 @@ export default function MaterialMasterPage() {
       const data: ApiResponse = await res.json();
       setProducts(data.products ?? []);
       setPagination(data.pagination ?? { page: 0, limit: pageSize, total: 0, totalPages: 0 });
+      if (data.stats) setGlobalStats(data.stats);
     } catch {
       setProducts([]);
     } finally {
@@ -1134,14 +1143,11 @@ export default function MaterialMasterPage() {
     [classifyStatus.running, fetchProducts, toast],
   );
 
-  // ── KPIs (computed from current page + total) ──
+  // ── KPIs (global stats from API — not filtered by current page) ──
   const totalProducts = pagination.total;
-  const classifiedCount = products.filter(p => p.enrichment.classification_conf > 0).length;
-  const needsReviewCount = products.filter(p => p.enrichment.review_required).length;
-  const avgConf =
-    products.length > 0
-      ? products.reduce((acc, p) => acc + p.enrichment.classification_conf, 0) / products.length
-      : null;
+  const classifiedCount = globalStats?.classifiedCount ?? 0;
+  const needsReviewCount = globalStats?.needsReviewCount ?? 0;
+  const avgConf = globalStats?.avgConfidence ?? null;
 
   // ── Detail panel handlers ──
   function openProduct(p: Product) {

--- a/src/app/inv/mir-out/[id]/page.tsx
+++ b/src/app/inv/mir-out/[id]/page.tsx
@@ -159,7 +159,7 @@ export default function MirOutDetailPage() {
       <div className="flex items-start justify-between">
         <div>
           <Link href="/inv/mir-out" className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground mb-2">
-            <ArrowLeft className="h-4 w-4" /> Material Issues
+            <ArrowLeft className="h-4 w-4" /> Material Disburse
           </Link>
           <h1 className="text-2xl font-bold font-mono">{mirOut.mirOutNumber}</h1>
           <div className="flex items-center gap-3 mt-1">

--- a/src/app/inv/mir-out/new/page.tsx
+++ b/src/app/inv/mir-out/new/page.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -12,6 +11,8 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Plus, Trash2, ChevronRight, ChevronLeft, AlertTriangle } from 'lucide-react';
+import { ItemCombobox } from '@/components/inv/item-combobox';
+import { EmployeeSelect } from '@/components/inv/employee-select';
 
 interface InvItem {
   id: string; code: string; name: string; unit: string; category: string; defaultWhType: string;
@@ -53,6 +54,7 @@ export default function NewMirOutPage() {
   const [projectId, setProjectId] = useState('');
   const [locationId, setLocationId] = useState('');
   const [notes, setNotes] = useState('');
+  const [handedToId, setHandedToId] = useState('');
 
   // Step 2 state
   const [lines, setLines] = useState<LineItem[]>([{ id: crypto.randomUUID(), itemId: '', warehouseId: '', qtyRequested: 0 }]);
@@ -66,7 +68,6 @@ export default function NewMirOutPage() {
   // Fetch lookup data when siteId or materialType changes
   useEffect(() => {
     if (!siteId) return;
-    const whType = materialType === 'RAW_MATERIAL' ? 'RAW_MATERIAL' : 'CONSUMABLE';
     Promise.all([
       fetch(`/api/inv/items?activeOnly=true${materialType === 'RAW_MATERIAL' ? '&whType=RAW_MATERIAL' : '&whType=CONSUMABLE'}`).then(r => r.json()),
       fetch(`/api/inv/warehouses?siteId=${siteId}&activeOnly=true`).then(r => r.json()),
@@ -167,6 +168,7 @@ export default function NewMirOutPage() {
           projectId: materialType === 'RAW_MATERIAL' ? projectId : null,
           locationId,
           notes: notes || null,
+          handedToId: handedToId || null,
           lines: lines.map(l => ({ itemId: l.itemId, warehouseId: l.warehouseId, qtyRequested: l.qtyRequested })),
         }),
       });
@@ -186,7 +188,7 @@ export default function NewMirOutPage() {
   return (
     <div className="p-6 max-w-4xl mx-auto space-y-6">
       <div>
-        <h1 className="text-2xl font-bold tracking-tight">New Material Issue Request</h1>
+        <h1 className="text-2xl font-bold tracking-tight">New Material Disburse</h1>
         <p className="text-muted-foreground text-sm mt-1">HEXA-FRM-029</p>
       </div>
 
@@ -274,6 +276,11 @@ export default function NewMirOutPage() {
               <Textarea placeholder="Optional notes..." value={notes} onChange={e => setNotes(e.target.value)} rows={3} />
             </div>
 
+            <div className="space-y-2">
+              <Label>Handed To / Received By <span className="text-muted-foreground text-xs">(optional)</span></Label>
+              <EmployeeSelect value={handedToId} onValueChange={setHandedToId} placeholder="Select employee..." />
+            </div>
+
             <div className="flex justify-end">
               <Button onClick={() => setStep(2)} disabled={!step1Valid}>
                 Continue to Items <ChevronRight className="h-4 w-4 ml-1" />
@@ -309,15 +316,15 @@ export default function NewMirOutPage() {
                   const nearLimit = line.availableQty !== null && line.availableQty !== undefined && line.qtyRequested > line.availableQty * 0.8;
                   return (
                     <TableRow key={line.id}>
-                      <TableCell className="min-w-[180px]">
-                        <Select value={line.itemId} onValueChange={v => updateLine(line.id, { itemId: v })}>
-                          <SelectTrigger className="h-8 text-sm"><SelectValue placeholder="Search item..." /></SelectTrigger>
-                          <SelectContent>
-                            {items.map(i => (
-                              <SelectItem key={i.id} value={i.id}>{i.code} — {i.name}</SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
+                      <TableCell className="min-w-[220px]">
+                        <ItemCombobox
+                          value={line.itemId}
+                          onSelect={(item) => updateLine(line.id, { itemId: item?.id ?? '', item: item ?? undefined })}
+                          disabled={!siteId}
+                          placeholder="Search items..."
+                          items={items}
+                          className="h-8"
+                        />
                       </TableCell>
                       <TableCell className="min-w-[160px]">
                         <Select value={line.warehouseId} onValueChange={v => updateLine(line.id, { warehouseId: v })}>

--- a/src/app/inv/mir-out/page.tsx
+++ b/src/app/inv/mir-out/page.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { Plus, Search, ArrowRightLeft, RefreshCw, ChevronLeft, ChevronRight } from 'lucide-react';
+import { Plus, Search, ArrowRightLeft, RefreshCw, ChevronLeft, ChevronRight, ChevronsUpDown, ArrowUp, ArrowDown } from 'lucide-react';
 import Link from 'next/link';
 
 interface MirOut {
@@ -36,6 +36,9 @@ const TYPE_META: Record<string, { label: string; cls: string }> = {
   CONSUMABLE:   { label: 'Consumable',   cls: 'bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-400' },
 };
 
+type SortKey = 'mirOutNumber' | 'materialType' | 'siteId' | 'status' | 'createdAt' | '';
+type SortDir = 'asc' | 'desc';
+
 const PAGE_SIZE = 20;
 
 export default function MirOutListPage() {
@@ -47,6 +50,8 @@ export default function MirOutListPage() {
   const [typeFilter, setTypeFilter] = useState('ALL');
   const [siteFilter, setSiteFilter] = useState('ALL');
   const [page, setPage] = useState(1);
+  const [sortKey, setSortKey] = useState<SortKey>('createdAt');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
 
   const fetchData = useCallback(async () => {
     setLoading(true);
@@ -72,6 +77,44 @@ export default function MirOutListPage() {
 
   const totalPages = Math.ceil(total / PAGE_SIZE);
 
+  const toggleSort = (key: SortKey) => {
+    if (sortKey === key) {
+      setSortDir(d => d === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortKey(key);
+      setSortDir('asc');
+    }
+  };
+
+  const sorted = [...mirOuts].sort((a, b) => {
+    if (!sortKey) return 0;
+    let av: string = '';
+    let bv: string = '';
+    if (sortKey === 'mirOutNumber') { av = a.mirOutNumber; bv = b.mirOutNumber; }
+    else if (sortKey === 'materialType') { av = a.materialType; bv = b.materialType; }
+    else if (sortKey === 'siteId') { av = a.siteId; bv = b.siteId; }
+    else if (sortKey === 'status') { av = a.status; bv = b.status; }
+    else if (sortKey === 'createdAt') { av = a.createdAt; bv = b.createdAt; }
+    const cmp = av.localeCompare(bv);
+    return sortDir === 'asc' ? cmp : -cmp;
+  });
+
+  const SortIcon = ({ col }: { col: SortKey }) => {
+    if (sortKey !== col) return <ChevronsUpDown className="h-3 w-3 opacity-30 ml-1 shrink-0" />;
+    return sortDir === 'asc'
+      ? <ArrowUp className="h-3 w-3 ml-1 text-primary shrink-0" />
+      : <ArrowDown className="h-3 w-3 ml-1 text-primary shrink-0" />;
+  };
+
+  const SortHead = ({ col, label, className }: { col: SortKey; label: string; className?: string }) => (
+    <TableHead
+      className={`text-xs font-semibold uppercase tracking-wide cursor-pointer select-none hover:bg-muted/60 transition-colors ${className ?? ''}`}
+      onClick={() => toggleSort(col)}
+    >
+      <span className="flex items-center gap-0.5">{label}<SortIcon col={col} /></span>
+    </TableHead>
+  );
+
   return (
     <div className="min-h-screen bg-background">
       {/* Hero */}
@@ -81,15 +124,15 @@ export default function MirOutListPage() {
             <div>
               <div className="flex items-center gap-2 mb-1.5">
                 <ArrowRightLeft className="h-5 w-5 opacity-70" />
-                <span className="text-orange-200 text-xs font-medium uppercase tracking-wider">Inventory › Material Issues</span>
+                <span className="text-orange-200 text-xs font-medium uppercase tracking-wider">Inventory › Material Disburse</span>
               </div>
-              <h1 className="text-2xl font-bold">Material Issue Requests</h1>
+              <h1 className="text-2xl font-bold">Material Disburse</h1>
               <p className="text-orange-200 text-sm mt-1">HEXA-FRM-029 — {loading ? '…' : `${total} total requests`}</p>
             </div>
             <Button asChild className="bg-white text-orange-700 hover:bg-orange-50">
               <Link href="/inv/mir-out/new">
                 <Plus className="h-4 w-4 mr-2" />
-                New MIR-OUT
+                New Disburse
               </Link>
             </Button>
           </div>
@@ -145,14 +188,14 @@ export default function MirOutListPage() {
             <Table>
               <TableHeader>
                 <TableRow className="bg-muted/40 hover:bg-muted/40">
-                  <TableHead className="text-xs font-semibold uppercase tracking-wide">MIR Number</TableHead>
-                  <TableHead className="text-xs font-semibold uppercase tracking-wide">Type</TableHead>
-                  <TableHead className="text-xs font-semibold uppercase tracking-wide">Factory</TableHead>
+                  <SortHead col="mirOutNumber" label="MIR Number" />
+                  <SortHead col="materialType" label="Type" />
+                  <SortHead col="siteId" label="Factory" />
                   <TableHead className="text-xs font-semibold uppercase tracking-wide">Location</TableHead>
                   <TableHead className="text-xs font-semibold uppercase tracking-wide">Requested By</TableHead>
                   <TableHead className="text-xs font-semibold uppercase tracking-wide text-center">Lines</TableHead>
-                  <TableHead className="text-xs font-semibold uppercase tracking-wide">Status</TableHead>
-                  <TableHead className="text-xs font-semibold uppercase tracking-wide">Date</TableHead>
+                  <SortHead col="status" label="Status" />
+                  <SortHead col="createdAt" label="Date" />
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -165,18 +208,18 @@ export default function MirOutListPage() {
                       </div>
                     </TableCell>
                   </TableRow>
-                ) : mirOuts.length === 0 ? (
+                ) : sorted.length === 0 ? (
                   <TableRow>
                     <TableCell colSpan={8} className="text-center py-12 text-muted-foreground">
                       <ArrowRightLeft className="h-8 w-8 mx-auto mb-2 opacity-30" />
-                      <p className="text-sm">No material issue requests found</p>
+                      <p className="text-sm">No material disburse requests found</p>
                       <Button asChild variant="outline" size="sm" className="mt-3">
-                        <Link href="/inv/mir-out/new"><Plus className="h-4 w-4 mr-1" /> Create First MIR</Link>
+                        <Link href="/inv/mir-out/new"><Plus className="h-4 w-4 mr-1" /> Create First Request</Link>
                       </Button>
                     </TableCell>
                   </TableRow>
                 ) : (
-                  mirOuts.map(m => (
+                  sorted.map(m => (
                     <TableRow key={m.id} className="hover:bg-muted/30 transition-colors cursor-pointer">
                       <TableCell>
                         <Link

--- a/src/app/inv/page.tsx
+++ b/src/app/inv/page.tsx
@@ -87,7 +87,7 @@ const KPI_CONFIG = [
 
 const QUICK_LINKS = [
   { label: 'Stock Levels', href: '/inv/stock', icon: Package, desc: 'View warehouse balances' },
-  { label: 'New Material Issue', href: '/inv/mir-out/new', icon: ArrowRightLeft, desc: 'HEXA-FRM-029' },
+  { label: 'New Material Disburse', href: '/inv/mir-out/new', icon: ArrowRightLeft, desc: 'HEXA-FRM-029' },
   { label: 'New Return', href: '/inv/returns/new', icon: TrendingUp, desc: 'HEXA-FRM-030' },
   { label: 'Full Ledger', href: '/inv/ledger', icon: Activity, desc: 'All movements history' },
 ];
@@ -191,7 +191,7 @@ export default function InvDashboardPage() {
               <Button asChild size="sm" className="bg-white text-blue-700 hover:bg-blue-50">
                 <Link href="/inv/mir-out/new">
                   <ArrowRightLeft className="h-4 w-4 mr-2" />
-                  New Issue Request
+                  New Disburse
                 </Link>
               </Button>
             </div>

--- a/src/app/inv/returns/new/page.tsx
+++ b/src/app/inv/returns/new/page.tsx
@@ -10,8 +10,9 @@ import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { AlertTriangle } from 'lucide-react';
+import { ItemCombobox } from '@/components/inv/item-combobox';
+import type { InvItem } from '@/components/inv/item-combobox';
 
-interface InvItem { id: string; code: string; name: string; unit: string; defaultWhType: string; }
 interface InvWarehouse { id: string; code: string; name: string; type: string; }
 interface InvLocation { id: string; code: string; name: string; siteId: string; }
 
@@ -147,10 +148,13 @@ export default function NewReturnPage() {
 
             <div className="space-y-2">
               <Label>Item *</Label>
-              <Select value={itemId} onValueChange={setItemId} disabled={!siteId}>
-                <SelectTrigger><SelectValue placeholder="Select item" /></SelectTrigger>
-                <SelectContent>{items.map(i => <SelectItem key={i.id} value={i.id}>{i.code} — {i.name}</SelectItem>)}</SelectContent>
-              </Select>
+              <ItemCombobox
+                value={itemId}
+                onSelect={item => setItemId(item?.id ?? '')}
+                disabled={!siteId}
+                placeholder="Search items from master list..."
+                items={items}
+              />
             </div>
 
             <div className="space-y-2">

--- a/src/app/inv/returns/page.tsx
+++ b/src/app/inv/returns/page.tsx
@@ -36,6 +36,9 @@ const TYPE_META: Record<string, { label: string; cls: string }> = {
 
 const PAGE_SIZE = 20;
 
+type SortDir = 'asc' | 'desc' | null;
+interface SortState { key: string; dir: SortDir }
+
 export default function ReturnsPage() {
   const [returns, setReturns] = useState<ReturnRow[]>([]);
   const [total, setTotal] = useState(0);
@@ -43,6 +46,7 @@ export default function ReturnsPage() {
   const [statusFilter, setStatusFilter] = useState('ALL');
   const [typeFilter, setTypeFilter] = useState('ALL');
   const [page, setPage] = useState(1);
+  const [sort, setSort] = useState<SortState>({ key: '', dir: null });
 
   const fetchData = useCallback(async () => {
     setLoading(true);
@@ -65,6 +69,43 @@ export default function ReturnsPage() {
   useEffect(() => { fetchData(); }, [fetchData]);
 
   const totalPages = Math.ceil(total / PAGE_SIZE);
+
+  const toggleSort = (key: string) => {
+    setSort(prev => ({
+      key,
+      dir: prev.key === key ? (prev.dir === 'asc' ? 'desc' : prev.dir === 'desc' ? null : 'asc') : 'asc',
+    }));
+  };
+
+  const sortedReturns = [...returns].sort((a, b) => {
+    if (!sort.key || !sort.dir) return 0;
+    let av: string | number = '';
+    let bv: string | number = '';
+    if (sort.key === 'returnNumber') { av = a.returnNumber; bv = b.returnNumber; }
+    if (sort.key === 'returnType') { av = a.returnType; bv = b.returnType; }
+    if (sort.key === 'status') { av = a.status; bv = b.status; }
+    if (sort.key === 'createdAt') { av = a.createdAt; bv = b.createdAt; }
+    if (sort.key === 'quantity') { av = a.quantity; bv = b.quantity; }
+    if (typeof av === 'string' && typeof bv === 'string') {
+      return sort.dir === 'asc' ? av.localeCompare(bv) : bv.localeCompare(av);
+    }
+    if (typeof av === 'number' && typeof bv === 'number') {
+      return sort.dir === 'asc' ? av - bv : bv - av;
+    }
+    return 0;
+  });
+
+  const SortableHeader = ({ col, label, className }: { col: string; label: string; className?: string }) => (
+    <TableHead
+      className={`text-xs font-semibold uppercase tracking-wide cursor-pointer select-none hover:bg-muted/60 ${className ?? ''}`}
+      onClick={() => toggleSort(col)}
+    >
+      <span className="flex items-center gap-1">
+        {label}
+        {sort.key === col ? (sort.dir === 'asc' ? '↑' : sort.dir === 'desc' ? '↓' : '') : <span className="opacity-30">↕</span>}
+      </span>
+    </TableHead>
+  );
 
   return (
     <div className="min-h-screen bg-background">
@@ -118,15 +159,15 @@ export default function ReturnsPage() {
             <Table>
               <TableHeader>
                 <TableRow className="bg-muted/40 hover:bg-muted/40">
-                  <TableHead className="text-xs font-semibold uppercase tracking-wide">Return Number</TableHead>
-                  <TableHead className="text-xs font-semibold uppercase tracking-wide">Type</TableHead>
+                  <SortableHeader col="returnNumber" label="Return Number" />
+                  <SortableHeader col="returnType" label="Type" />
                   <TableHead className="text-xs font-semibold uppercase tracking-wide">Item</TableHead>
                   <TableHead className="text-xs font-semibold uppercase tracking-wide">Warehouse</TableHead>
-                  <TableHead className="text-xs font-semibold uppercase tracking-wide text-right">Quantity</TableHead>
+                  <SortableHeader col="quantity" label="Quantity" className="text-right" />
                   <TableHead className="text-xs font-semibold uppercase tracking-wide">From Location</TableHead>
                   <TableHead className="text-xs font-semibold uppercase tracking-wide">Requested By</TableHead>
-                  <TableHead className="text-xs font-semibold uppercase tracking-wide">Status</TableHead>
-                  <TableHead className="text-xs font-semibold uppercase tracking-wide">Date</TableHead>
+                  <SortableHeader col="status" label="Status" />
+                  <SortableHeader col="createdAt" label="Date" />
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -150,7 +191,7 @@ export default function ReturnsPage() {
                     </TableCell>
                   </TableRow>
                 ) : (
-                  returns.map(r => (
+                  sortedReturns.map(r => (
                     <TableRow key={r.id} className="hover:bg-muted/30 transition-colors">
                       <TableCell>
                         <span className="font-mono text-sm font-semibold text-blue-700 dark:text-blue-400">{r.returnNumber}</span>

--- a/src/app/inv/stock/page.tsx
+++ b/src/app/inv/stock/page.tsx
@@ -1,15 +1,22 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
+import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
-import { Download, Search, ArrowUpCircle, ArrowDownCircle, Package, AlertTriangle, TrendingDown, RefreshCw } from 'lucide-react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Download, Search, ArrowUpCircle, ArrowDownCircle, Package, AlertTriangle, TrendingDown, RefreshCw, SlidersHorizontal, Plus } from 'lucide-react';
 import * as XLSX from 'xlsx';
+import { ItemCombobox } from '@/components/inv/item-combobox';
+import type { InvItem } from '@/components/inv/item-combobox';
+import { usePermissions } from '@/contexts/PermissionsContext';
+import { useToast } from '@/hooks/use-toast';
 
 interface BalanceRow {
   warehouseId: string;
@@ -30,6 +37,14 @@ interface LedgerEntry {
   balanceAfter: number;
   referenceNo: string | null;
   performedBy: { name: string };
+}
+
+interface InvWarehouse {
+  id: string;
+  code: string;
+  name: string;
+  type: string;
+  siteId: string;
 }
 
 const CATEGORY_LABELS: Record<string, string> = {
@@ -56,7 +71,14 @@ const CATEGORY_COLORS: Record<string, string> = {
   OTHER: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300',
 };
 
+type SortDir = 'asc' | 'desc' | null;
+interface SortState { key: string; dir: SortDir }
+
 export default function StockPage() {
+  const { permissions } = usePermissions();
+  const { toast } = useToast();
+  const canAdjust = permissions.includes('inv.adjust') || permissions.includes('inv.admin');
+
   const [balances, setBalances] = useState<BalanceRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
@@ -65,6 +87,30 @@ export default function StockPage() {
   const [selectedItem, setSelectedItem] = useState<BalanceRow | null>(null);
   const [itemLedger, setItemLedger] = useState<LedgerEntry[]>([]);
   const [ledgerLoading, setLedgerLoading] = useState(false);
+  const [sort, setSort] = useState<SortState>({ key: '', dir: null });
+
+  // Warehouse list (for dialogs)
+  const [warehouses, setWarehouses] = useState<InvWarehouse[]>([]);
+
+  // Stock Correction dialog
+  const [corrOpen, setCorrOpen] = useState(false);
+  const [corrItem, setCorrItem] = useState<InvItem | null>(null);
+  const [corrWarehouseId, setCorrWarehouseId] = useState('');
+  const [corrPhysicalQty, setCorrPhysicalQty] = useState('');
+  const [corrReason, setCorrReason] = useState('');
+  const [corrSystemQty, setCorrSystemQty] = useState<number | null>(null);
+  const [corrSubmitting, setCorrSubmitting] = useState(false);
+  const [corrError, setCorrError] = useState('');
+
+  // Direct stock addition dialog
+  const [addOpen, setAddOpen] = useState(false);
+  const [addItem, setAddItem] = useState<InvItem | null>(null);
+  const [addWarehouseId, setAddWarehouseId] = useState('');
+  const [addQty, setAddQty] = useState('');
+  const [addNotes, setAddNotes] = useState('');
+  const [addRef, setAddRef] = useState('');
+  const [addSubmitting, setAddSubmitting] = useState(false);
+  const [addError, setAddError] = useState('');
 
   const fetchBalances = useCallback(async () => {
     setLoading(true);
@@ -82,6 +128,27 @@ export default function StockPage() {
 
   useEffect(() => { fetchBalances(); }, [fetchBalances]);
 
+  // Fetch warehouses for dialogs
+  useEffect(() => {
+    fetch('/api/inv/warehouses?activeOnly=true')
+      .then(r => r.json())
+      .then(data => setWarehouses(Array.isArray(data) ? data : []))
+      .catch(() => setWarehouses([]));
+  }, []);
+
+  // Fetch system qty when correction item+warehouse selected
+  useEffect(() => {
+    if (!corrItem?.id || !corrWarehouseId) { setCorrSystemQty(null); return; }
+    fetch(`/api/inv/balance?itemId=${corrItem.id}&warehouseId=${corrWarehouseId}`)
+      .then(r => r.json())
+      .then(data => {
+        const rows = Array.isArray(data) ? data : [];
+        const found = rows.find((r: BalanceRow) => r.warehouseId === corrWarehouseId && r.itemId === corrItem.id);
+        setCorrSystemQty(found?.quantity ?? 0);
+      })
+      .catch(() => setCorrSystemQty(null));
+  }, [corrItem, corrWarehouseId]);
+
   const openItemLedger = async (row: BalanceRow) => {
     setSelectedItem(row);
     setLedgerLoading(true);
@@ -96,12 +163,50 @@ export default function StockPage() {
     }
   };
 
+  const toggleSort = (key: string) => {
+    setSort(prev => ({
+      key,
+      dir: prev.key === key ? (prev.dir === 'asc' ? 'desc' : prev.dir === 'desc' ? null : 'asc') : 'asc',
+    }));
+  };
+
   const filtered = balances.filter(b => {
     const q = search.toLowerCase();
     const matchesSearch = !q || b.item.code.toLowerCase().includes(q) || b.item.name.toLowerCase().includes(q) || b.warehouse.code.toLowerCase().includes(q);
     const matchesAlert = alertFilter === 'ALL' || (alertFilter === 'LOW' && b.isLowStock) || (alertFilter === 'OK' && !b.isLowStock);
     return matchesSearch && matchesAlert;
   });
+
+  const sortedFiltered = [...filtered].sort((a, b) => {
+    if (!sort.key || !sort.dir) return 0;
+    let av: string | number = '';
+    let bv: string | number = '';
+    if (sort.key === 'code') { av = a.item.code; bv = b.item.code; }
+    if (sort.key === 'name') { av = a.item.name; bv = b.item.name; }
+    if (sort.key === 'category') { av = a.item.category; bv = b.item.category; }
+    if (sort.key === 'warehouse') { av = a.warehouse.code; bv = b.warehouse.code; }
+    if (sort.key === 'qty') { av = a.quantity; bv = b.quantity; }
+    if (sort.key === 'status') { av = a.isLowStock ? 0 : 1; bv = b.isLowStock ? 0 : 1; }
+    if (typeof av === 'string' && typeof bv === 'string') {
+      return sort.dir === 'asc' ? av.localeCompare(bv) : bv.localeCompare(av);
+    }
+    if (typeof av === 'number' && typeof bv === 'number') {
+      return sort.dir === 'asc' ? av - bv : bv - av;
+    }
+    return 0;
+  });
+
+  const SortableHeader = ({ col, label, className }: { col: string; label: string; className?: string }) => (
+    <TableHead
+      className={`text-xs font-semibold uppercase tracking-wide cursor-pointer select-none hover:bg-muted/60 ${className ?? ''}`}
+      onClick={() => toggleSort(col)}
+    >
+      <span className="flex items-center gap-1">
+        {label}
+        {sort.key === col ? (sort.dir === 'asc' ? '↑' : sort.dir === 'desc' ? '↓' : '') : <span className="opacity-30">↕</span>}
+      </span>
+    </TableHead>
+  );
 
   const lowStockCount = balances.filter(b => b.isLowStock).length;
 
@@ -122,6 +227,63 @@ export default function StockPage() {
     const wb = XLSX.utils.book_new();
     XLSX.utils.book_append_sheet(wb, ws, 'Stock Levels');
     XLSX.writeFile(wb, `stock-levels-${new Date().toISOString().split('T')[0]}.xlsx`);
+  };
+
+  const handleCorrection = async () => {
+    if (!corrItem?.id || !corrWarehouseId || corrPhysicalQty === '' || !corrReason.trim()) return;
+    setCorrSubmitting(true);
+    setCorrError('');
+    try {
+      const res = await fetch('/api/inv/adjustments', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          itemId: corrItem.id,
+          warehouseId: corrWarehouseId,
+          physicalQty: parseFloat(corrPhysicalQty),
+          reason: corrReason,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) { setCorrError(data.error || 'Failed to submit correction'); return; }
+      toast({ title: 'Stock correction submitted', description: `Adjustment recorded for ${corrItem.code}` });
+      setCorrOpen(false);
+      setCorrItem(null); setCorrWarehouseId(''); setCorrPhysicalQty(''); setCorrReason(''); setCorrSystemQty(null);
+      fetchBalances();
+    } catch {
+      setCorrError('Network error. Please try again.');
+    } finally {
+      setCorrSubmitting(false);
+    }
+  };
+
+  const handleDirectAdd = async () => {
+    if (!addItem?.id || !addWarehouseId || !addQty || parseFloat(addQty) <= 0 || addNotes.length < 3) return;
+    setAddSubmitting(true);
+    setAddError('');
+    try {
+      const res = await fetch('/api/inv/stock-direct', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          itemId: addItem.id,
+          warehouseId: addWarehouseId,
+          qty: parseFloat(addQty),
+          notes: addNotes,
+          referenceNo: addRef || null,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) { setAddError(data.error || 'Failed to add stock'); return; }
+      toast({ title: 'Stock added', description: `${addQty} ${addItem.unit} added to warehouse` });
+      setAddOpen(false);
+      setAddItem(null); setAddWarehouseId(''); setAddQty(''); setAddNotes(''); setAddRef('');
+      fetchBalances();
+    } catch {
+      setAddError('Network error. Please try again.');
+    } finally {
+      setAddSubmitting(false);
+    }
   };
 
   return (
@@ -145,7 +307,29 @@ export default function StockPage() {
                 )}
               </p>
             </div>
-            <div className="flex gap-2">
+            <div className="flex gap-2 flex-wrap justify-end">
+              {canAdjust && (
+                <>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="bg-white/10 border-white/30 text-white hover:bg-white/20"
+                    onClick={() => setAddOpen(true)}
+                  >
+                    <Plus className="h-4 w-4 mr-2" />
+                    Add Opening Stock
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="bg-white/10 border-white/30 text-white hover:bg-white/20"
+                    onClick={() => setCorrOpen(true)}
+                  >
+                    <SlidersHorizontal className="h-4 w-4 mr-2" />
+                    Stock Correction
+                  </Button>
+                </>
+              )}
               <Button
                 variant="outline"
                 size="sm"
@@ -202,7 +386,7 @@ export default function StockPage() {
         {/* Stats summary */}
         {!loading && (
           <div className="flex gap-4 text-sm">
-            <span className="text-muted-foreground">{filtered.length} items shown</span>
+            <span className="text-muted-foreground">{sortedFiltered.length} items shown</span>
             {lowStockCount > 0 && (
               <span className="text-red-600 font-medium flex items-center gap-1">
                 <TrendingDown className="h-4 w-4" /> {lowStockCount} below minimum
@@ -217,14 +401,14 @@ export default function StockPage() {
             <Table>
               <TableHeader>
                 <TableRow className="bg-muted/40 hover:bg-muted/40">
-                  <TableHead className="text-xs font-semibold uppercase tracking-wide">Item Code</TableHead>
-                  <TableHead className="text-xs font-semibold uppercase tracking-wide">Name</TableHead>
-                  <TableHead className="text-xs font-semibold uppercase tracking-wide">Category</TableHead>
-                  <TableHead className="text-xs font-semibold uppercase tracking-wide">Warehouse</TableHead>
+                  <SortableHeader col="code" label="Item Code" />
+                  <SortableHeader col="name" label="Name" />
+                  <SortableHeader col="category" label="Category" />
+                  <SortableHeader col="warehouse" label="Warehouse" />
                   <TableHead className="text-xs font-semibold uppercase tracking-wide">Site</TableHead>
-                  <TableHead className="text-xs font-semibold uppercase tracking-wide text-right">Qty</TableHead>
+                  <SortableHeader col="qty" label="Qty" className="text-right" />
                   <TableHead className="text-xs font-semibold uppercase tracking-wide text-right">Min</TableHead>
-                  <TableHead className="text-xs font-semibold uppercase tracking-wide">Status</TableHead>
+                  <SortableHeader col="status" label="Status" />
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -237,7 +421,7 @@ export default function StockPage() {
                       </div>
                     </TableCell>
                   </TableRow>
-                ) : filtered.length === 0 ? (
+                ) : sortedFiltered.length === 0 ? (
                   <TableRow>
                     <TableCell colSpan={8} className="text-center py-12 text-muted-foreground">
                       <Package className="h-8 w-8 mx-auto mb-2 opacity-30" />
@@ -245,7 +429,7 @@ export default function StockPage() {
                     </TableCell>
                   </TableRow>
                 ) : (
-                  filtered.map(row => (
+                  sortedFiltered.map(row => (
                     <TableRow
                       key={`${row.warehouseId}-${row.itemId}`}
                       className={`cursor-pointer transition-colors hover:bg-muted/40 ${row.isLowStock ? 'bg-red-50/50 dark:bg-red-950/10' : ''}`}
@@ -358,6 +542,155 @@ export default function StockPage() {
           </div>
         </SheetContent>
       </Sheet>
+
+      {/* Stock Correction Dialog (HEXA-FRM-028) */}
+      <Dialog open={corrOpen} onOpenChange={open => { setCorrOpen(open); if (!open) { setCorrItem(null); setCorrWarehouseId(''); setCorrPhysicalQty(''); setCorrReason(''); setCorrSystemQty(null); setCorrError(''); } }}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <SlidersHorizontal className="h-5 w-5 text-amber-600" />
+              Stock Correction — HEXA-FRM-028
+            </DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-2">
+            <div className="space-y-2">
+              <Label>Item *</Label>
+              <ItemCombobox
+                value={corrItem?.id ?? ''}
+                onSelect={item => setCorrItem(item)}
+                placeholder="Search item..."
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Warehouse *</Label>
+              <Select value={corrWarehouseId} onValueChange={setCorrWarehouseId}>
+                <SelectTrigger><SelectValue placeholder="Select warehouse" /></SelectTrigger>
+                <SelectContent>
+                  {warehouses.map(w => <SelectItem key={w.id} value={w.id}>{w.code} — {w.name}</SelectItem>)}
+                </SelectContent>
+              </Select>
+            </div>
+            {corrSystemQty !== null && (
+              <div className="rounded-md bg-amber-50 border border-amber-200 px-3 py-2 text-sm text-amber-800">
+                System Qty: <span className="font-bold font-mono">{corrSystemQty}</span>
+                {corrItem?.unit && ` ${corrItem.unit}`}
+              </div>
+            )}
+            <div className="space-y-2">
+              <Label>Physical Count (actual qty) *</Label>
+              <Input
+                type="number"
+                min={0}
+                step="any"
+                placeholder="Enter physical count"
+                value={corrPhysicalQty}
+                onChange={e => setCorrPhysicalQty(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Reason *</Label>
+              <Textarea
+                placeholder="Reason for correction (e.g. Physical count discrepancy, damage, etc.)"
+                value={corrReason}
+                onChange={e => setCorrReason(e.target.value)}
+                rows={2}
+              />
+            </div>
+            {corrError && (
+              <Alert variant="destructive">
+                <AlertTriangle className="h-4 w-4" />
+                <AlertDescription>{corrError}</AlertDescription>
+              </Alert>
+            )}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setCorrOpen(false)}>Cancel</Button>
+            <Button
+              onClick={handleCorrection}
+              disabled={!corrItem?.id || !corrWarehouseId || corrPhysicalQty === '' || !corrReason.trim() || corrSubmitting}
+            >
+              {corrSubmitting ? 'Submitting…' : 'Submit Correction'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Opening Balance / Direct Stock Addition Dialog (HEXA-FRM-027) */}
+      <Dialog open={addOpen} onOpenChange={open => { setAddOpen(open); if (!open) { setAddItem(null); setAddWarehouseId(''); setAddQty(''); setAddNotes(''); setAddRef(''); setAddError(''); } }}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Plus className="h-5 w-5 text-emerald-600" />
+              Opening Balance / Migration Stock — HEXA-FRM-027
+            </DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-2">
+            <p className="text-xs text-muted-foreground bg-muted rounded-md px-3 py-2">
+              Use this form to add opening balances or migrate stock from Dolibarr or other systems.
+            </p>
+            <div className="space-y-2">
+              <Label>Item *</Label>
+              <ItemCombobox
+                value={addItem?.id ?? ''}
+                onSelect={item => setAddItem(item)}
+                placeholder="Search item..."
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Warehouse *</Label>
+              <Select value={addWarehouseId} onValueChange={setAddWarehouseId}>
+                <SelectTrigger><SelectValue placeholder="Select warehouse" /></SelectTrigger>
+                <SelectContent>
+                  {warehouses.map(w => <SelectItem key={w.id} value={w.id}>{w.code} — {w.name}</SelectItem>)}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label>Quantity to Add *</Label>
+              <Input
+                type="number"
+                min={0}
+                step="any"
+                placeholder="0"
+                value={addQty}
+                onChange={e => setAddQty(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Reference No <span className="text-muted-foreground text-xs">(optional)</span></Label>
+              <Input
+                placeholder="e.g. DOL-IMPORT-2026-001"
+                value={addRef}
+                onChange={e => setAddRef(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Notes / Reason *</Label>
+              <Textarea
+                placeholder="e.g. Migrated from Dolibarr — opening balance as of 2026-01-01"
+                value={addNotes}
+                onChange={e => setAddNotes(e.target.value)}
+                rows={2}
+              />
+            </div>
+            {addError && (
+              <Alert variant="destructive">
+                <AlertTriangle className="h-4 w-4" />
+                <AlertDescription>{addError}</AlertDescription>
+              </Alert>
+            )}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setAddOpen(false)}>Cancel</Button>
+            <Button
+              onClick={handleDirectAdd}
+              disabled={!addItem?.id || !addWarehouseId || !addQty || parseFloat(addQty) <= 0 || addNotes.length < 3 || addSubmitting}
+            >
+              {addSubmitting ? 'Adding…' : 'Add Stock'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -337,7 +337,7 @@ const navigationSections: NavigationSection[] = [
     items: [
       { name: 'Dashboard',       href: '/inv',           icon: LayoutDashboard, newSince: '2026-05-24' },
       { name: 'Stock Levels',    href: '/inv/stock',     icon: Package,         newSince: '2026-05-24' },
-      { name: 'Material Issues', href: '/inv/mir-out',   icon: ArrowRightLeft,  newSince: '2026-05-24' },
+      { name: 'Material Disburse', href: '/inv/mir-out',   icon: ArrowRightLeft,  newSince: '2026-05-24' },
       { name: 'Returns',         href: '/inv/returns',   icon: Undo2,           newSince: '2026-05-24' },
       { name: 'Ledger',           href: '/inv/ledger',            icon: BookOpen,  newSince: '2026-05-24' },
       { name: 'Material Master',  href: '/inv/material-master',   icon: Database,  newSince: '2026-05-25' },

--- a/src/components/inv/employee-select.tsx
+++ b/src/components/inv/employee-select.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Loader2 } from 'lucide-react';
+
+interface UserOption {
+  id: string;
+  name: string;
+  position?: string;
+  department?: { name: string };
+}
+
+interface EmployeeSelectProps {
+  value: string;
+  onValueChange: (id: string) => void;
+  disabled?: boolean;
+  placeholder?: string;
+}
+
+export function EmployeeSelect({
+  value,
+  onValueChange,
+  disabled = false,
+  placeholder = 'Select employee...',
+}: EmployeeSelectProps) {
+  const [users, setUsers] = useState<UserOption[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('/api/users?forAssignment=true')
+      .then(r => r.json())
+      .then(data => {
+        const list: UserOption[] = Array.isArray(data) ? data : (data?.users ?? []);
+        const sorted = [...list].sort((a, b) => a.name.localeCompare(b.name));
+        setUsers(sorted);
+      })
+      .catch(() => setUsers([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 h-10 px-3 border rounded-md text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Loading employees…
+      </div>
+    );
+  }
+
+  return (
+    <Select value={value} onValueChange={onValueChange} disabled={disabled}>
+      <SelectTrigger>
+        <SelectValue placeholder={placeholder} />
+      </SelectTrigger>
+      <SelectContent>
+        {users.map(u => (
+          <SelectItem key={u.id} value={u.id}>
+            <span className="font-medium">{u.name}</span>
+            {(u.position || u.department?.name) && (
+              <span className="text-xs text-muted-foreground ml-2">
+                {[u.position, u.department?.name].filter(Boolean).join(' · ')}
+              </span>
+            )}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/components/inv/item-combobox.tsx
+++ b/src/components/inv/item-combobox.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import { Input } from '@/components/ui/input';
+import { Search, Loader2 } from 'lucide-react';
+
+export interface InvItem {
+  id: string;
+  code: string;
+  name: string;
+  unit: string;
+  category: string;
+  defaultWhType: string;
+}
+
+interface ItemComboboxProps {
+  value: string;
+  onSelect: (item: InvItem | null) => void;
+  disabled?: boolean;
+  placeholder?: string;
+  className?: string;
+  /** If provided, filter locally — no API call */
+  items?: InvItem[];
+}
+
+export function ItemCombobox({
+  value,
+  onSelect,
+  disabled = false,
+  placeholder = 'Search items...',
+  className,
+  items: preloadedItems,
+}: ItemComboboxProps) {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<InvItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [open, setOpen] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Show label of currently selected item
+  const selectedLabel = (() => {
+    if (!value) return '';
+    // Look in preloaded or results
+    const all = preloadedItems ?? results;
+    const found = all.find(i => i.id === value);
+    return found ? `${found.code} — ${found.name}` : value;
+  })();
+
+  // Initialise display with selected value label
+  useEffect(() => {
+    if (!value) {
+      setQuery('');
+    }
+  }, [value]);
+
+  // Close on outside click
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const search = (input: string) => {
+    setQuery(input);
+
+    if (!input.trim() || input.length < 2) {
+      setResults([]);
+      setOpen(false);
+      return;
+    }
+
+    // Local filter mode
+    if (preloadedItems) {
+      const q = input.toLowerCase();
+      const filtered = preloadedItems.filter(
+        i => i.code.toLowerCase().includes(q) || i.name.toLowerCase().includes(q),
+      );
+      setResults(filtered.slice(0, 30));
+      setOpen(true);
+      return;
+    }
+
+    // API mode with debounce
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(async () => {
+      setLoading(true);
+      try {
+        const res = await fetch(
+          `/api/inv/items?activeOnly=true&search=${encodeURIComponent(input)}`,
+        );
+        if (res.ok) {
+          const data = await res.json();
+          setResults(Array.isArray(data) ? data.slice(0, 30) : []);
+          setOpen(true);
+        }
+      } catch {
+        setResults([]);
+      } finally {
+        setLoading(false);
+      }
+    }, 300);
+  };
+
+  const handleSelect = (item: InvItem) => {
+    setQuery(`${item.code} — ${item.name}`);
+    onSelect(item);
+    setOpen(false);
+    setResults([]);
+  };
+
+  const handleClear = () => {
+    setQuery('');
+    onSelect(null);
+    setResults([]);
+    setOpen(false);
+  };
+
+  const displayValue = query || (value ? selectedLabel : '');
+
+  return (
+    <div ref={containerRef} className={`relative ${className ?? ''}`}>
+      <div className="relative">
+        <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+        <Input
+          value={displayValue}
+          onChange={e => search(e.target.value)}
+          onFocus={() => {
+            if (preloadedItems && query.length >= 2 && results.length > 0) setOpen(true);
+            if (!preloadedItems && query.length >= 2 && results.length > 0) setOpen(true);
+          }}
+          placeholder={placeholder}
+          disabled={disabled}
+          className="pl-7 pr-6 h-8 text-sm"
+        />
+        {loading && (
+          <Loader2 className="absolute right-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 animate-spin text-muted-foreground" />
+        )}
+        {!loading && value && (
+          <button
+            type="button"
+            onClick={handleClear}
+            className="absolute right-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground hover:text-foreground leading-none"
+          >
+            ×
+          </button>
+        )}
+      </div>
+
+      {open && results.length > 0 && (
+        <div className="absolute z-50 w-full mt-1 bg-background border rounded-md shadow-lg max-h-60 overflow-auto">
+          {results.map(item => (
+            <button
+              key={item.id}
+              type="button"
+              className="w-full text-left px-3 py-2 hover:bg-muted text-sm"
+              onClick={() => handleSelect(item)}
+            >
+              <div className="font-mono font-medium text-xs text-blue-700 dark:text-blue-400">
+                {item.code}
+              </div>
+              <div className="text-xs text-muted-foreground truncate">{item.name}</div>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {open && !loading && results.length === 0 && query.length >= 2 && (
+        <div className="absolute z-50 w-full mt-1 bg-background border rounded-md shadow-lg px-3 py-2 text-sm text-muted-foreground">
+          No items found
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/navigation-permissions.ts
+++ b/src/lib/navigation-permissions.ts
@@ -321,6 +321,7 @@ export const NAVIGATION_PERMISSIONS: NavigationPermissionMap = {
   '/inv/returns/new': ['inv.request'],
   '/inv/ledger': ['inv.view', 'inv.request', 'inv.approve', 'inv.issue', 'inv.adjust', 'inv.admin'],
   '/inv/material-master': ['inv.view', 'inv.admin'],
+  '/inv/stock/corrections': ['inv.adjust', 'inv.admin'],
   '/inv/settings': ['inv.view', 'inv.request', 'inv.approve', 'inv.issue', 'inv.adjust', 'inv.admin'],
 };
 


### PR DESCRIPTION
- Rename Material Issue Request → Material Disburse (HEXA-FRM-029) throughout all inv pages and sidebar
- Add searchable ItemCombobox component backed by InvItem master list (type ≥2 chars to search)
- Add EmployeeSelect component for 'Handed To / Received By' DDL on Material Disburse form
- Add handedToId field to inv_mir_outs (migration v37_0) and POST /api/inv/mir-out API
- Stock Correction dialog (HEXA-FRM-028): physical vs system count with variance display
- Opening Balance / Add Stock dialog (HEXA-FRM-027): direct stock entry for Dolibarr migration
- POST /api/inv/stock-direct: new API endpoint for direct stock addition
- Sortable column headers on all /inv table views (Stock, Disburse, Returns, Ledger)
- Material Master KPI tiles now show global stats (classified/review/avgConf) across all pages
- dolibarr/products API: global stats always computed regardless of active filters
- Forms directory updated: HEXA-FRM-027-030 added (30 total)
- CLAUDE.md: added Table & Dashboard Rules (sortable headers, clickable KPI tiles)
- Package version bumped to 24.1.1
- CHANGELOG.md and hardcoded changelog page updated

https://claude.ai/code/session_01NoBKCXVSbrx3ob3Cth3R6C