### PR TITLE
fix: ensure closedAt exists before adding handed_to_id in v37 migration

### DIFF
--- a/prisma/manual_migrations/v37_0_inv_handed_to.sql
+++ b/prisma/manual_migrations/v37_0_inv_handed_to.sql
@@ -1,4 +1,26 @@
 -- Add handedToId to inv_mir_outs for "handed to / received by" tracking
+
+-- Step 1: Ensure closed_at exists (may be absent on databases where the table
+--         pre-dated v36_0 and the CREATE TABLE branch was skipped)
+DROP PROCEDURE IF EXISTS _v37_closed_at;
+DELIMITER $$
+CREATE PROCEDURE _v37_closed_at()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME   = 'inv_mir_outs'
+      AND COLUMN_NAME  = 'closedAt'
+  ) THEN
+    ALTER TABLE inv_mir_outs
+      ADD COLUMN `closedAt` DATETIME(3) NULL AFTER `rejectionReason`;
+  END IF;
+END$$
+DELIMITER ;
+CALL _v37_closed_at();
+DROP PROCEDURE IF EXISTS _v37_closed_at;
+
+-- Step 2: Add handed_to_id after closed_at
 DROP PROCEDURE IF EXISTS _v37_handed_to;
 DELIMITER $$
 CREATE PROCEDURE _v37_handed_to()
@@ -10,9 +32,28 @@ BEGIN
       AND COLUMN_NAME  = 'handed_to_id'
   ) THEN
     ALTER TABLE inv_mir_outs
-      ADD COLUMN handed_to_id CHAR(36) NULL AFTER closed_at;
+      ADD COLUMN `handed_to_id` CHAR(36) NULL AFTER `closedAt`;
   END IF;
 END$$
 DELIMITER ;
 CALL _v37_handed_to();
 DROP PROCEDURE IF EXISTS _v37_handed_to;
+
+-- Step 3: Add index on handed_to_id
+DROP PROCEDURE IF EXISTS _v37_idx_handed_to;
+DELIMITER $$
+CREATE PROCEDURE _v37_idx_handed_to()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME   = 'inv_mir_outs'
+      AND INDEX_NAME   = 'inv_mir_outs_handed_to_id_idx'
+  ) THEN
+    ALTER TABLE inv_mir_outs
+      ADD INDEX `inv_mir_outs_handed_to_id_idx` (`handed_to_id`);
+  END IF;
+END$$
+DELIMITER ;
+CALL _v37_idx_handed_to();
+DROP PROCEDURE IF EXISTS _v37_idx_handed_to;


### PR DESCRIPTION
The v36_0 migration creates inv_mir_outs with closedAt only when the table
is being created fresh. On existing databases where the table pre-dated v36,
the CREATE TABLE branch is skipped and closedAt is never added. The v37
migration then crashes with 'Unknown column closed_at' when trying to
position handed_to_id AFTER it.

Fix: add an idempotent step in v37 to backfill closedAt first (using the
standard stored-procedure pattern), then place handed_to_id after it.
Also fix the column reference: the actual DB name is 'closedAt' (camelCase,
no @map in schema), not 'closed_at'. Added index on handed_to_id to match
schema @@index expectations.

https://claude.ai/code/session_019c1AMgVmDB4ymPQ3gHogje