### PR TITLE
Add diagnostic logging for 502 and slowness investigation

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -10,6 +10,33 @@
 export async function register() {
   // Only run on the server (Node.js runtime)
   if (process.env.NEXT_RUNTIME === 'nodejs') {
+    const { logger } = await import('@/lib/logger');
+    const startupStart = Date.now();
+
+    // Catch process-level crashes so we can see what's causing 502s
+    process.on('uncaughtException', (err: Error) => {
+      logger.error({ error: err, uptimeSec: Math.round(process.uptime()) }, '[Process] Uncaught exception');
+    });
+
+    process.on('unhandledRejection', (reason: unknown) => {
+      logger.error({ reason, uptimeSec: Math.round(process.uptime()) }, '[Process] Unhandled promise rejection');
+    });
+
+    // Log memory every 5 minutes to catch leaks / pressure leading to 502s
+    const memTimer = setInterval(() => {
+      const mem = process.memoryUsage();
+      const heapUsedMb = Math.round(mem.heapUsed / 1024 / 1024);
+      const heapTotalMb = Math.round(mem.heapTotal / 1024 / 1024);
+      const rssMb = Math.round(mem.rss / 1024 / 1024);
+      if (heapUsedMb > 800) {
+        logger.warn({ heapUsedMb, heapTotalMb, rssMb, uptimeSec: Math.round(process.uptime()) }, '[Process] High memory usage');
+      } else {
+        logger.info({ heapUsedMb, heapTotalMb, rssMb }, '[Process] Memory usage');
+      }
+    }, 5 * 60 * 1000);
+    // unref so this interval won't block a clean process exit
+    (memTimer as unknown as { unref(): void }).unref();
+
     // Dynamically import to avoid client-side bundling
     const { EarlyWarningScheduler } = await import('@/lib/scheduler/early-warning.scheduler');
     const { LcrSyncScheduler } = await import('@/lib/scheduler/lcr-sync.scheduler');
@@ -60,5 +87,7 @@ export async function register() {
 
     // Register integration event listeners (open-audit, Libre MES, …)
     registerIntegrationListeners();
+
+    logger.info({ durationMs: Date.now() - startupStart }, '[Startup] Server initialization complete');
   }
 }

--- a/src/lib/api-utils.ts
+++ b/src/lib/api-utils.ts
@@ -49,11 +49,18 @@ function toSessionData(payload: SessionPayload | null): SessionData | null {
 /**
  * Wrap an API handler with session verification and request context
  */
+const SLOW_REQUEST_WARN_MS = 5_000;
+const SLOW_REQUEST_ERROR_MS = 10_000;
+
 export function withApiContext<T = any>(
   handler: ApiHandler<T>,
   options: ApiHandlerOptions = { requireAuth: true }
 ): (request: NextRequest, context?: { params: Record<string, string> }) => Promise<NextResponse> {
   return async (request: NextRequest, context?: { params: Record<string, string> }) => {
+    const startMs = Date.now();
+    const method = request.method;
+    const url = request.nextUrl.pathname;
+
     try {
       const cookieStore = await cookies();
       const cookieName = process.env.COOKIE_NAME || 'ots_session';
@@ -70,18 +77,32 @@ export function withApiContext<T = any>(
         payload ? { userId: payload.sub, name: payload.name, role: payload.role } : null,
         'API'
       );
-      
+
       // Next.js 15: context.params is a Promise — resolve before passing to handler
       let resolvedContext = context;
       if (context?.params && typeof (context.params as unknown as Promise<Record<string, string>>).then === 'function') {
         resolvedContext = { params: await (context.params as unknown as Promise<Record<string, string>>) };
       }
 
-      return await runWithContextAsync(requestContext, async () => {
+      const response = await runWithContextAsync(requestContext, async () => {
         return handler(request, session, resolvedContext);
       });
+
+      const durationMs = Date.now() - startMs;
+      if (durationMs >= SLOW_REQUEST_ERROR_MS) {
+        const mem = process.memoryUsage();
+        logger.error(
+          { method, url, durationMs, heapUsedMb: Math.round(mem.heapUsed / 1024 / 1024) },
+          '[API] Very slow request — likely 502 source'
+        );
+      } else if (durationMs >= SLOW_REQUEST_WARN_MS) {
+        logger.warn({ method, url, durationMs }, '[API] Slow request');
+      }
+
+      return response;
     } catch (error) {
-      logger.error({ error }, '[API] Unhandled error in route handler');
+      const durationMs = Date.now() - startMs;
+      logger.error({ error, method, url, durationMs }, '[API] Unhandled error in route handler');
       return NextResponse.json(
         { error: 'Internal server error' },
         { status: 500 }

--- a/src/lib/middleware/db-connection-pool.ts
+++ b/src/lib/middleware/db-connection-pool.ts
@@ -12,7 +12,8 @@
  * (3 connections) and interactive MySQL sessions.
  */
 
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, Prisma } from '@prisma/client';
+import { logger } from '@/lib/logger';
 
 // ── Global guard (survives Next.js hot-reloads in dev) ────────────────────────
 declare global {
@@ -24,13 +25,32 @@ declare global {
 
 // ── Singleton factory ─────────────────────────────────────────────────────────
 
+const SLOW_QUERY_WARN_MS = 1_000;
+const SLOW_QUERY_ERROR_MS = 3_000;
+
 function createClient(): PrismaClient {
-  return new PrismaClient({
-    log: ['error'],
-    // connection_limit should be set in DATABASE_URL query string.
-    // The datasources block is intentionally omitted here so Prisma reads
-    // directly from DATABASE_URL (which can include ?connection_limit=10).
+  const client = new PrismaClient({
+    log: [
+      { emit: 'event', level: 'query' },
+      { emit: 'stdout', level: 'error' },
+    ],
   });
+
+  client.$on('query', (e: Prisma.QueryEvent) => {
+    if (e.duration >= SLOW_QUERY_ERROR_MS) {
+      logger.error(
+        { durationMs: e.duration, query: e.query.slice(0, 400), params: e.params.slice(0, 200) },
+        '[DB] Very slow query'
+      );
+    } else if (e.duration >= SLOW_QUERY_WARN_MS) {
+      logger.warn(
+        { durationMs: e.duration, query: e.query.slice(0, 400) },
+        '[DB] Slow query'
+      );
+    }
+  });
+
+  return client;
 }
 
 /**


### PR DESCRIPTION
- withApiContext: log warn at 5s, error at 10s with method/URL/heap usage
- PrismaClient: log slow queries (warn >1s, error >3s) with query text
- instrumentation: catch uncaughtException + unhandledRejection; log memory every 5min; log startup duration

https://claude.ai/code/session_013oQDn5NpKYwtFX59Rvfqt8