### PR TITLE
fix: handle session-expiry redirect gracefully on contract save

### DIFF
--- a/src/app/supply-chain/subcontractors/new/_page-client.tsx
+++ b/src/app/supply-chain/subcontractors/new/_page-client.tsx
@@ -269,8 +269,18 @@ export default function NewSubcontractorContractPage() {
         }),
       });
 
-      const data = await res.json() as { id?: string; contractNumber?: string; error?: string };
-      if (!res.ok) throw new Error(data.error ?? 'Failed to create contract');
+      if (res.redirected) {
+        throw new Error('Your session has expired. Please refresh the page and log in again.');
+      }
+      if (!res.ok) {
+        const ct = res.headers.get('content-type') ?? '';
+        if (ct.includes('application/json')) {
+          const errData = await res.json() as { error?: string };
+          throw new Error(errData.error ?? 'Failed to create contract');
+        }
+        throw new Error(`Request failed (${res.status}). Please refresh the page and try again.`);
+      }
+      const data = await res.json() as { id?: string; contractNumber?: string };
 
       if (action === 'submit' && data.id) {
         await fetch(`/api/subcontractor-contracts/${data.id}/status`, {


### PR DESCRIPTION
When the JWT expires while a user fills out the multi-step form, the
Next.js middleware redirects the POST to the HTML login page.  The old
code called res.json() unconditionally, causing the cryptic
"Unexpected token '<', <!DOCTYPE..." error.

Now checks res.redirected first, then falls back to Content-Type
inspection for non-2xx responses, so the user sees a clear
"session expired" message instead of a raw JSON parse error.

https://claude.ai/code/session_01FU8X1U7LW7gqhnSPamrVxQ