### PR TITLE
Add idempotent startup migration tracking with connection pooling

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -26,6 +26,11 @@ export async function register() {
     // Run idempotent SQL migrations (18.11.0+)
     await runStartupMigrations();
 
+    // Warm up the Prisma engine so the first HTTP requests don't race against
+    // engine startup and get "Engine is not yet connected" errors.
+    const { db } = await import('@/lib/middleware/db-connection-pool');
+    await db.$connect();
+
     // Initialize the Early Warning Engine scheduler
     EarlyWarningScheduler.initialize();
 

--- a/src/lib/startup-migrations.ts
+++ b/src/lib/startup-migrations.ts
@@ -337,11 +337,12 @@ function splitStatements(sql: string): string[] {
   return statements;
 }
 
+const TRACKING_TABLE = '_startup_migrations';
+
 /**
- * Execute a single migration file via mysql2 (not Prisma) so stored
- * procedures, DELIMITER changes, and other DDL work correctly.
+ * Execute a single migration file using an existing mysql2 connection.
  */
-async function runMigrationFile(filename: string): Promise<void> {
+async function runMigrationFile(filename: string, conn: mysql.Connection): Promise<void> {
   const filePath = join(MIGRATIONS_DIR, filename);
   let sql: string;
 
@@ -352,36 +353,56 @@ async function runMigrationFile(filename: string): Promise<void> {
     return;
   }
 
-  const statements = splitStatements(sql);
-  const conn = await mysql.createConnection(parseMysqlUrl(env.DATABASE_URL));
+  for (const stmt of splitStatements(sql)) {
+    const normalized = stmt.replace(/;$/, '').trim();
+    if (!normalized) continue;
 
-  try {
-    for (const stmt of statements) {
-      const normalized = stmt.replace(/;$/, '').trim();
-      if (!normalized) continue;
-
-      try {
-        await conn.query(normalized);
-      } catch (error) {
-        logger.warn(
-          { filename, error, statement: normalized.slice(0, 120) },
-          '[startup-migration] Statement failed (non-fatal)'
-        );
-      }
+    try {
+      await conn.query(normalized);
+    } catch (error) {
+      logger.warn(
+        { filename, error, statement: normalized.slice(0, 120) },
+        '[startup-migration] Statement failed (non-fatal)'
+      );
     }
-  } finally {
-    await conn.end();
   }
 }
 
 export async function runStartupMigrations(): Promise<void> {
-  for (const filename of STARTUP_MIGRATIONS) {
-    try {
-      logger.info({ filename }, '[startup-migration] Running migration');
-      await runMigrationFile(filename);
-      logger.info({ filename }, '[startup-migration] Migration complete');
-    } catch (error) {
-      logger.warn({ filename, error }, '[startup-migration] Migration failed (non-fatal)');
+  const conn = await mysql.createConnection(parseMysqlUrl(env.DATABASE_URL));
+
+  try {
+    // Ensure the tracking table exists so we can skip already-applied migrations.
+    await conn.query(`
+      CREATE TABLE IF NOT EXISTS \`${TRACKING_TABLE}\` (
+        \`filename\` VARCHAR(255) NOT NULL,
+        \`applied_at\` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (\`filename\`)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    `);
+
+    for (const filename of STARTUP_MIGRATIONS) {
+      try {
+        // Skip migrations that have already been applied.
+        const [rows] = await conn.query(
+          `SELECT 1 FROM \`${TRACKING_TABLE}\` WHERE filename = ? LIMIT 1`,
+          [filename]
+        );
+        if ((rows as unknown[]).length > 0) continue;
+
+        logger.info({ filename }, '[startup-migration] Running migration');
+        await runMigrationFile(filename, conn);
+
+        await conn.query(
+          `INSERT IGNORE INTO \`${TRACKING_TABLE}\` (filename) VALUES (?)`,
+          [filename]
+        );
+        logger.info({ filename }, '[startup-migration] Migration complete');
+      } catch (error) {
+        logger.warn({ filename, error }, '[startup-migration] Migration failed (non-fatal)');
+      }
     }
+  } finally {
+    await conn.end();
   }
 }


### PR DESCRIPTION
## Summary
Refactored startup migrations to track applied migrations in a dedicated database table, preventing duplicate execution on server restarts. Also added Prisma engine warm-up during initialization to prevent "Engine is not yet connected" errors on first requests.

## Key Changes
- **Migration tracking table**: Created `_startup_migrations` table to record which migrations have been applied, enabling idempotent re-runs
- **Connection management**: Moved connection creation into `runStartupMigrations()` and passed it to `runMigrationFile()` to avoid creating multiple connections per migration
- **Prisma engine warm-up**: Added `db.$connect()` call in `instrumentation.ts` to initialize the Prisma engine before handling HTTP requests, preventing race conditions on cold starts
- **Improved logging**: Added per-migration start/complete logging and better error context

## Implementation Details
- The tracking table uses `filename` as primary key with `applied_at` timestamp
- Migrations are skipped if already recorded in the tracking table (checked before execution)
- Individual statement failures within a migration remain non-fatal (logged as warnings)
- Connection is properly closed in a `finally` block to ensure cleanup
- Prisma warm-up happens after SQL migrations but before scheduler initialization

https://claude.ai/code/session_01K97GHe1KXp1QMaSJ6b7Z7h