### PR TITLE
Fix 502: eliminate double getUserRank call and parallelize getPointsS…

### DIFF
--- a/src/app/api/points/me/route.ts
+++ b/src/app/api/points/me/route.ts
@@ -5,10 +5,9 @@ import { pointsService } from '@/lib/services/points-service';
 // GET /api/points/me — returns current user's points and rank for the TopBar badge
 export const GET = withApiContext(async (_req, session) => {
   const stats = await pointsService.getPointsStats(session!.userId);
-  const rank = await pointsService.getUserRank(session!.userId);
 
   return NextResponse.json({
     totalPoints: stats.totalPoints,
-    rank,
+    rank: stats.rank, // already computed inside getPointsStats — do not call getUserRank again
   });
 });

--- a/src/lib/services/points-service.ts
+++ b/src/lib/services/points-service.ts
@@ -462,35 +462,36 @@ class PointsService {
     thisWeekPoints: number;
     thisMonthPoints: number;
   }> {
+    // ensureUserPoints may INSERT a row, so resolve it first before running rank/badge queries
     const userPoints = await this.ensureUserPoints(userId);
-    const rank = await this.getUserRank(userId);
-    const badges = await this.getUserBadges(userId);
-    
-    // Get this week's points
+
     const weekStart = new Date();
     weekStart.setDate(weekStart.getDate() - weekStart.getDay());
     weekStart.setHours(0, 0, 0, 0);
-    
-    const weekPoints = await prisma.$queryRaw<[{ total: number | null }]>`
-      SELECT COALESCE(SUM(points), 0) as total
-      FROM point_transactions
-      WHERE user_id = ${userId} 
-        AND transaction_type IN ('EARN', 'BONUS')
-        AND created_at >= ${weekStart}
-    `;
-    
-    // Get this month's points
+
     const monthStart = new Date();
     monthStart.setDate(1);
     monthStart.setHours(0, 0, 0, 0);
-    
-    const monthPoints = await prisma.$queryRaw<[{ total: number | null }]>`
-      SELECT COALESCE(SUM(points), 0) as total
-      FROM point_transactions
-      WHERE user_id = ${userId}
-        AND transaction_type IN ('EARN', 'BONUS')
-        AND created_at >= ${monthStart}
-    `;
+
+    // Run all remaining queries in parallel — avoids holding connections sequentially
+    const [rank, badges, weekPoints, monthPoints] = await Promise.all([
+      this.getUserRank(userId),
+      this.getUserBadges(userId),
+      prisma.$queryRaw<[{ total: number | null }]>`
+        SELECT COALESCE(SUM(points), 0) as total
+        FROM point_transactions
+        WHERE user_id = ${userId}
+          AND transaction_type IN ('EARN', 'BONUS')
+          AND created_at >= ${weekStart}
+      `,
+      prisma.$queryRaw<[{ total: number | null }]>`
+        SELECT COALESCE(SUM(points), 0) as total
+        FROM point_transactions
+        WHERE user_id = ${userId}
+          AND transaction_type IN ('EARN', 'BONUS')
+          AND created_at >= ${monthStart}
+      `,
+    ]);
 
     return {
       totalPoints: userPoints.total_points,
@@ -500,7 +501,7 @@ class PointsService {
       rank,
       badgeCount: badges.length,
       thisWeekPoints: Number(weekPoints[0].total) || 0,
-      thisMonthPoints: Number(monthPoints[0].total) || 0
+      thisMonthPoints: Number(monthPoints[0].total) || 0,
     };
   }
 


### PR DESCRIPTION
…tats queries

/api/points/me was calling getUserRank twice per request — once inside getPointsStats() and again directly in the route handler. The getUserRank query is a full-table ROW_NUMBER() window function; running it twice per page load (every TopBar render) was saturating the DB connection pool (limit=10) and causing all other requests to queue and time out.

- Remove redundant getUserRank call in route handler; use stats.rank instead
- Parallelize the 4 independent queries inside getPointsStats with Promise.all (rank, badges, weekPoints, monthPoints now run concurrently after ensureUserPoints resolves)

This reduces the connection hold time for /api/points/me from ~15s to the duration of the single slowest parallel query.

https://claude.ai/code/session_013oQDn5NpKYwtFX59Rvfqt8