### PR TITLE
Add v40 & v41 startup migrations for MIR & INV sites

### DIFF
--- a/prisma/manual_migrations/v41_0_inv_sites.sql
+++ b/prisma/manual_migrations/v41_0_inv_sites.sql
@@ -36,7 +36,7 @@ DELIMITER $$
 CREATE PROCEDURE _v41_inv_sites_seed()
 BEGIN
   DECLARE v_creator CHAR(36);
-  SELECT id INTO v_creator FROM users ORDER BY createdAt ASC LIMIT 1;
+  SELECT id INTO v_creator FROM User ORDER BY createdAt ASC LIMIT 1;
 
   INSERT IGNORE INTO inv_sites (id, code, name, isActive, createdById, createdAt, updatedAt)
   SELECT UUID(), w.siteId, w.siteName, 1, v_creator, NOW(3), NOW(3)

--- a/src/lib/startup-migrations.ts
+++ b/src/lib/startup-migrations.ts
@@ -271,6 +271,12 @@ const STARTUP_MIGRATIONS = [
 
   // ── v39.0.0 — Re-ensure dolibarr_id on inv_items (v38 may have been tracked but not applied) ──
   'v39_0_ensure_inv_items_dolibarr_id.sql',
+
+  // ── v40.0.0 — MIR target_site_id + dolibarr_products default_wh_type ────────
+  'v40_0_mir_target_site_and_wh_type.sql',
+
+  // ── v41.0.0 — INV: Sites table (factory/site canonical source) ───────────────
+  'v41_0_inv_sites.sql',
 ];
 
 /**


### PR DESCRIPTION
## Summary
Registers two new database migrations in the startup sequence and fixes a table name reference in the v41 migration.

## Changes
- **v40.0.0 migration**: Added `v40_0_mir_target_site_and_wh_type.sql` to handle MIR `target_site_id` and dolibarr_products `default_wh_type` schema updates
- **v41.0.0 migration**: Added `v41_0_inv_sites.sql` to establish the INV sites table as the canonical source for factory/site data
- **Bug fix**: Corrected table reference in v41 migration from `users` to `User` (Prisma model name) to match actual schema

## Implementation Details
- Both migrations are registered in `STARTUP_MIGRATIONS` array in execution order
- The v41 migration includes a seeding procedure (`_v41_inv_sites_seed`) that populates initial site records from existing warehouse data, using the earliest created user as the creator
- Follows the idempotent stored-procedure pattern for safe re-execution

https://claude.ai/code/session_013UDzinjKHZaecMPbEesYEa