### PR TITLE
v39.0: Re-ensure dolibarr_id column on inv_items + defer MIR sync

### DIFF
--- a/prisma/manual_migrations/v39_0_ensure_inv_items_dolibarr_id.sql
+++ b/prisma/manual_migrations/v39_0_ensure_inv_items_dolibarr_id.sql
@@ -1,0 +1,39 @@
+-- v39_0_ensure_inv_items_dolibarr_id.sql
+-- Re-ensures dolibarr_id column and index on inv_items.
+-- v38_0 migration may have been tracked as applied on production before
+-- the statements executed (silent failure), leaving the column absent.
+
+DROP PROCEDURE IF EXISTS _v39_inv_dolibarr_id;
+DELIMITER $$
+CREATE PROCEDURE _v39_inv_dolibarr_id()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME   = 'inv_items'
+      AND COLUMN_NAME  = 'dolibarr_id'
+  ) THEN
+    ALTER TABLE inv_items
+      ADD COLUMN dolibarr_id INT NULL;
+  END IF;
+END$$
+DELIMITER ;
+CALL _v39_inv_dolibarr_id();
+DROP PROCEDURE IF EXISTS _v39_inv_dolibarr_id;
+
+DROP PROCEDURE IF EXISTS _v39_idx_inv_dolibarr_id;
+DELIMITER $$
+CREATE PROCEDURE _v39_idx_inv_dolibarr_id()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME   = 'inv_items'
+      AND INDEX_NAME   = 'idx_inv_items_dolibarr_id'
+  ) THEN
+    ALTER TABLE inv_items ADD INDEX idx_inv_items_dolibarr_id (dolibarr_id);
+  END IF;
+END$$
+DELIMITER ;
+CALL _v39_idx_inv_dolibarr_id();
+DROP PROCEDURE IF EXISTS _v39_idx_inv_dolibarr_id;

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -88,11 +88,14 @@ export async function register() {
     // Register integration event listeners (open-audit, Libre MES, …)
     registerIntegrationListeners();
 
-    // Retroactive MIR stock-in: sync any received MIRs that were never posted to inventory
+    // Retroactive MIR stock-in: sync any received MIRs that were never posted to inventory.
+    // Deferred 3 s to ensure the Prisma query engine is fully ready after $connect().
     const { backfillMirStockIn } = await import('@/lib/services/qc/mir-stock-sync.service');
-    backfillMirStockIn().catch(err =>
-      logger.error({ err }, '[Startup] MIR stock backfill failed'),
-    );
+    setTimeout(() => {
+      backfillMirStockIn().catch(err =>
+        logger.error({ err }, '[Startup] MIR stock backfill failed'),
+      );
+    }, 3000);
 
     logger.info({ durationMs: Date.now() - startupStart }, '[Startup] Server initialization complete');
   }

--- a/src/lib/startup-migrations.ts
+++ b/src/lib/startup-migrations.ts
@@ -268,6 +268,9 @@ const STARTUP_MIGRATIONS = [
 
   // ── v38.0.0 — Material Master fixes: reviewed_by type fix + dolibarr_id on inv_items ──
   'v38_0_material_master_fixes.sql',
+
+  // ── v39.0.0 — Re-ensure dolibarr_id on inv_items (v38 may have been tracked but not applied) ──
+  'v39_0_ensure_inv_items_dolibarr_id.sql',
 ];
 
 /**


### PR DESCRIPTION
## Summary
Adds a safety migration to re-ensure the `dolibarr_id` column and index on `inv_items` table, and defers the MIR stock backfill operation to allow the Prisma query engine to fully initialize.

## Changes

- **Database Migration (v39.0)**  
  Added `v39_0_ensure_inv_items_dolibarr_id.sql` to re-apply the `dolibarr_id` column and index on `inv_items`. The v38.0 migration may have been marked as applied in production before the DDL statements actually executed (silent failure), leaving the column absent on some deployments. This migration uses the idempotent stored-procedure pattern to safely add both the column and index only if they don't already exist.

- **Startup Initialization**  
  Modified `src/instrumentation.ts` to defer the `backfillMirStockIn()` call by 3 seconds. This ensures the Prisma query engine is fully ready after `$connect()` completes, preventing potential race conditions during server startup.

- **Migration Registry**  
  Updated `src/lib/startup-migrations.ts` to register the new v39.0 migration in the execution queue.

## Implementation Details
- Follows the MySQL-compatible conditional DDL pattern (stored procedures with `information_schema` checks) as documented in CLAUDE.md
- Deferred async operation uses `setTimeout` to avoid blocking startup while ensuring initialization order
- No breaking changes; purely defensive/corrective

https://claude.ai/code/session_01HAJbMWGtd8qmA33VcJGSYc