### PR TITLE
fix: add reference_no migration so inv_stock_ledger cost migration succeeds

### DIFF
--- a/prisma/manual_migrations/v44_1_inv_ledger_reference_no.sql
+++ b/prisma/manual_migrations/v44_1_inv_ledger_reference_no.sql
@@ -1,0 +1,19 @@
+-- v44_1: Add reference_no to inv_stock_ledger
+
+DROP PROCEDURE IF EXISTS _v44_reference_no;
+DELIMITER $$
+CREATE PROCEDURE _v44_reference_no()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME   = 'inv_stock_ledger'
+      AND COLUMN_NAME  = 'reference_no'
+  ) THEN
+    ALTER TABLE inv_stock_ledger
+      ADD COLUMN reference_no VARCHAR(50) NULL AFTER reference_id;
+  END IF;
+END$$
+DELIMITER ;
+CALL _v44_reference_no();
+DROP PROCEDURE IF EXISTS _v44_reference_no;

--- a/src/lib/startup-migrations.ts
+++ b/src/lib/startup-migrations.ts
@@ -277,6 +277,21 @@ const STARTUP_MIGRATIONS = [
 
   // ── v41.0.0 — INV: Sites table (factory/site canonical source) ───────────────
   'v41_0_inv_sites.sql',
+
+  // ── v42.0.0 — INV: Site source-code aliases for MIR routing ──────────────────
+  'v42_0_inv_site_source_codes.sql',
+
+  // ── v43.0.0 — INV: Rename PLATE→SHEET category; backfill from dolibarr_products ──
+  'v43_0_plate_to_sheet_and_category_fix.sql',
+
+  // ── v44.0.0 — MIR: quarantine_qty + unit_price on receipt items ──────────────
+  'v44_0_mir_quarantine_unit_price.sql',
+
+  // ── v44.1.0 — INV: reference_no on inv_stock_ledger ─────────────────────────
+  'v44_1_inv_ledger_reference_no.sql',
+
+  // ── v44.1.1 — INV: unit_cost + total_cost on inv_stock_ledger ────────────────
+  'v44_1_inv_ledger_cost.sql',
 ];
 
 /**


### PR DESCRIPTION
Creates v44_1_inv_ledger_reference_no.sql to add the reference_no column
to inv_stock_ledger before v44_1_inv_ledger_cost.sql runs (which positions
unit_cost AFTER reference_no). Also registers all missing migrations
(v42–v44) in the startup-migrations list.

https://claude.ai/code/session_01VztCgHnAnCZ4ZcsPVZYfcd