### PR TITLE
feat(inv): allow site reassignment on warehouse edit

### DIFF
--- a/src/app/api/inv/warehouses/[id]/route.ts
+++ b/src/app/api/inv/warehouses/[id]/route.ts
@@ -8,7 +8,7 @@ import { logActivity } from '@/lib/api-utils';
 
 const UpdateSchema = z.object({
   name: z.string().min(1).max(100).optional(),
-  siteName: z.string().min(1).max(50).optional(),
+  siteId: z.string().min(1).max(10).optional(),
   isActive: z.boolean().optional(),
 });
 
@@ -39,10 +39,23 @@ export async function PUT(
     });
     if (!warehouse) return NextResponse.json({ error: 'Warehouse not found' }, { status: 404 });
 
+    const updateData: Record<string, unknown> = { updatedAt: new Date() };
+    if (parsed.data.name !== undefined) updateData.name = parsed.data.name;
+    if (parsed.data.isActive !== undefined) updateData.isActive = parsed.data.isActive;
+    if (parsed.data.siteId !== undefined) {
+      const site = await prisma.invSite.findFirst({
+        where: { code: parsed.data.siteId, deletedAt: null },
+        select: { code: true, name: true },
+      });
+      if (!site) return NextResponse.json({ error: 'Site not found' }, { status: 404 });
+      updateData.siteId = site.code;
+      updateData.siteName = site.name;
+    }
+
     const updated = await prisma.invWarehouse.update({
       where: { id },
-      data: { ...parsed.data, updatedAt: new Date() },
-      select: { id: true, code: true, name: true, isActive: true },
+      data: updateData,
+      select: { id: true, code: true, name: true, siteId: true, siteName: true, isActive: true },
     });
 
     await logActivity({

--- a/src/app/inv/settings/page.tsx
+++ b/src/app/inv/settings/page.tsx
@@ -280,7 +280,7 @@ function WarehousesTab() {
     setSaving(true); setError('');
     try {
       const res = editing
-        ? await fetch(`/api/inv/warehouses/${editing.id}`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: form.name, siteName: form.siteName }) })
+        ? await fetch(`/api/inv/warehouses/${editing.id}`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: form.name, siteId: form.siteId }) })
         : await fetch('/api/inv/warehouses', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(form) });
       const data = await res.json();
       if (!res.ok) { setError(data.error || 'Failed to save'); return; }
@@ -365,27 +365,25 @@ function WarehousesTab() {
                   <Label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Code *</Label>
                   <Input value={form.code} onChange={e => setForm(f => ({ ...f, code: e.target.value }))} placeholder="RM-WH-F004" />
                 </div>
-                <div className="grid grid-cols-2 gap-3">
-                  <div className="space-y-1.5">
-                    <Label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Type</Label>
-                    <Select value={form.type} onValueChange={v => setForm(f => ({ ...f, type: v }))}>
-                      <SelectTrigger><SelectValue /></SelectTrigger>
-                      <SelectContent>{WH_TYPES.map(t => <SelectItem key={t} value={t}>{labelify(t)}</SelectItem>)}</SelectContent>
-                    </Select>
-                  </div>
-                  <div className="space-y-1.5">
-                    <Label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Factory</Label>
-                    <Select value={form.siteId} onValueChange={v => setForm(f => ({ ...f, siteId: v, siteName: sites.find(s => s.code === v)?.name || v }))}>
-                      <SelectTrigger><SelectValue placeholder="Select factory" /></SelectTrigger>
-                      <SelectContent>{sites.map(s => <SelectItem key={s.code} value={s.code}>{s.code} — {s.name}</SelectItem>)}</SelectContent>
-                    </Select>
-                  </div>
+                <div className="space-y-1.5">
+                  <Label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Type</Label>
+                  <Select value={form.type} onValueChange={v => setForm(f => ({ ...f, type: v }))}>
+                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectContent>{WH_TYPES.map(t => <SelectItem key={t} value={t}>{labelify(t)}</SelectItem>)}</SelectContent>
+                  </Select>
                 </div>
               </>
             )}
             <div className="space-y-1.5">
               <Label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Name *</Label>
               <Input value={form.name} onChange={e => setForm(f => ({ ...f, name: e.target.value }))} placeholder="Raw Material Warehouse — Factory 004" />
+            </div>
+            <div className="space-y-1.5">
+              <Label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Factory</Label>
+              <Select value={form.siteId} onValueChange={v => setForm(f => ({ ...f, siteId: v, siteName: sites.find(s => s.code === v)?.name || v }))}>
+                <SelectTrigger><SelectValue placeholder="Select factory" /></SelectTrigger>
+                <SelectContent>{sites.map(s => <SelectItem key={s.code} value={s.code}>{s.code} — {s.name}</SelectItem>)}</SelectContent>
+              </Select>
             </div>
           </div>
           {error && <p className="text-sm text-red-500 bg-red-50 dark:bg-red-950/30 px-3 py-2 rounded">{error}</p>}


### PR DESCRIPTION
Warehouse edit dialog now shows the Factory selector (previously only available on create). The PUT API accepts siteId and auto-derives siteName from the site record, keeping the denormalised field in sync.

https://claude.ai/code/session_01Ejrw3ecx1j5dpZfLZqPWGk