### PR TITLE
fix: stabilize server, rename PLATE→SHEET, fix stock categories

### DIFF
--- a/prisma/manual_migrations/v43_0_plate_to_sheet_and_category_fix.sql
+++ b/prisma/manual_migrations/v43_0_plate_to_sheet_and_category_fix.sql
@@ -1,0 +1,90 @@
+-- v43_0_plate_to_sheet_and_category_fix.sql
+-- Renames PLATE → SHEET in inv_items.category enum,
+-- updates dolibarr_products.material_category PLATE → SHEET,
+-- and backfills inv_items.category from dolibarr_products for all items
+-- that still have category = 'OTHER' but have a matched dolibarr product.
+
+-- ── Step 1: Add SHEET to enum (only if not already present) ───────────────
+DROP PROCEDURE IF EXISTS _v43_add_sheet_enum;
+DELIMITER $$
+CREATE PROCEDURE _v43_add_sheet_enum()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME   = 'inv_items'
+      AND COLUMN_NAME  = 'category'
+      AND COLUMN_TYPE  LIKE "%'SHEET'%"
+  ) THEN
+    ALTER TABLE inv_items MODIFY COLUMN category
+      ENUM('STRUCTURAL_STEEL','SHEET','PLATE','PIPE','CONSUMABLE','FASTENER','PAINT','ELECTRICAL','OFFCUT','OTHER') NOT NULL;
+  END IF;
+END$$
+DELIMITER ;
+CALL _v43_add_sheet_enum();
+DROP PROCEDURE IF EXISTS _v43_add_sheet_enum;
+
+-- ── Step 2: Migrate PLATE data → SHEET ────────────────────────────────────
+UPDATE inv_items SET category = 'SHEET' WHERE category = 'PLATE';
+
+-- ── Step 3: Remove PLATE from enum (safe now that no rows have PLATE) ─────
+DROP PROCEDURE IF EXISTS _v43_remove_plate_enum;
+DELIMITER $$
+CREATE PROCEDURE _v43_remove_plate_enum()
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME   = 'inv_items'
+      AND COLUMN_NAME  = 'category'
+      AND COLUMN_TYPE  LIKE "%'PLATE'%"
+  ) THEN
+    ALTER TABLE inv_items MODIFY COLUMN category
+      ENUM('STRUCTURAL_STEEL','SHEET','PIPE','CONSUMABLE','FASTENER','PAINT','ELECTRICAL','OFFCUT','OTHER') NOT NULL;
+  END IF;
+END$$
+DELIMITER ;
+CALL _v43_remove_plate_enum();
+DROP PROCEDURE IF EXISTS _v43_remove_plate_enum;
+
+-- ── Step 4: Update dolibarr_products PLATE → SHEET ────────────────────────
+UPDATE dolibarr_products SET material_category = 'SHEET' WHERE material_category = 'PLATE';
+
+-- ── Step 5: Backfill inv_items.category from dolibarr_products ────────────
+-- Maps the rich dolibarr material_category to the simpler InvItemCategory enum.
+-- Only updates items that have a dolibarr_id link and are not deleted.
+DROP PROCEDURE IF EXISTS _v43_backfill_item_categories;
+DELIMITER $$
+CREATE PROCEDURE _v43_backfill_item_categories()
+BEGIN
+  UPDATE inv_items i
+  INNER JOIN dolibarr_products dp ON dp.dolibarr_id = i.dolibarr_id
+  SET i.category = CASE dp.material_category
+    WHEN 'SHEET'             THEN 'SHEET'
+    WHEN 'PIPE'              THEN 'PIPE'
+    WHEN 'PROFILE_H'         THEN 'STRUCTURAL_STEEL'
+    WHEN 'PROFILE_I'         THEN 'STRUCTURAL_STEEL'
+    WHEN 'PROFILE_HEA'       THEN 'STRUCTURAL_STEEL'
+    WHEN 'PROFILE_HEB'       THEN 'STRUCTURAL_STEEL'
+    WHEN 'PROFILE_IPE'       THEN 'STRUCTURAL_STEEL'
+    WHEN 'PROFILE_C'         THEN 'STRUCTURAL_STEEL'
+    WHEN 'PROFILE_ANGLE'     THEN 'STRUCTURAL_STEEL'
+    WHEN 'FLAT_BAR'          THEN 'STRUCTURAL_STEEL'
+    WHEN 'ROUND_BAR'         THEN 'STRUCTURAL_STEEL'
+    WHEN 'BOLT'              THEN 'FASTENER'
+    WHEN 'NUT'               THEN 'FASTENER'
+    WHEN 'WELDING_ELECTRODE' THEN 'CONSUMABLE'
+    WHEN 'WELDING_WIRE_FLUX' THEN 'CONSUMABLE'
+    WHEN 'WELDING_PPE'       THEN 'CONSUMABLE'
+    WHEN 'GAS_CYLINDER'      THEN 'CONSUMABLE'
+    WHEN 'PAINT'             THEN 'PAINT'
+    ELSE 'OTHER'
+  END
+  WHERE i.dolibarr_id IS NOT NULL
+    AND i.deletedAt IS NULL
+    AND dp.material_category IS NOT NULL
+    AND dp.material_category != '';
+END$$
+DELIMITER ;
+CALL _v43_backfill_item_categories();
+DROP PROCEDURE IF EXISTS _v43_backfill_item_categories;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7774,7 +7774,7 @@ enum InvMaterialType {
 
 enum InvItemCategory {
   STRUCTURAL_STEEL
-  PLATE
+  SHEET
   PIPE
   CONSUMABLE
   FASTENER

--- a/src/app/api/admin/material-master/sync-items/route.ts
+++ b/src/app/api/admin/material-master/sync-items/route.ts
@@ -21,7 +21,7 @@ type DolibarrProduct = {
 function mapCategory(itemClass: string | null): string {
   switch (itemClass) {
     case 'STRUCTURAL_STEEL': return 'STRUCTURAL_STEEL'
-    case 'PLATE':            return 'PLATE'
+    case 'PLATE':            return 'SHEET'
     case 'PIPE':             return 'PIPE'
     case 'CONSUMABLE':       return 'CONSUMABLE'
     case 'FASTENER':         return 'FASTENER'

--- a/src/app/api/inv/items/[id]/route.ts
+++ b/src/app/api/inv/items/[id]/route.ts
@@ -10,7 +10,7 @@ const UpdateSchema = z.object({
   name: z.string().min(1).max(150).optional(),
   description: z.string().optional().nullable(),
   unit: z.string().min(1).max(20).optional(),
-  category: z.enum(['STRUCTURAL_STEEL', 'PLATE', 'PIPE', 'CONSUMABLE', 'FASTENER', 'PAINT', 'ELECTRICAL', 'OFFCUT', 'OTHER']).optional(),
+  category: z.enum(['STRUCTURAL_STEEL', 'SHEET', 'PIPE', 'CONSUMABLE', 'FASTENER', 'PAINT', 'ELECTRICAL', 'OFFCUT', 'OTHER']).optional(),
   defaultWhType: z.enum(['RAW_MATERIAL', 'CONSUMABLE', 'OFFCUT']).optional(),
   minStockLevel: z.number().min(0).optional(),
   isActive: z.boolean().optional(),

--- a/src/app/api/inv/items/route.ts
+++ b/src/app/api/inv/items/route.ts
@@ -12,7 +12,7 @@ const CreateSchema = z.object({
   name: z.string().min(1).max(150),
   description: z.string().optional().nullable(),
   unit: z.string().min(1).max(20),
-  category: z.enum(['STRUCTURAL_STEEL', 'PLATE', 'PIPE', 'CONSUMABLE', 'FASTENER', 'PAINT', 'ELECTRICAL', 'OFFCUT', 'OTHER']),
+  category: z.enum(['STRUCTURAL_STEEL', 'SHEET', 'PIPE', 'CONSUMABLE', 'FASTENER', 'PAINT', 'ELECTRICAL', 'OFFCUT', 'OTHER']),
   defaultWhType: z.enum(['RAW_MATERIAL', 'CONSUMABLE', 'OFFCUT']),
   minStockLevel: z.number().min(0).default(0),
 });

--- a/src/app/inv/material-master/page.tsx
+++ b/src/app/inv/material-master/page.tsx
@@ -269,7 +269,7 @@ function getKeyDims(p: Product): string {
   const d = e.dimensions;
   const sp = e.section_props;
 
-  if (cat === 'SHEET' || cat === 'PLATE') {
+  if (cat === 'SHEET') {
     if (d.thickness_mm) return `${d.thickness_mm}mm thick`;
   }
   if (
@@ -300,7 +300,7 @@ function getConversions(p: Product): string {
   const e = p.enrichment;
   const cat = e.material_category;
 
-  if (cat === 'SHEET' || cat === 'PLATE') {
+  if (cat === 'SHEET') {
     const kgm2 = e.kg_per_m2 !== null && e.kg_per_m2 !== undefined ? Number(e.kg_per_m2) : 0;
     if (!kgm2 || kgm2 <= 0) return '—';
     return `${kgm2} kg/m² | ${(1000 / kgm2).toFixed(1)} m²/t`;
@@ -335,7 +335,7 @@ function ConversionWidget({ product }: { product: Product }) {
   const [qty, setQty] = useState<string>('1');
   const [fromUnit, setFromUnit] = useState<ConvUnit>('TON');
 
-  const isSheet = cat === 'SHEET' || cat === 'PLATE';
+  const isSheet = cat === 'SHEET';
   const isProfile =
     cat === 'PROFILE_H' ||
     cat === 'PROFILE_I' ||
@@ -592,7 +592,7 @@ function ReviewForm({ product, onSuccess }: ReviewFormProps) {
             </SelectTrigger>
             <SelectContent>
               {[
-                'SHEET', 'PLATE', 'PROFILE_H', 'PROFILE_I', 'PROFILE_C', 'PROFILE_ANGLE',
+                'SHEET', 'PROFILE_H', 'PROFILE_I', 'PROFILE_C', 'PROFILE_ANGLE',
                 'FLAT_BAR', 'ROUND_BAR', 'BOLT', 'NUT', 'WELDING_ELECTRODE',
                 'WELDING_WIRE_FLUX', 'WELDING_PPE', 'PAINT', 'GAS_CYLINDER', 'OTHER',
               ].map(v => (
@@ -1534,7 +1534,7 @@ export default function MaterialMasterPage() {
               <SelectContent>
                 <SelectItem value="ALL">All Categories</SelectItem>
                 {[
-                  'SHEET', 'PLATE', 'PROFILE_H', 'PROFILE_I', 'PROFILE_C',
+                  'SHEET', 'PROFILE_H', 'PROFILE_I', 'PROFILE_C',
                   'PROFILE_ANGLE', 'FLAT_BAR', 'ROUND_BAR', 'BOLT', 'NUT',
                   'WELDING_ELECTRODE', 'WELDING_WIRE_FLUX', 'WELDING_PPE',
                   'PAINT', 'GAS_CYLINDER', 'OTHER',
@@ -1664,7 +1664,7 @@ export default function MaterialMasterPage() {
           {bulkField === 'material_category' && (
             <select value={bulkValue} onChange={e => setBulkValue(e.target.value)} className="h-7 rounded bg-slate-800 border border-slate-700 text-xs text-white px-2 focus:outline-none">
               <option value="">— select —</option>
-              {['SHEET','PLATE','PROFILE_H','PROFILE_I','PROFILE_C','PROFILE_ANGLE','FLAT_BAR','ROUND_BAR','BOLT','NUT','WELDING_ELECTRODE','WELDING_WIRE_FLUX','WELDING_PPE','PAINT','GAS_CYLINDER','OTHER'].map(v => <option key={v} value={v}>{v.replace(/_/g,' ')}</option>)}
+              {['SHEET','PROFILE_H','PROFILE_I','PROFILE_C','PROFILE_ANGLE','FLAT_BAR','ROUND_BAR','BOLT','NUT','WELDING_ELECTRODE','WELDING_WIRE_FLUX','WELDING_PPE','PAINT','GAS_CYLINDER','OTHER'].map(v => <option key={v} value={v}>{v.replace(/_/g,' ')}</option>)}
             </select>
           )}
           {bulkField === 'default_wh_type' && (

--- a/src/app/inv/settings/page.tsx
+++ b/src/app/inv/settings/page.tsx
@@ -27,7 +27,7 @@ interface InvSite {
   id: string; code: string; name: string; description: string | null; sourceCodes: string | null; isActive: boolean;
 }
 
-const CATEGORIES = ['STRUCTURAL_STEEL','PLATE','PIPE','CONSUMABLE','FASTENER','PAINT','ELECTRICAL','OFFCUT','OTHER'];
+const CATEGORIES = ['STRUCTURAL_STEEL','SHEET','PIPE','CONSUMABLE','FASTENER','PAINT','ELECTRICAL','OFFCUT','OTHER'];
 const WH_TYPES = ['RAW_MATERIAL','CONSUMABLE','OFFCUT'];
 
 function labelify(s: string) {
@@ -36,7 +36,7 @@ function labelify(s: string) {
 
 const CATEGORY_COLORS: Record<string, string> = {
   STRUCTURAL_STEEL: 'bg-slate-100 text-slate-700',
-  PLATE: 'bg-blue-100 text-blue-700',
+  SHEET: 'bg-blue-100 text-blue-700',
   PIPE: 'bg-indigo-100 text-indigo-700',
   CONSUMABLE: 'bg-orange-100 text-orange-700',
   FASTENER: 'bg-yellow-100 text-yellow-700',

--- a/src/app/inv/stock/page.tsx
+++ b/src/app/inv/stock/page.tsx
@@ -49,7 +49,7 @@ interface InvWarehouse {
 
 const CATEGORY_LABELS: Record<string, string> = {
   STRUCTURAL_STEEL: 'Structural Steel',
-  PLATE: 'Plate',
+  SHEET: 'Sheet',
   PIPE: 'Pipe',
   CONSUMABLE: 'Consumable',
   FASTENER: 'Fastener',
@@ -61,7 +61,7 @@ const CATEGORY_LABELS: Record<string, string> = {
 
 const CATEGORY_COLORS: Record<string, string> = {
   STRUCTURAL_STEEL: 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300',
-  PLATE: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
+  SHEET: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
   PIPE: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300',
   CONSUMABLE: 'bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-300',
   FASTENER: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300',
@@ -78,9 +78,6 @@ export default function StockPage() {
   const { permissions } = usePermissions();
   const { toast } = useToast();
   const canAdjust = permissions.includes('inv.adjust') || permissions.includes('inv.admin');
-  const isInvAdmin = permissions.includes('inv.admin');
-
-  const [syncing, setSyncing] = useState(false);
 
   const [balances, setBalances] = useState<BalanceRow[]>([]);
   const [loading, setLoading] = useState(true);
@@ -130,27 +127,6 @@ export default function StockPage() {
   }, [siteFilter]);
 
   useEffect(() => { fetchBalances(); }, [fetchBalances]);
-
-  const runBackfill = async () => {
-    setSyncing(true);
-    try {
-      const res = await fetch('/api/inv/internal/backfill', { method: 'POST' });
-      const data = await res.json();
-      if (!res.ok) {
-        toast({ title: 'Sync failed', description: data.error || 'Unknown error', variant: 'destructive' });
-      } else {
-        toast({
-          title: 'MIR sync complete',
-          description: `${data.posted} stock entries posted, ${data.skipped} skipped.`,
-        });
-        fetchBalances();
-      }
-    } catch {
-      toast({ title: 'Sync failed', description: 'Network error.', variant: 'destructive' });
-    } finally {
-      setSyncing(false);
-    }
-  };
 
   // Fetch warehouses for dialogs
   useEffect(() => {
@@ -332,18 +308,6 @@ export default function StockPage() {
               </p>
             </div>
             <div className="flex gap-2 flex-wrap justify-end">
-              {isInvAdmin && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="bg-white/10 border-white/30 text-white hover:bg-white/20"
-                  onClick={runBackfill}
-                  disabled={syncing}
-                >
-                  <RefreshCw className={`h-4 w-4 mr-2 ${syncing ? 'animate-spin' : ''}`} />
-                  {syncing ? 'Syncing…' : 'Sync from MIR'}
-                </Button>
-              )}
               {canAdjust && (
                 <>
                   <Button
@@ -366,15 +330,6 @@ export default function StockPage() {
                   </Button>
                 </>
               )}
-              <Button
-                variant="outline"
-                size="sm"
-                className="bg-white/10 border-white/30 text-white hover:bg-white/20"
-                onClick={fetchBalances}
-              >
-                <RefreshCw className="h-4 w-4 mr-2" />
-                Refresh
-              </Button>
               <Button
                 variant="outline"
                 size="sm"

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -85,15 +85,6 @@ export async function register() {
     // Register integration event listeners (open-audit, Libre MES, …)
     registerIntegrationListeners();
 
-    // Retroactive MIR stock-in: sync any received MIRs that were never posted to inventory.
-    // Deferred 3 s to ensure the Prisma query engine is fully ready after $connect().
-    const { backfillMirStockIn } = await import('@/lib/services/qc/mir-stock-sync.service');
-    setTimeout(() => {
-      backfillMirStockIn().catch(err =>
-        logger.error({ err }, '[Startup] MIR stock backfill failed'),
-      );
-    }, 3000);
-
     logger.info({ durationMs: Date.now() - startupStart }, '[Startup] Server initialization complete');
   }
 }

--- a/src/lib/material-master/classifier.ts
+++ b/src/lib/material-master/classifier.ts
@@ -111,9 +111,9 @@ export function classifyProduct(ref: string, label: string): ClassificationResul
       return {
         ...EMPTY,
         item_class: 'RAW_MATERIAL', material_nature: nature,
-        material_category: t >= 6 ? 'PLATE' : 'SHEET',
+        material_category: 'SHEET',
         grade, finish: 'Black Steel', unit_of_measure: 'KG',
-        profile_type: t >= 6 ? 'PLATE' : 'SHEET',
+        profile_type: 'SHEET',
         dim_width_mm: w, dim_length_mm: len, dim_thickness_mm: t,
         density_kg_m3: density,
         kg_per_m2: sc.kg_per_m2, unit_area_m2: sc.unit_area_m2,
@@ -310,7 +310,7 @@ export function classifyProduct(ref: string, label: string): ClassificationResul
         return {
           ...EMPTY,
           item_class: 'RAW_MATERIAL', material_nature: 'STAINLESS_STEEL',
-          material_category: t >= 6 ? 'PLATE' : 'SHEET',
+          material_category: 'SHEET',
           grade: r.includes('304') ? '304SS' : r.includes('316') ? '316SS' : null,
           unit_of_measure: 'KG',
           dim_width_mm: w, dim_length_mm: len, dim_thickness_mm: t,

--- a/src/lib/services/qc/mir-stock-sync.service.ts
+++ b/src/lib/services/qc/mir-stock-sync.service.ts
@@ -12,12 +12,44 @@
  */
 
 import { v4 as uuidv4 } from 'uuid';
-import type { InvWarehouseType } from '@prisma/client';
+import type { InvItemCategory, InvWarehouseType } from '@prisma/client';
 import prisma from '@/lib/db';
 import { logger } from '@/lib/logger';
 import { stockIn } from '@/lib/services/inv/inv-stock.service';
 
 type ResolvedItem = { id: string; defaultWhType: InvWarehouseType };
+
+function mapMaterialCategory(cat: string | null | undefined): InvItemCategory {
+  switch (cat) {
+    case 'SHEET':
+    case 'PLATE':
+      return 'SHEET';
+    case 'PIPE':
+      return 'PIPE';
+    case 'PROFILE_H':
+    case 'PROFILE_I':
+    case 'PROFILE_HEA':
+    case 'PROFILE_HEB':
+    case 'PROFILE_IPE':
+    case 'PROFILE_C':
+    case 'PROFILE_ANGLE':
+    case 'FLAT_BAR':
+    case 'ROUND_BAR':
+      return 'STRUCTURAL_STEEL';
+    case 'BOLT':
+    case 'NUT':
+      return 'FASTENER';
+    case 'WELDING_ELECTRODE':
+    case 'WELDING_WIRE_FLUX':
+    case 'WELDING_PPE':
+    case 'GAS_CYLINDER':
+      return 'CONSUMABLE';
+    case 'PAINT':
+      return 'PAINT';
+    default:
+      return 'OTHER';
+  }
+}
 
 /**
  * Look up the Dolibarr product mirror for a given dolibarrId and return a
@@ -29,23 +61,30 @@ async function resolveInvItemFromDolibarr(
   performedById: string,
 ): Promise<ResolvedItem | null> {
   try {
-    const rows = await prisma.$queryRaw<{ ref: string; label: string }[]>`
-      SELECT ref, label FROM dolibarr_products
+    const rows = await prisma.$queryRaw<{ ref: string; label: string; material_category: string | null; item_class: string | null }[]>`
+      SELECT ref, label, material_category, item_class FROM dolibarr_products
       WHERE dolibarr_id = ${dolibarrId} AND is_active = 1 LIMIT 1
     `;
     const product = rows[0];
     if (!product) return null;
 
+    const category = mapMaterialCategory(product.material_category);
+    const defaultWhType: InvWarehouseType =
+      product.item_class === 'CONSUMABLE' ? 'CONSUMABLE' : 'RAW_MATERIAL';
+
     // Link an existing InvItem whose code matches the Dolibarr product ref
     const existingByCode = await prisma.invItem.findFirst({
       where: { code: product.ref, deletedAt: null },
-      select: { id: true, defaultWhType: true },
+      select: { id: true, defaultWhType: true, category: true },
     });
 
     if (existingByCode) {
       await prisma.invItem.update({
         where: { id: existingByCode.id },
-        data: { dolibarrId },
+        data: {
+          dolibarrId,
+          ...(existingByCode.category === 'OTHER' && category !== 'OTHER' ? { category } : {}),
+        },
       });
       logger.info(
         { dolibarrId, invItemId: existingByCode.id, code: product.ref },
@@ -54,7 +93,7 @@ async function resolveInvItemFromDolibarr(
       return { id: existingByCode.id, defaultWhType: existingByCode.defaultWhType };
     }
 
-    // Create a new InvItem with safe defaults (category/whType can be updated later)
+    // Create a new InvItem with mapped category
     const id = uuidv4();
     await prisma.invItem.create({
       data: {
@@ -62,8 +101,8 @@ async function resolveInvItemFromDolibarr(
         code: product.ref,
         name: product.label.slice(0, 150),
         unit: 'PCS',
-        category: 'OTHER',
-        defaultWhType: 'RAW_MATERIAL',
+        category,
+        defaultWhType,
         dolibarrId,
         createdById: performedById,
       },


### PR DESCRIPTION
- Remove MIR backfill from startup to stop PM2 crash loop (659 restarts
  caused by 57 concurrent Prisma queries firing before engine warms up)
- Rename InvItemCategory PLATE→SHEET across schema, migrations, and all
  UI/API references; dolibarr_products.material_category PLATE→SHEET
- Add migration v43_0 to rename enum in inv_items, update dolibarr_products,
  and backfill inv_items.category from dolibarr_products for all linked items
  (fixes stock levels showing "Other" for all items)
- MIR sync service now maps dolibarr material_category to InvItemCategory
  when creating or linking InvItems, and upgrades "OTHER" items when a
  better category is resolvable
- Remove "Sync from MIR" and "Refresh" buttons from stock levels page
  (MIRs now auto-sync on creation; no manual sync needed)
- Remove PLATE from all material-master UI dropdowns and bulk-action selects

https://claude.ai/code/session_01EF8w9o57RkbGdUYKJco79D