### PR TITLE
fix(inv): add missing INV migrations to startup list — resolves 502 on stock page

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -66,7 +66,8 @@ export function middleware(req: NextRequest) {
                           pathname.startsWith('/supply-chain') ||
                           pathname.startsWith('/hr') ||
                           pathname.startsWith('/workflow') ||
-                          pathname.startsWith('/financial');
+                          pathname.startsWith('/financial') ||
+                          pathname.startsWith('/inv');
   const isProtectedApi = pathname.startsWith('/api') && !pathname.startsWith('/api/auth');
 
   if (isProtectedPage || isProtectedApi) {

--- a/src/app/api/inv/balance/route.ts
+++ b/src/app/api/inv/balance/route.ts
@@ -20,10 +20,14 @@ export async function GET(req: Request) {
     const itemId = searchParams.get('itemId');
     const siteId = searchParams.get('siteId');
 
-    const where: Record<string, unknown> = {};
+    const where: Record<string, unknown> = {
+      warehouse: { deletedAt: null },
+      item:      { deletedAt: null },
+    };
 
     if (warehouseId) {
       where.warehouseId = warehouseId;
+      where.warehouse = { deletedAt: null };
     } else if (siteId) {
       where.warehouse = { siteId, deletedAt: null };
     }

--- a/src/lib/startup-migrations.ts
+++ b/src/lib/startup-migrations.ts
@@ -253,6 +253,18 @@ const STARTUP_MIGRATIONS = [
 
   // ── v34.0.0 — MIR: planned_delivery_date from Dolibarr PO ────────────────
   'v34_0_mir_planned_delivery_date.sql',
+
+  // ── v35.0.0 — Integrity Reports table ────────────────────────────────────
+  'v35_0_integrity_reports.sql',
+
+  // ── v36.0.0 — INV: Warehouse, Location, Item, Stock Balance, Ledger, MIR-Out, Return, Adjustment ──
+  'v36_0_inv_warehouse_management.sql',
+
+  // ── v36.1 — Material Master Enrichment (dolibarr_products columns) ────────
+  'v36_1_material_master_enrichment.sql',
+
+  // ── v37.0.0 — INV MIR-Out: handedToId column ─────────────────────────────
+  'v37_0_inv_handed_to.sql',
 ];
 
 /**


### PR DESCRIPTION
The 4 migration files added in v24.1.x were never registered in
STARTUP_MIGRATIONS, so inv_warehouses, inv_items, inv_stock_balances,
inv_stock_ledger and all other INV tables were never created in
production on server start — causing every INV API call to throw a
Prisma 'table does not exist' error, which surfaced as a 502.

Changes:
- startup-migrations.ts: add v35_0_integrity_reports.sql,
  v36_0_inv_warehouse_management.sql,
  v36_1_material_master_enrichment.sql,
  v37_0_inv_handed_to.sql to STARTUP_MIGRATIONS in order
- middleware.ts: add /inv to the isProtectedPage list (auth gap —
  /inv routes were reachable without a session cookie)
- balance/route.ts: apply soft-delete filter (deletedAt: null) on
  warehouse and item relations in the default (no-filter) query path

https://claude.ai/code/session_01GT93n2ek1d18tFaF6UAFzG