### PR TITLE
feat: inventory & MIR feature bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [24.2.0] - 2026-05-31 — **Inventory & MIR: Pricing, Quarantine, Category Fix, Purchases History & Pagination**
+
+### Added
+- **Material pricing in stock**: unit price is now captured from the PO line at MIR receipt creation and flows through to `inv_stock_ledger` as `unit_cost` / `total_cost` for weighted average cost calculation
+- **Purchases tab** in Material Master detail panel: shows all stock-in movements for a product with date, MIR ref, supplier, qty, unit cost, total cost, weighted average price, and avg price per tonne
+- **Quarantine Qty** field in MIR item inspection form: quantity requiring further inspection (auto-computes `rejected = received − accepted − quarantine`)
+- **Receive All / Accept All** bulk action buttons in MIR receipt detail view (Draft workflow only)
+- **Expanded page sizes** in Material Master: 25 / 50 / 100 / 250 / 500 / 1000 / 5000 / All
+- **First/Last page navigation** (double-arrow `«»`) in Material Master and Stock Level pagination
+- **Stock Level pagination**: client-side paging with 50 / 100 / 250 / 500 / All rows per page
+
+### Changed
+- **Category fix**: `sync-items` now uses `material_category` (via `mapMaterialCategory`) instead of `item_class` — HEA / IPE / HEB profiles now correctly show as Structural Steel in Stock Levels. Existing items with stale category are updated on every sync run.
+- **Ledger API**: extended to accept `dolibarrId` for product lookup; returns `unitCost`, `totalCost`, and `supplierName` per MIR entry
+- **Sidebar active state**: `/inv` Dashboard, `/hr`, and `/backlog/dashboard` no longer remain highlighted when sub-pages are open
+
+### Fixed
+- Stock Levels page showed "Other" category for structural steel items (HEA, IPE, HEB profiles); fixed by correcting the category mapping logic during inventory sync
+
+---
+
 ## [24.1.1] - 2026-05-26 — **Inventory Module Refactor: Material Disburse, Sortable Tables & Stock Management**
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexa-steel-ots",
-  "version": "24.1.1",
+  "version": "24.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/prisma/manual_migrations/v44_0_mir_quarantine_unit_price.sql
+++ b/prisma/manual_migrations/v44_0_mir_quarantine_unit_price.sql
@@ -1,0 +1,37 @@
+-- v44_0: Add quarantine_qty and unit_price to material_inspection_receipt_items
+
+DROP PROCEDURE IF EXISTS _v44_quarantine_qty;
+DELIMITER $$
+CREATE PROCEDURE _v44_quarantine_qty()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME   = 'material_inspection_receipt_items'
+      AND COLUMN_NAME  = 'quarantine_qty'
+  ) THEN
+    ALTER TABLE material_inspection_receipt_items
+      ADD COLUMN quarantine_qty DOUBLE NOT NULL DEFAULT 0 AFTER rejected_qty;
+  END IF;
+END$$
+DELIMITER ;
+CALL _v44_quarantine_qty();
+DROP PROCEDURE IF EXISTS _v44_quarantine_qty;
+
+DROP PROCEDURE IF EXISTS _v44_unit_price;
+DELIMITER $$
+CREATE PROCEDURE _v44_unit_price()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME   = 'material_inspection_receipt_items'
+      AND COLUMN_NAME  = 'unit_price'
+  ) THEN
+    ALTER TABLE material_inspection_receipt_items
+      ADD COLUMN unit_price DECIMAL(12,4) NULL AFTER unit;
+  END IF;
+END$$
+DELIMITER ;
+CALL _v44_unit_price();
+DROP PROCEDURE IF EXISTS _v44_unit_price;

--- a/prisma/manual_migrations/v44_1_inv_ledger_cost.sql
+++ b/prisma/manual_migrations/v44_1_inv_ledger_cost.sql
@@ -1,0 +1,37 @@
+-- v44_1: Add unit_cost and total_cost to inv_stock_ledger
+
+DROP PROCEDURE IF EXISTS _v44_unit_cost;
+DELIMITER $$
+CREATE PROCEDURE _v44_unit_cost()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME   = 'inv_stock_ledger'
+      AND COLUMN_NAME  = 'unit_cost'
+  ) THEN
+    ALTER TABLE inv_stock_ledger
+      ADD COLUMN unit_cost DECIMAL(12,4) NULL AFTER reference_no;
+  END IF;
+END$$
+DELIMITER ;
+CALL _v44_unit_cost();
+DROP PROCEDURE IF EXISTS _v44_unit_cost;
+
+DROP PROCEDURE IF EXISTS _v44_total_cost;
+DELIMITER $$
+CREATE PROCEDURE _v44_total_cost()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME   = 'inv_stock_ledger'
+      AND COLUMN_NAME  = 'total_cost'
+  ) THEN
+    ALTER TABLE inv_stock_ledger
+      ADD COLUMN total_cost DECIMAL(12,2) NULL AFTER unit_cost;
+  END IF;
+END$$
+DELIMITER ;
+CALL _v44_total_cost();
+DROP PROCEDURE IF EXISTS _v44_total_cost;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1712,11 +1712,15 @@ model MaterialInspectionReceiptItem {
   specification   String?
 
   // Quantities
-  orderedQty  Float  @map("ordered_qty")
-  receivedQty Float  @default(0) @map("received_qty")
-  acceptedQty Float  @default(0) @map("accepted_qty")
-  rejectedQty Float  @default(0) @map("rejected_qty")
-  unit        String @default("pcs")
+  orderedQty    Float  @map("ordered_qty")
+  receivedQty   Float  @default(0) @map("received_qty")
+  acceptedQty   Float  @default(0) @map("accepted_qty")
+  rejectedQty   Float  @default(0) @map("rejected_qty")
+  quarantineQty Float  @default(0) @map("quarantine_qty")
+  unit          String @default("pcs")
+
+  // Pricing (from PO line)
+  unitPrice Decimal? @db.Decimal(12, 4) @map("unit_price")
 
   // Quality inspection per item
   qualityStatus String @default("Pending") @map("quality_status")
@@ -7950,6 +7954,8 @@ model InvStockLedger {
   referenceType String?              @db.VarChar(30)
   referenceId   String?              @db.Char(36)
   referenceNo   String?              @db.VarChar(50)
+  unitCost      Decimal?             @db.Decimal(12, 4) @map("unit_cost")
+  totalCost     Decimal?             @db.Decimal(12, 2) @map("total_cost")
   projectId     String?              @db.Char(36)
   locationId    String?              @db.Char(36)
   location      InvLocation?         @relation(fields: [locationId], references: [id])

--- a/src/app/api/admin/material-master/sync-items/route.ts
+++ b/src/app/api/admin/material-master/sync-items/route.ts
@@ -4,6 +4,7 @@ import { checkPermission } from '@/lib/permission-checker'
 import { logger } from '@/lib/logger'
 import prisma from '@/lib/db'
 import { v4 as uuidv4 } from 'uuid'
+import { mapMaterialCategory } from '@/lib/services/qc/mir-stock-sync.service'
 
 export const dynamic = 'force-dynamic'
 
@@ -14,21 +15,8 @@ type DolibarrProduct = {
   unit_of_measure: string | null
   item_class: string | null
   material_nature: string | null
+  material_category: string | null
   default_wh_type: string | null
-}
-
-// Map dolibarr item_class to InvItemCategory
-function mapCategory(itemClass: string | null): string {
-  switch (itemClass) {
-    case 'STRUCTURAL_STEEL': return 'STRUCTURAL_STEEL'
-    case 'PLATE':            return 'SHEET'
-    case 'PIPE':             return 'PIPE'
-    case 'CONSUMABLE':       return 'CONSUMABLE'
-    case 'FASTENER':         return 'FASTENER'
-    case 'PAINT':            return 'PAINT'
-    case 'ELECTRICAL':       return 'ELECTRICAL'
-    default:                 return 'OTHER'
-  }
 }
 
 // Map item_class / material_nature to InvWarehouseType
@@ -39,6 +27,7 @@ function mapWhType(itemClass: string | null, materialNature: string | null): str
 
 // POST /api/admin/material-master/sync-items
 // Imports active dolibarr_products into inv_items (skips existing by code or dolibarr_id)
+// Also updates category on existing items when it was previously OTHER or has changed.
 export const POST = withApiContext(async (
   _req: NextRequest,
   session
@@ -49,39 +38,51 @@ export const POST = withApiContext(async (
 
   try {
     const products = (await prisma.$queryRawUnsafe(
-      `SELECT dolibarr_id, ref, label, unit_of_measure, item_class, material_nature, default_wh_type
+      `SELECT dolibarr_id, ref, label, unit_of_measure, item_class, material_nature, material_category, default_wh_type
        FROM dolibarr_products
        WHERE is_active = 1
        ORDER BY ref ASC`
     )) as DolibarrProduct[]
 
     let created = 0
+    let updated = 0
     let skipped = 0
     let errors = 0
 
     for (const p of products) {
       try {
-        // Skip if already linked by dolibarr_id or same code
+        const category = mapMaterialCategory(p.material_category)
+
+        // Check if already linked by dolibarr_id or same code
         const existing = (await prisma.$queryRawUnsafe(
-          `SELECT id FROM inv_items
+          `SELECT id, category FROM inv_items
            WHERE (dolibarr_id = ? OR code = ?)
            AND deleted_at IS NULL
            LIMIT 1`,
           p.dolibarr_id, p.ref
-        )) as Array<{ id: string }>
+        )) as Array<{ id: string; category: string }>
 
         if (existing.length > 0) {
-          // Update the dolibarr_id link if missing
-          await prisma.$executeRawUnsafe(
-            `UPDATE inv_items SET dolibarr_id = ? WHERE id = ? AND dolibarr_id IS NULL`,
-            p.dolibarr_id, existing[0].id
-          )
-          skipped++
+          const item = existing[0]
+          // Always link dolibarr_id if missing; also update category when it has changed
+          const categoryChanged = item.category !== category
+          if (categoryChanged) {
+            await prisma.$executeRawUnsafe(
+              `UPDATE inv_items SET dolibarr_id = COALESCE(dolibarr_id, ?), category = ?, updated_at = NOW() WHERE id = ?`,
+              p.dolibarr_id, category, item.id
+            )
+            updated++
+          } else {
+            await prisma.$executeRawUnsafe(
+              `UPDATE inv_items SET dolibarr_id = ? WHERE id = ? AND dolibarr_id IS NULL`,
+              p.dolibarr_id, item.id
+            )
+            skipped++
+          }
           continue
         }
 
         const unit = p.unit_of_measure ?? 'PC'
-        const category = mapCategory(p.item_class)
         const defaultWhType = p.default_wh_type ?? mapWhType(p.item_class, p.material_nature)
         const id = uuidv4()
 
@@ -100,8 +101,8 @@ export const POST = withApiContext(async (
       }
     }
 
-    logger.info({ created, skipped, errors, userId: session!.userId }, 'Material master sync-items complete')
-    return NextResponse.json({ created, skipped, errors, total: products.length })
+    logger.info({ created, updated, skipped, errors, userId: session!.userId }, 'Material master sync-items complete')
+    return NextResponse.json({ created, updated, skipped, errors, total: products.length })
   } catch (err) {
     logger.error({ err }, 'sync-items: fatal error')
     return NextResponse.json({ error: 'Sync failed' }, { status: 500 })

--- a/src/app/api/dolibarr/products/route.ts
+++ b/src/app/api/dolibarr/products/route.ts
@@ -26,8 +26,10 @@ export async function GET(req: Request) {
     const withSpecs = searchParams.get('with_specs') === '1';
     const isExport = searchParams.get('export') === '1';
     const page = Math.max(0, parseInt(searchParams.get('page') || '0', 10));
-    const limit = isExport ? 999999 : Math.min(200, Math.max(1, parseInt(searchParams.get('limit') || '50', 10)));
-    const offset = isExport ? 0 : page * limit;
+    const limitParam = searchParams.get('limit') || '50';
+    const limitAll = limitParam === 'all' || isExport;
+    const limit = limitAll ? 999999 : Math.min(9999, Math.max(1, parseInt(limitParam, 10)));
+    const offset = limitAll ? 0 : page * limit;
 
     // Enrichment filters
     const itemClass = searchParams.get('item_class') || '';

--- a/src/app/api/inv/ledger/route.ts
+++ b/src/app/api/inv/ledger/route.ts
@@ -16,8 +16,18 @@ export async function GET(req: Request) {
     if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const { searchParams } = new URL(req.url);
-    const itemId = searchParams.get('itemId');
+    let itemId = searchParams.get('itemId');
+    const dolibarrId = searchParams.get('dolibarrId');
     const warehouseId = searchParams.get('warehouseId');
+
+    // Resolve itemId from dolibarrId if provided
+    if (!itemId && dolibarrId) {
+      const invItem = await prisma.invItem.findFirst({
+        where: { dolibarrId: parseInt(dolibarrId, 10), deletedAt: null },
+        select: { id: true },
+      });
+      if (invItem) itemId = invItem.id;
+    }
     const movementType = searchParams.get('movementType');
     const direction = searchParams.get('direction');
     const projectId = searchParams.get('projectId');
@@ -56,8 +66,31 @@ export async function GET(req: Request) {
       prisma.invStockLedger.count({ where }),
     ]);
 
+    // Enrich MIR entries with supplier name from receipt
+    const mirReferenceIds = entries
+      .filter(e => e.referenceType === 'MIR' && e.referenceId)
+      .map(e => e.referenceId as string);
+
+    const mirSupplierMap: Record<string, string> = {};
+    if (mirReferenceIds.length > 0) {
+      const mirReceipts = await prisma.materialInspectionReceipt.findMany({
+        where: { id: { in: mirReferenceIds } },
+        select: { id: true, supplierName: true },
+      });
+      for (const r of mirReceipts) {
+        if (r.supplierName) mirSupplierMap[r.id] = r.supplierName;
+      }
+    }
+
+    const enrichedEntries = entries.map(e => ({
+      ...e,
+      unitCost: e.unitCost ? Number(e.unitCost) : null,
+      totalCost: e.totalCost ? Number(e.totalCost) : null,
+      supplierName: e.referenceType === 'MIR' && e.referenceId ? (mirSupplierMap[e.referenceId] ?? null) : null,
+    }));
+
     return NextResponse.json({
-      entries,
+      entries: enrichedEntries,
       total,
       page,
       pageSize,

--- a/src/app/api/qc/material-receipts/items/route.ts
+++ b/src/app/api/qc/material-receipts/items/route.ts
@@ -44,6 +44,7 @@ export async function PATCH(request: NextRequest) {
       receivedQty,
       acceptedQty,
       rejectedQty,
+      quarantineQty,
       qualityStatus,
       surfaceCondition,
       surfaceNotes,
@@ -76,16 +77,21 @@ export async function PATCH(request: NextRequest) {
 
     const parsedReceivedQty = receivedQty !== undefined ? parseFloat(receivedQty) : undefined;
     const parsedAcceptedQty = acceptedQty !== undefined ? parseFloat(acceptedQty) : undefined;
+    const parsedQuarantineQty = quarantineQty !== undefined && quarantineQty !== '' && !isNaN(parseFloat(quarantineQty))
+      ? Math.max(0, parseFloat(quarantineQty))
+      : undefined;
 
     if (parsedReceivedQty !== undefined && !isNaN(parsedReceivedQty)) updateData.receivedQty = parsedReceivedQty;
     if (parsedAcceptedQty !== undefined && !isNaN(parsedAcceptedQty)) updateData.acceptedQty = parsedAcceptedQty;
+    if (parsedQuarantineQty !== undefined) updateData.quarantineQty = parsedQuarantineQty;
 
-    // Auto-compute rejectedQty: if not provided or empty, derive from received - accepted
+    // Auto-compute rejectedQty: if not provided or empty, derive from received - accepted - quarantine
     if (rejectedQty !== undefined && rejectedQty !== '' && !isNaN(parseFloat(rejectedQty))) {
       updateData.rejectedQty = parseFloat(rejectedQty);
     } else if (parsedAcceptedQty !== undefined && !isNaN(parsedAcceptedQty)) {
       const rec = parsedReceivedQty ?? 0;
-      updateData.rejectedQty = Math.max(0, rec - parsedAcceptedQty);
+      const quar = parsedQuarantineQty ?? 0;
+      updateData.rejectedQty = Math.max(0, rec - parsedAcceptedQty - quar);
     }
 
     if (qualityStatus) updateData.qualityStatus = qualityStatus;

--- a/src/app/api/qc/material-receipts/route.ts
+++ b/src/app/api/qc/material-receipts/route.ts
@@ -228,7 +228,9 @@ export async function POST(request: NextRequest) {
         receivedQty: 0,
         acceptedQty: 0,
         rejectedQty: 0,
+        quarantineQty: 0,
         unit: item.unit || 'pcs',
+        unitPrice: item.unitPrice != null ? parseFloat(item.unitPrice) : null,
         qualityStatus: 'Pending',
         inspectionResult: 'Pending',
       }));

--- a/src/app/inv/material-master/page.tsx
+++ b/src/app/inv/material-master/page.tsx
@@ -39,6 +39,8 @@ import {
   BarChart2,
   ChevronLeft,
   ChevronRight,
+  ChevronsLeft,
+  ChevronsRight,
   ExternalLink,
   Loader2,
   RefreshCw,
@@ -685,9 +687,113 @@ interface DetailPanelProps {
   onReviewSuccess: (updated: Product) => void;
 }
 
+function PurchasesTab({ entries, loading, weightKgPerM }: {
+  entries: { id: string; createdAt: string; quantity: number; unitCost: number | null; totalCost: number | null; supplierName: string | null; referenceNo: string | null; warehouse: { code: string; siteId: string }; }[];
+  loading: boolean;
+  weightKgPerM: number | null;
+}) {
+
+  const totalQty = entries.reduce((s, e) => s + e.quantity, 0);
+  const totalCost = entries.reduce((s, e) => s + (e.totalCost ?? 0), 0);
+  const weightedAvg = totalQty > 0 && totalCost > 0 ? totalCost / totalQty : null;
+  const weightedAvgPerTonne = weightedAvg != null && weightKgPerM != null && weightKgPerM > 0
+    ? (weightedAvg / (weightKgPerM / 1000))
+    : null;
+
+  if (loading) return <div className="py-10 text-center text-sm text-slate-400">Loading purchase history…</div>;
+  if (entries.length === 0) return <div className="py-10 text-center text-sm text-slate-400">No stock-in movements found for this item.</div>;
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-3 gap-3">
+        <div className="rounded-lg bg-slate-50 border border-slate-200 px-4 py-2.5">
+          <p className="text-xs text-slate-500 mb-0.5">Total Received</p>
+          <p className="text-base font-bold text-slate-800">{totalQty.toLocaleString('en-SA-u-ca-gregory', { maximumFractionDigits: 2 })}</p>
+        </div>
+        <div className="rounded-lg bg-slate-50 border border-slate-200 px-4 py-2.5">
+          <p className="text-xs text-slate-500 mb-0.5">Weighted Avg Price</p>
+          <p className="text-base font-bold text-slate-800">
+            {weightedAvg != null ? weightedAvg.toLocaleString('en-SA-u-ca-gregory', { style: 'currency', currency: 'SAR', maximumFractionDigits: 2 }) : '—'}
+          </p>
+        </div>
+        <div className="rounded-lg bg-slate-50 border border-slate-200 px-4 py-2.5">
+          <p className="text-xs text-slate-500 mb-0.5">Avg Price / Tonne</p>
+          <p className="text-base font-bold text-slate-800">
+            {weightedAvgPerTonne != null ? weightedAvgPerTonne.toLocaleString('en-SA-u-ca-gregory', { style: 'currency', currency: 'SAR', maximumFractionDigits: 0 }) : '—'}
+          </p>
+        </div>
+      </div>
+      <div className="border rounded-lg overflow-hidden">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="bg-slate-50 border-b">
+              <th className="text-left px-3 py-2 font-semibold text-slate-600">Date</th>
+              <th className="text-left px-3 py-2 font-semibold text-slate-600">MIR</th>
+              <th className="text-left px-3 py-2 font-semibold text-slate-600">Supplier</th>
+              <th className="text-left px-3 py-2 font-semibold text-slate-600">Warehouse</th>
+              <th className="text-right px-3 py-2 font-semibold text-slate-600">Qty</th>
+              <th className="text-right px-3 py-2 font-semibold text-slate-600">Unit Cost</th>
+              <th className="text-right px-3 py-2 font-semibold text-slate-600">Total</th>
+            </tr>
+          </thead>
+          <tbody>
+            {entries.map(entry => (
+              <tr key={entry.id} className="border-b last:border-0 hover:bg-slate-50/60">
+                <td className="px-3 py-2 text-slate-700">
+                  {new Date(entry.createdAt).toLocaleDateString('en-SA-u-ca-gregory', { day: '2-digit', month: 'short', year: 'numeric' })}
+                </td>
+                <td className="px-3 py-2 font-mono text-blue-700">{entry.referenceNo ?? '—'}</td>
+                <td className="px-3 py-2 text-slate-600">{entry.supplierName ?? '—'}</td>
+                <td className="px-3 py-2 text-slate-600">{entry.warehouse.code}</td>
+                <td className="px-3 py-2 text-right font-mono font-medium">{entry.quantity.toLocaleString('en-SA-u-ca-gregory', { maximumFractionDigits: 2 })}</td>
+                <td className="px-3 py-2 text-right font-mono">
+                  {entry.unitCost != null ? entry.unitCost.toLocaleString('en-SA-u-ca-gregory', { style: 'currency', currency: 'SAR', maximumFractionDigits: 2 }) : '—'}
+                </td>
+                <td className="px-3 py-2 text-right font-mono font-medium">
+                  {entry.totalCost != null ? entry.totalCost.toLocaleString('en-SA-u-ca-gregory', { style: 'currency', currency: 'SAR', maximumFractionDigits: 2 }) : '—'}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+interface PurchaseLedgerEntry {
+  id: string;
+  createdAt: string;
+  direction: string;
+  movementType: string;
+  quantity: number;
+  balanceAfter: number;
+  referenceNo: string | null;
+  referenceType: string | null;
+  unitCost: number | null;
+  totalCost: number | null;
+  supplierName: string | null;
+  performedBy: { name: string };
+  warehouse: { code: string; siteId: string };
+}
+
 function DetailPanel({ product, open, onClose, isAdmin, onReviewSuccess }: DetailPanelProps) {
   if (!product) return null;
   const e = product.enrichment;
+
+  const [purchaseEntries, setPurchaseEntries] = useState<PurchaseLedgerEntry[]>([]);
+  const [purchaseLoading, setPurchaseLoading] = useState(false);
+  const [purchaseTab, setPurchaseTab] = useState(false);
+
+  useEffect(() => {
+    if (!purchaseTab || !product.dolibarr_id) return;
+    setPurchaseLoading(true);
+    fetch(`/api/inv/ledger?dolibarrId=${product.dolibarr_id}&movementType=STOCK_IN&pageSize=50`)
+      .then(r => r.ok ? r.json() : { entries: [] })
+      .then(data => setPurchaseEntries(data.entries ?? []))
+      .catch(() => setPurchaseEntries([]))
+      .finally(() => setPurchaseLoading(false));
+  }, [purchaseTab, product.dolibarr_id]);
 
   function OverviewRow({ label, value }: { label: string; value: string | number | null | undefined }) {
     if (!value && value !== 0) return null;
@@ -748,13 +854,14 @@ function DetailPanel({ product, open, onClose, isAdmin, onReviewSuccess }: Detai
 
         {/* Tabs */}
         <div className="flex-1 px-6 py-4">
-          <Tabs defaultValue="overview">
-            <TabsList className="grid w-full grid-cols-6 mb-4 transition-all duration-150">
+          <Tabs defaultValue="overview" onValueChange={v => { if (v === 'purchases') setPurchaseTab(true); }}>
+            <TabsList className="grid w-full grid-cols-7 mb-4 transition-all duration-150">
               <TabsTrigger value="overview" className="text-xs">Overview</TabsTrigger>
               <TabsTrigger value="dimensions" className="text-xs">Dims</TabsTrigger>
               <TabsTrigger value="section-props" className="text-xs">Section</TabsTrigger>
               <TabsTrigger value="conversions" className="text-xs">Convert</TabsTrigger>
               <TabsTrigger value="tds" className="text-xs">TDS</TabsTrigger>
+              <TabsTrigger value="purchases" className="text-xs">Purchases</TabsTrigger>
               {isAdmin && <TabsTrigger value="review" className="text-xs">Review</TabsTrigger>}
               {!isAdmin && <TabsTrigger value="review" className="text-xs" disabled>Review</TabsTrigger>}
             </TabsList>
@@ -1032,7 +1139,16 @@ function DetailPanel({ product, open, onClose, isAdmin, onReviewSuccess }: Detai
               )}
             </TabsContent>
 
-            {/* TAB 6: Review (admin only) */}
+            {/* TAB 6: Purchases */}
+            <TabsContent value="purchases" className="mt-0">
+              <PurchasesTab
+                entries={purchaseEntries}
+                loading={purchaseLoading}
+                weightKgPerM={e.section_props?.weight_kg_per_m ?? null}
+              />
+            </TabsContent>
+
+            {/* TAB 7: Review (admin only) */}
             <TabsContent value="review" className="mt-0">
               {isAdmin ? (
                 <ReviewForm product={product} onSuccess={onReviewSuccess} />
@@ -1171,7 +1287,7 @@ export default function MaterialMasterPage() {
     setLoading(true);
     try {
       const params = new URLSearchParams({
-        limit: String(pageSize),
+        limit: pageSize >= 999999 ? 'all' : String(pageSize),
         page: String(page),
         search: debouncedSearch,
         item_class: itemClass === 'ALL' ? '' : itemClass,
@@ -1587,14 +1703,19 @@ export default function MaterialMasterPage() {
             <div className="flex-1" />
 
             {/* Page size */}
-            <Select value={String(pageSize)} onValueChange={v => setPageSize(Number(v))}>
-              <SelectTrigger className="h-9 w-20 text-sm">
+            <Select value={pageSize >= 999999 ? 'all' : String(pageSize)} onValueChange={v => { setPageSize(v === 'all' ? 999999 : Number(v)); setPage(0); }}>
+              <SelectTrigger className="h-9 w-24 text-sm">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="25">25</SelectItem>
                 <SelectItem value="50">50</SelectItem>
                 <SelectItem value="100">100</SelectItem>
+                <SelectItem value="250">250</SelectItem>
+                <SelectItem value="500">500</SelectItem>
+                <SelectItem value="1000">1000</SelectItem>
+                <SelectItem value="5000">5000</SelectItem>
+                <SelectItem value="all">All</SelectItem>
               </SelectContent>
             </Select>
 
@@ -1883,7 +2004,17 @@ export default function MaterialMasterPage() {
 
       {/* ── SECTION 5: PAGINATION ─────────────────────────────────────────── */}
       {!loading && pagination.totalPages > 1 && (
-        <div className="flex items-center justify-center gap-3">
+        <div className="flex items-center justify-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page === 0}
+            onClick={() => setPage(0)}
+            className="px-2 active:scale-[0.97] transition-transform"
+            title="First page"
+          >
+            <ChevronsLeft className="h-4 w-4" />
+          </Button>
           <Button
             variant="outline"
             size="sm"
@@ -1894,7 +2025,7 @@ export default function MaterialMasterPage() {
             <ChevronLeft className="h-4 w-4" />
             Previous
           </Button>
-          <span className="text-sm text-slate-600 font-medium px-2">
+          <span className="text-sm text-slate-600 font-medium px-3">
             Page {page + 1} of {pagination.totalPages}
           </span>
           <Button
@@ -1906,6 +2037,16 @@ export default function MaterialMasterPage() {
           >
             Next
             <ChevronRight className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page >= pagination.totalPages - 1}
+            onClick={() => setPage(pagination.totalPages - 1)}
+            className="px-2 active:scale-[0.97] transition-transform"
+            title="Last page"
+          >
+            <ChevronsRight className="h-4 w-4" />
           </Button>
         </div>
       )}

--- a/src/app/inv/stock/page.tsx
+++ b/src/app/inv/stock/page.tsx
@@ -11,7 +11,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Download, Search, ArrowUpCircle, ArrowDownCircle, Package, AlertTriangle, TrendingDown, RefreshCw, SlidersHorizontal, Plus } from 'lucide-react';
+import { Download, Search, ArrowUpCircle, ArrowDownCircle, Package, AlertTriangle, TrendingDown, RefreshCw, SlidersHorizontal, Plus, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from 'lucide-react';
 import * as XLSX from 'xlsx';
 import { ItemCombobox } from '@/components/inv/item-combobox';
 import type { InvItem } from '@/components/inv/item-combobox';
@@ -88,6 +88,8 @@ export default function StockPage() {
   const [itemLedger, setItemLedger] = useState<LedgerEntry[]>([]);
   const [ledgerLoading, setLedgerLoading] = useState(false);
   const [sort, setSort] = useState<SortState>({ key: '', dir: null });
+  const [stockPage, setStockPage] = useState(0);
+  const [stockPageSize, setStockPageSize] = useState(100);
 
   // Warehouse list (for dialogs)
   const [warehouses, setWarehouses] = useState<InvWarehouse[]>([]);
@@ -164,6 +166,7 @@ export default function StockPage() {
   };
 
   const toggleSort = (key: string) => {
+    setStockPage(0);
     setSort(prev => ({
       key,
       dir: prev.key === key ? (prev.dir === 'asc' ? 'desc' : prev.dir === 'desc' ? null : 'asc') : 'asc',
@@ -195,6 +198,11 @@ export default function StockPage() {
     }
     return 0;
   });
+
+  const stockTotalPages = stockPageSize >= 999999 ? 1 : Math.ceil(sortedFiltered.length / stockPageSize);
+  const pagedRows = stockPageSize >= 999999
+    ? sortedFiltered
+    : sortedFiltered.slice(stockPage * stockPageSize, (stockPage + 1) * stockPageSize);
 
   const SortableHeader = ({ col, label, className }: { col: string; label: string; className?: string }) => (
     <TableHead
@@ -377,7 +385,7 @@ export default function StockPage() {
         {/* Stats summary */}
         {!loading && (
           <div className="flex gap-4 text-sm">
-            <span className="text-muted-foreground">{sortedFiltered.length} items shown</span>
+            <span className="text-muted-foreground">{sortedFiltered.length} items total</span>
             {lowStockCount > 0 && (
               <span className="text-red-600 font-medium flex items-center gap-1">
                 <TrendingDown className="h-4 w-4" /> {lowStockCount} below minimum
@@ -420,7 +428,7 @@ export default function StockPage() {
                     </TableCell>
                   </TableRow>
                 ) : (
-                  sortedFiltered.map(row => (
+                  pagedRows.map(row => (
                     <TableRow
                       key={`${row.warehouseId}-${row.itemId}`}
                       className={`cursor-pointer transition-colors hover:bg-muted/40 ${row.isLowStock ? 'bg-red-50/50 dark:bg-red-950/10' : ''}`}
@@ -468,6 +476,46 @@ export default function StockPage() {
             </Table>
           </CardContent>
         </Card>
+
+        {/* Stock pagination */}
+        {!loading && (
+          <div className="flex items-center justify-between gap-2 flex-wrap">
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-muted-foreground">Rows per page:</span>
+              <Select value={stockPageSize >= 999999 ? 'all' : String(stockPageSize)} onValueChange={v => { setStockPageSize(v === 'all' ? 999999 : Number(v)); setStockPage(0); }}>
+                <SelectTrigger className="h-8 w-20 text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="50">50</SelectItem>
+                  <SelectItem value="100">100</SelectItem>
+                  <SelectItem value="250">250</SelectItem>
+                  <SelectItem value="500">500</SelectItem>
+                  <SelectItem value="all">All</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            {stockTotalPages > 1 && (
+              <div className="flex items-center gap-2">
+                <Button variant="outline" size="sm" disabled={stockPage === 0} onClick={() => setStockPage(0)} className="px-2 h-8">
+                  <ChevronsLeft className="h-3.5 w-3.5" />
+                </Button>
+                <Button variant="outline" size="sm" disabled={stockPage === 0} onClick={() => setStockPage(p => p - 1)} className="px-2 h-8">
+                  <ChevronLeft className="h-3.5 w-3.5" />
+                </Button>
+                <span className="text-xs text-muted-foreground px-1">
+                  Page {stockPage + 1} of {stockTotalPages}
+                </span>
+                <Button variant="outline" size="sm" disabled={stockPage >= stockTotalPages - 1} onClick={() => setStockPage(p => p + 1)} className="px-2 h-8">
+                  <ChevronRight className="h-3.5 w-3.5" />
+                </Button>
+                <Button variant="outline" size="sm" disabled={stockPage >= stockTotalPages - 1} onClick={() => setStockPage(stockTotalPages - 1)} className="px-2 h-8">
+                  <ChevronsRight className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
       </div>
 
       {/* Ledger Slide-over */}

--- a/src/app/qc/material/_page-client.tsx
+++ b/src/app/qc/material/_page-client.tsx
@@ -148,6 +148,7 @@ type ReceiptItem = {
   receivedQty: number;
   acceptedQty: number;
   rejectedQty: number;
+  quarantineQty: number;
   unit: string;
   qualityStatus: string;
   surfaceCondition?: string;
@@ -369,6 +370,7 @@ export default function MaterialInspectionReceiptPage() {
         specification: '',
         orderedQty: Number(line.qty),
         unit: 'pcs',
+        unitPrice: line.subprice != null ? Number(line.subprice) : null,
       }));
 
       const response = await fetch('/api/qc/material-receipts', {
@@ -411,6 +413,7 @@ export default function MaterialInspectionReceiptPage() {
       receivedQty: item.receivedQty || '',
       acceptedQty: item.acceptedQty || '',
       rejectedQty: item.rejectedQty || '',
+      quarantineQty: item.quarantineQty || '',
       surfaceCondition: item.surfaceCondition || '',
       surfaceNotes: item.surfaceNotes || '',
       dimensionStatus: item.dimensionStatus || '',
@@ -481,6 +484,52 @@ export default function MaterialInspectionReceiptPage() {
       console.error('Error saving item inspection:', error);
     } finally {
       setSavingItem(false);
+    }
+  };
+
+  const [bulkActioning, setBulkActioning] = useState(false);
+
+  const handleReceiveAll = async () => {
+    if (!selectedReceipt) return;
+    const pendingItems = selectedReceipt.items.filter(i => i.receivedQty <= 0);
+    if (pendingItems.length === 0) return;
+    setBulkActioning(true);
+    try {
+      await Promise.all(pendingItems.map(item =>
+        fetch('/api/qc/material-receipts/items', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ itemId: item.id, receivedQty: item.orderedQty }),
+        })
+      ));
+      const res = await fetch(`/api/qc/material-receipts?id=${selectedReceipt.id}`);
+      if (res.ok) setSelectedReceipt(await res.json());
+    } catch { /* non-fatal */ } finally {
+      setBulkActioning(false);
+    }
+  };
+
+  const handleAcceptAll = async () => {
+    if (!selectedReceipt) return;
+    const receivedItems = selectedReceipt.items.filter(i => i.receivedQty > 0 && i.inspectionResult !== 'Accepted');
+    if (receivedItems.length === 0) return;
+    setBulkActioning(true);
+    try {
+      await Promise.all(receivedItems.map(item =>
+        fetch('/api/qc/material-receipts/items', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            itemId: item.id,
+            acceptedQty: item.receivedQty,
+            inspectionResult: 'Accepted',
+          }),
+        })
+      ));
+      const res = await fetch(`/api/qc/material-receipts?id=${selectedReceipt.id}`);
+      if (res.ok) setSelectedReceipt(await res.json());
+    } catch { /* non-fatal */ } finally {
+      setBulkActioning(false);
     }
   };
 
@@ -1497,7 +1546,31 @@ export default function MaterialInspectionReceiptPage() {
               )}
 
               <div>
-                <h3 className="font-semibold mb-3">Items ({selectedReceipt.items.length})</h3>
+                <div className="flex items-center justify-between mb-3">
+                  <h3 className="font-semibold">Items ({selectedReceipt.items.length})</h3>
+                  {(!selectedReceipt.workflowStatus || selectedReceipt.workflowStatus === 'Draft') && (
+                    <div className="flex gap-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={handleReceiveAll}
+                        disabled={bulkActioning}
+                        className="h-7 text-xs gap-1 border-blue-200 text-blue-700 hover:bg-blue-50"
+                      >
+                        Receive All
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={handleAcceptAll}
+                        disabled={bulkActioning}
+                        className="h-7 text-xs gap-1 border-green-200 text-green-700 hover:bg-green-50"
+                      >
+                        Accept All
+                      </Button>
+                    </div>
+                  )}
+                </div>
                 <div className="border rounded-lg overflow-x-auto">
                   <table className="w-full text-sm min-w-[800px]">
                     <thead>
@@ -1779,7 +1852,7 @@ export default function MaterialInspectionReceiptPage() {
 
             <div className="flex-1 overflow-y-auto px-6 py-4 space-y-4">
               {/* Quantities */}
-              <div className="grid grid-cols-3 gap-3">
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
                 <div className="space-y-1.5">
                   <Label htmlFor="receivedQty" className="text-sm font-semibold">
                     Received Qty *
@@ -1811,6 +1884,23 @@ export default function MaterialInspectionReceiptPage() {
                   />
                 </div>
                 <div className="space-y-1.5">
+                  <Label htmlFor="quarantineQty" className="text-sm flex items-center gap-1">
+                    Quarantine Qty
+                    <span className="inline-flex items-center justify-center w-3.5 h-3.5 rounded-full bg-amber-100 text-amber-700 text-[10px] cursor-default" title="This quantity needs further inspection">?</span>
+                  </Label>
+                  <Input
+                    id="quarantineQty"
+                    type="number"
+                    step="0.01"
+                    min={0}
+                    placeholder="0"
+                    value={itemFormData.quarantineQty as string}
+                    className="border-amber-200 focus-visible:ring-amber-400"
+                    onChange={(e) => setItemFormData({ ...itemFormData, quarantineQty: e.target.value })}
+                  />
+                  <p className="text-xs text-amber-600">This quantity needs further inspection</p>
+                </div>
+                <div className="space-y-1.5">
                   <Label htmlFor="rejectedQty" className="text-sm">Rejected Qty</Label>
                   <Input
                     id="rejectedQty"
@@ -1822,9 +1912,9 @@ export default function MaterialInspectionReceiptPage() {
                   />
                 </div>
               </div>
-              {itemFormData.receivedQty && (Number(itemFormData.acceptedQty) + Number(itemFormData.rejectedQty)) > Number(itemFormData.receivedQty) && (
+              {itemFormData.receivedQty && (Number(itemFormData.acceptedQty) + Number(itemFormData.quarantineQty ?? 0) + Number(itemFormData.rejectedQty)) > Number(itemFormData.receivedQty) && (
                 <p className="text-xs text-amber-600 bg-amber-50 dark:bg-amber-950/20 px-3 py-1.5 rounded-md -mt-2">
-                  Accepted + Rejected ({Number(itemFormData.acceptedQty) + Number(itemFormData.rejectedQty)}) exceeds Received ({itemFormData.receivedQty as string})
+                  Accepted + Quarantine + Rejected ({Number(itemFormData.acceptedQty) + Number(itemFormData.quarantineQty ?? 0) + Number(itemFormData.rejectedQty)}) exceeds Received ({itemFormData.receivedQty as string})
                 </p>
               )}
 

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -507,7 +507,7 @@ export function AppSidebar() {
       }
       return true;
     }
-    if (href === '/qc' || href === '/production' || href === '/financial') return pathname === href;
+    if (href === '/qc' || href === '/production' || href === '/financial' || href === '/inv' || href === '/hr' || href === '/backlog/dashboard') return pathname === href;
     return pathname === href || pathname.startsWith(href + '/');
   };
 

--- a/src/lib/services/inv/inv-stock.service.ts
+++ b/src/lib/services/inv/inv-stock.service.ts
@@ -20,6 +20,7 @@ export interface StockInParams {
   referenceNo?: string;
   performedById: string;
   notes?: string;
+  unitCost?: number;
 }
 
 export interface IssueStockParams {
@@ -64,7 +65,7 @@ export async function stockIn(
   tx: Prisma.TransactionClient,
   params: StockInParams
 ): Promise<number> {
-  const { warehouseId, itemId, qty, referenceType, referenceId, referenceNo, performedById, notes } = params;
+  const { warehouseId, itemId, qty, referenceType, referenceId, referenceNo, performedById, notes, unitCost } = params;
 
   // Upsert the stock balance
   const existing = await tx.invStockBalance.findUnique({
@@ -105,6 +106,8 @@ export async function stockIn(
       referenceType: referenceType ?? null,
       referenceId: referenceId ?? null,
       referenceNo: referenceNo ?? null,
+      unitCost: unitCost ?? null,
+      totalCost: unitCost != null ? unitCost * qty : null,
       performedById,
       notes: notes ?? null,
     },

--- a/src/lib/services/qc/mir-stock-sync.service.ts
+++ b/src/lib/services/qc/mir-stock-sync.service.ts
@@ -19,7 +19,7 @@ import { stockIn } from '@/lib/services/inv/inv-stock.service';
 
 type ResolvedItem = { id: string; defaultWhType: InvWarehouseType };
 
-function mapMaterialCategory(cat: string | null | undefined): InvItemCategory {
+export function mapMaterialCategory(cat: string | null | undefined): InvItemCategory {
   switch (cat) {
     case 'SHEET':
     case 'PLATE':
@@ -130,7 +130,7 @@ export async function syncMirStockIn(
       dolibarrPoRef: true,
       targetSiteId: true,
       items: {
-        select: { dolibarrProductId: true, acceptedQty: true },
+        select: { dolibarrProductId: true, acceptedQty: true, unitPrice: true },
       },
     },
   });
@@ -238,6 +238,7 @@ export async function syncMirStockIn(
           referenceId: mirId,
           referenceNo: receipt.receiptNumber,
           performedById,
+          unitCost: item.unitPrice ? Number(item.unitPrice) : undefined,
         });
       });
       posted++;


### PR DESCRIPTION
- Fix category mapping in stock page: sync-items now uses mapMaterialCategory
  (material_category field) so HEA/IPE profiles show Structural Steel, not Other.
  Existing items with wrong category are updated on every sync run.

- MIR inspection form: add Receive All / Accept All bulk action buttons.
  New quarantine_qty field for items pending further inspection with auto-
  computed rejected qty = received - accepted - quarantine.

- Material pricing: unit_price stored from PO line (subprice) at receipt
  creation; passed through MIR stock sync to inv_stock_ledger as unit_cost
  and total_cost for weighted average cost tracking.

- Purchases tab in material master detail panel: shows all stock-in movements
  for a product with date, MIR ref, supplier, qty, unit cost, total, weighted
  average price, and avg price per tonne.

- Sidebar fix: /inv Dashboard no longer stays active when sub-pages are open.
  Added /inv, /hr, /backlog/dashboard to exact-match list.

- Material master pagination: added 250/500/1000/5000/All page sizes and
  first/last page navigation (double-arrow) buttons.

- Stock page: client-side pagination with 50/100/250/500/All page sizes and
  first/last navigation buttons.

- Ledger API: extended to accept dolibarrId lookup and return unit_cost,
  total_cost, and supplier name for MIR entries.

Migrations: v44_0 (quarantine_qty, unit_price on MIR items),
            v44_1 (unit_cost, total_cost on inv_stock_ledger).

https://claude.ai/code/session_01MsAdDRK8KnWVCxNXwtiQAy