### PR TITLE
fix(monitoring): make restart loop self-diagnosing instead of "reason unknown"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **Restart loop diagnostics — stop guessing the cause.** The process was restarting every ~30s but every event logged as *"reason unknown"*. Root cause of the blindness: process memory was only sampled every 60s (so the run-up to a kill was never captured) and only `SIGTERM` was handled (but PM2 restarts via `SIGINT`), so the OOM detector could never fire. Now: memory is sampled every 5s with a persisted **peak RSS**; `SIGINT`/`SIGHUP` are handled alongside `SIGTERM`; restarts are classified using peak memory; a one-shot **heap snapshot** is written to `logs/heapsnapshots/` when RSS crosses 700MB (plus a V8 near-heap-limit backstop); and each API request's heap growth is attributed per-endpoint so the leaking route names itself in the restart event metadata (`topRoutesByHeapGrowth`). `max_memory_restart` raised 800M→1200M so the snapshot can finish before the kill.
+
+---
+
 ## [24.2.0] - 2026-05-31 — **Inventory & MIR: Pricing, Quarantine, Category Fix, Purchases History & Pagination**
 
 ### Added

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -7,9 +7,15 @@ module.exports = {
       cwd: '/var/www/hexasteel.sa/ots',
       instances: 1,
       exec_mode: 'fork',
-      node_args: '--max-old-space-size=1024 --expose-gc',
+      // --heapsnapshot-near-heap-limit=2: V8 writes a .heapsnapshot to the cwd
+      //   when it approaches the heap limit — a backstop that names the leaking
+      //   objects even if the in-process RSS watchdog misses.
+      node_args: '--max-old-space-size=1024 --expose-gc --heapsnapshot-near-heap-limit=2',
       watch: false,
-      max_memory_restart: '800M',
+      // Raised from 800M so the in-process heap-snapshot (triggered at ~700MB RSS)
+      // has headroom to finish writing before PM2 kills the process. If the host
+      // has < ~1.5GB RAM, lower this back toward 900M to avoid OS OOM kills.
+      max_memory_restart: '1200M',
       env: {
         NODE_ENV: 'production',
         PORT: 3000,

--- a/src/lib/api-utils.ts
+++ b/src/lib/api-utils.ts
@@ -15,6 +15,7 @@ import { auditService } from '@/lib/services/governance';
 import { eventService } from '@/lib/services/event.service';
 import { AuditAction } from '@prisma/client';
 import { logger } from '@/lib/logger';
+import { recordRouteMemory } from '@/lib/monitoring/leak-diagnostics';
 
 export interface SessionData {
   userId: string;
@@ -58,6 +59,7 @@ export function withApiContext<T = any>(
 ): (request: NextRequest, context?: { params: Record<string, string> }) => Promise<NextResponse> {
   return async (request: NextRequest, context?: { params: Record<string, string> }) => {
     const startMs = Date.now();
+    const heapBeforeBytes = process.memoryUsage().heapUsed;
     const method = request.method;
     const url = request.nextUrl.pathname;
 
@@ -89,8 +91,31 @@ export function withApiContext<T = any>(
       });
 
       const durationMs = Date.now() - startMs;
+      const mem = process.memoryUsage();
+      const heapDeltaMb = Math.round((mem.heapUsed - heapBeforeBytes) / 1024 / 1024);
+
+      // Attribute heap growth to the endpoint so a request-driven leak names
+      // itself in the heap-snapshot / restart event. Noisy by nature (GC and
+      // concurrency), but a route that repeatedly shows large positive deltas
+      // is the prime suspect.
+      if (heapDeltaMb >= 5) {
+        recordRouteMemory({
+          method,
+          url,
+          heapDeltaMb,
+          rssAfterMb: Math.round(mem.rss / 1024 / 1024),
+          durationMs,
+          at: new Date().toISOString(),
+        });
+      }
+      if (heapDeltaMb >= 40) {
+        logger.warn(
+          { method, url, durationMs, heapDeltaMb, rssAfterMb: Math.round(mem.rss / 1024 / 1024) },
+          '[API] Large heap growth in single request — possible leak source'
+        );
+      }
+
       if (durationMs >= SLOW_REQUEST_ERROR_MS) {
-        const mem = process.memoryUsage();
         logger.error(
           { method, url, durationMs, heapUsedMb: Math.round(mem.heapUsed / 1024 / 1024) },
           '[API] Very slow request — likely 502 source'

--- a/src/lib/monitoring/leak-diagnostics.ts
+++ b/src/lib/monitoring/leak-diagnostics.ts
@@ -1,0 +1,105 @@
+/**
+ * Leak Diagnostics
+ *
+ * Turns an otherwise-invisible memory leak into hard evidence:
+ *
+ *  1. Heap snapshot on demand — `writeHeapSnapshotOnce()` dumps a
+ *     `.heapsnapshot` file (openable in Chrome DevTools → Memory) the first
+ *     time the process crosses a memory threshold or receives a kill signal.
+ *     The snapshot names the retained objects, so the leak is identified by
+ *     class/closure rather than guessed at.
+ *
+ *  2. Per-route heap attribution — API routes feed `recordRouteMemory()` with
+ *     the heap delta of each request. We keep the worst offenders so the
+ *     snapshot / shutdown log can point at the endpoint that grows the heap.
+ *
+ * This module holds NO timers and registers NO handlers; it is pure state +
+ * helpers so it can be imported from both the request path (api-utils) and the
+ * restart logger without circular side effects.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import v8 from 'v8';
+import { logger } from '@/lib/logger';
+
+const LOGS_DIR = path.join(process.cwd(), 'logs');
+const SNAPSHOT_DIR = path.join(LOGS_DIR, 'heapsnapshots');
+
+// ── per-route memory attribution ─────────────────────────────────────────────
+
+export interface RouteMemSample {
+  method: string;
+  url: string;
+  heapDeltaMb: number;
+  rssAfterMb: number;
+  durationMs: number;
+  at: string;
+}
+
+/** Keep the worst N requests by heap growth observed this process lifetime. */
+const MAX_SAMPLES = 25;
+const worstSamples: RouteMemSample[] = [];
+
+export function recordRouteMemory(sample: RouteMemSample): void {
+  // Only worth tracking meaningful growth — ignore the noise floor.
+  if (sample.heapDeltaMb < 5) return;
+
+  worstSamples.push(sample);
+  worstSamples.sort((a, b) => b.heapDeltaMb - a.heapDeltaMb);
+  if (worstSamples.length > MAX_SAMPLES) worstSamples.length = MAX_SAMPLES;
+}
+
+export function getTopRouteMemory(n = 10): RouteMemSample[] {
+  return worstSamples.slice(0, n);
+}
+
+// ── heap snapshot (one per process) ──────────────────────────────────────────
+
+let _snapshotWritten = false;
+
+/**
+ * Write a single heap snapshot for this process. No-op on subsequent calls so a
+ * memory spike can't itself spiral into repeated multi-second snapshot writes.
+ *
+ * Returns the file path written, or null if skipped/failed.
+ */
+export function writeHeapSnapshotOnce(reason: string): string | null {
+  if (_snapshotWritten) return null;
+  _snapshotWritten = true;
+
+  try {
+    if (!fs.existsSync(SNAPSHOT_DIR)) fs.mkdirSync(SNAPSHOT_DIR, { recursive: true });
+
+    const mem = process.memoryUsage();
+    const file = path.join(
+      SNAPSHOT_DIR,
+      `heap-${new Date().toISOString().replace(/[:.]/g, '-')}-${reason}.heapsnapshot`,
+    );
+
+    // Synchronous and can block the event loop for a couple of seconds at high
+    // heap usage — acceptable for a once-per-process diagnostic that only fires
+    // when the process is already about to be killed.
+    const written = v8.writeHeapSnapshot(file);
+
+    logger.error(
+      {
+        file: written,
+        reason,
+        rssMb: Math.round(mem.rss / 1024 / 1024),
+        heapUsedMb: Math.round(mem.heapUsed / 1024 / 1024),
+        topRoutesByHeapGrowth: getTopRouteMemory(10),
+      },
+      '[LeakDiagnostics] Heap snapshot written — open in Chrome DevTools → Memory to identify retained objects',
+    );
+
+    return written;
+  } catch (err) {
+    logger.error({ err, reason }, '[LeakDiagnostics] Failed to write heap snapshot');
+    return null;
+  }
+}
+
+export function hasSnapshotBeenWritten(): boolean {
+  return _snapshotWritten;
+}

--- a/src/lib/monitoring/restart-logger.ts
+++ b/src/lib/monitoring/restart-logger.ts
@@ -4,29 +4,46 @@
  * Persists the reason for every PM2 restart so we can investigate the root cause.
  *
  * How it works:
- *  1. Writes process state (memory, uptime) to logs/process-state.json every minute
- *     using synchronous I/O so it survives OOM kills.
- *  2. On SIGTERM / uncaughtException / unhandledRejection writes
- *     logs/last-shutdown.json synchronously before the process exits.
- *  3. On startup, reads both files and posts a PROCESS_RESTART event to the DB:
- *       - CLEAN_SHUTDOWN   → SIGTERM received (cron restart or manual pm2 restart)
+ *  1. Writes process state (memory, uptime, peak RSS) to logs/process-state.json
+ *     every 5s using synchronous I/O so it survives OOM kills. The 5s cadence is
+ *     deliberate: the process was dying every ~30s while state was only written
+ *     every 60s, so the high-memory reading was never captured and every restart
+ *     was misclassified as "reason unknown".
+ *  2. On SIGTERM / SIGINT / SIGHUP (PM2 restarts via SIGINT) / uncaughtException /
+ *     unhandledRejection writes logs/last-shutdown.json synchronously, including
+ *     the memory at kill time, before the process exits.
+ *  3. When RSS climbs past SNAPSHOT_RSS_MB it writes a one-shot heap snapshot to
+ *     logs/heapsnapshots/ that names the retained objects causing the leak.
+ *  4. On startup, reads both files and posts a PROCESS_RESTART event to the DB:
+ *       - CLEAN_SHUTDOWN   → signal received with low memory (cron/manual restart)
  *       - CRASH_EXCEPTION  → uncaughtException
  *       - CRASH_REJECTION  → unhandledRejection
- *       - OOM_SUSPECTED    → no clean shutdown + last state showed rss ≥ 700 MB
- *       - UNKNOWN_RESTART  → process-state.json exists but no shutdown file
+ *       - OOM_SUSPECTED    → killed/signalled with peak rss ≥ OOM_RSS_MB
+ *       - UNKNOWN_RESTART  → hard kill with no shutdown file and low peak rss
  *       - FIRST_START      → no prior state at all
  */
 
 import fs from 'fs';
 import path from 'path';
 import { logger } from '@/lib/logger';
+import { writeHeapSnapshotOnce, getTopRouteMemory } from '@/lib/monitoring/leak-diagnostics';
 
 // ─── paths ─────────────────────────────────────────────────────────────────
 
 const LOGS_DIR = path.join(process.cwd(), 'logs');
 const SHUTDOWN_FILE = path.join(LOGS_DIR, 'last-shutdown.json');
 const STATE_FILE = path.join(LOGS_DIR, 'process-state.json');
-const STATE_INTERVAL_MS = 60_000; // 1 minute
+
+// Sample frequently so the run-up to a kill is always persisted.
+const STATE_INTERVAL_MS = 5_000;
+
+// RSS (MB) at which we proactively dump a heap snapshot. Set comfortably below
+// the PM2 max_memory_restart limit so the snapshot finishes before any kill.
+const SNAPSHOT_RSS_MB = 700;
+
+// Peak RSS (MB) at/above which a restart with no clean cause is attributed to
+// memory pressure rather than left as "unknown".
+const OOM_RSS_MB = 700;
 
 // ─── types ─────────────────────────────────────────────────────────────────
 
@@ -38,6 +55,8 @@ interface MemSnapshot {
 
 type ShutdownReason =
   | 'SIGTERM'
+  | 'SIGINT'
+  | 'SIGHUP'
   | 'UNCAUGHT_EXCEPTION'
   | 'UNHANDLED_REJECTION'
   | 'EXIT_NONZERO';
@@ -48,6 +67,8 @@ interface ShutdownRecord {
   error?: string;
   stack?: string;
   mem: MemSnapshot;
+  /** Highest RSS (MB) observed during this process's lifetime. */
+  peakRssMb: number;
   uptimeSec: number;
   timestamp: string;
 }
@@ -58,6 +79,16 @@ interface StateRecord {
   updatedAt: string;
   uptimeSec: number;
   mem: MemSnapshot;
+  /** Highest RSS (MB) observed so far — survives a kill that strikes between samples. */
+  peakRssMb: number;
+}
+
+// Running peak RSS for this process, updated on every sample / signal.
+let _peakRssMb = 0;
+
+function trackPeak(mem: MemSnapshot): number {
+  if (mem.rssMb > _peakRssMb) _peakRssMb = mem.rssMb;
+  return _peakRssMb;
 }
 
 // ─── helpers ────────────────────────────────────────────────────────────────
@@ -88,17 +119,26 @@ function readJsonSync<T>(filePath: string): T | null {
 }
 
 function writeStateSync(startedAt: Date): void {
+  const mem = currentMem();
+  const peakRssMb = trackPeak(mem);
   const state: StateRecord = {
     pid: process.pid,
     startedAt: startedAt.toISOString(),
     updatedAt: new Date().toISOString(),
     uptimeSec: Math.round(process.uptime()),
-    mem: currentMem(),
+    mem,
+    peakRssMb,
   };
   try {
     fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2), 'utf8');
   } catch {
     // non-fatal — disk full or permissions issue
+  }
+
+  // Capture the leak before the kill: dump a heap snapshot the first time RSS
+  // crosses the threshold. One per process — the guard lives in leak-diagnostics.
+  if (mem.rssMb >= SNAPSHOT_RSS_MB) {
+    writeHeapSnapshotOnce('high-rss');
   }
 }
 
@@ -138,15 +178,23 @@ async function postRestartEvent(
 
     const prevUptimeSec = prevState?.uptimeSec ?? null;
     const prevMem = prevState?.mem ?? shutdown?.mem ?? null;
+    const peakRssMb = Math.max(
+      prevState?.peakRssMb ?? 0,
+      shutdown?.peakRssMb ?? 0,
+      prevState?.mem.rssMb ?? 0,
+      shutdown?.mem.rssMb ?? 0,
+    ) || null;
     const errorMsg = shutdown?.error ?? null;
     const stack = shutdown?.stack ?? null;
+    const signal = shutdown?.reason ?? null;
+    const topRoutes = getTopRouteMemory(10);
 
     const titleMap: Record<RestartKind, string> = {
-      CLEAN_SHUTDOWN: 'Process restarted cleanly (SIGTERM)',
+      CLEAN_SHUTDOWN: `Process restarted cleanly${signal ? ` (${signal})` : ''}`,
       CRASH_EXCEPTION: `Process crashed — uncaughtException${errorMsg ? `: ${errorMsg.slice(0, 100)}` : ''}`,
       CRASH_REJECTION: `Process crashed — unhandledRejection${errorMsg ? `: ${errorMsg.slice(0, 100)}` : ''}`,
-      OOM_SUSPECTED: `Process killed — OOM suspected (RSS was ${prevMem?.rssMb ?? '?'} MB)`,
-      UNKNOWN_RESTART: 'Process restarted — reason unknown (no shutdown record)',
+      OOM_SUSPECTED: `Process killed — memory pressure (peak RSS ${peakRssMb ?? '?'} MB${signal ? `, ${signal}` : ', hard kill'})`,
+      UNKNOWN_RESTART: `Process restarted — hard kill, low memory (peak RSS ${peakRssMb ?? '?'} MB)`,
       FIRST_START: 'Process started for the first time',
     };
 
@@ -168,21 +216,30 @@ async function postRestartEvent(
         title: titleMap[kind],
         entityType: 'Process',
         entityId: String(process.pid),
-        metadata: {
-          kind,
-          prevUptimeSec,
-          prevMem,
-          exitCode: shutdown?.exitCode ?? null,
-          error: errorMsg,
-          stack,
-          prevStartedAt: prevState?.startedAt ?? null,
-          prevUpdatedAt: prevState?.updatedAt ?? null,
-        },
+        // JSON-serialize so the typed interfaces (MemSnapshot / RouteMemSample)
+        // satisfy Prisma's InputJsonValue and undefined fields are dropped.
+        metadata: JSON.parse(
+          JSON.stringify({
+            kind,
+            signal,
+            prevUptimeSec,
+            prevMem,
+            peakRssMb,
+            exitCode: shutdown?.exitCode ?? null,
+            error: errorMsg,
+            stack,
+            prevStartedAt: prevState?.startedAt ?? null,
+            prevUpdatedAt: prevState?.updatedAt ?? null,
+            // The endpoints that grew the heap the most before the kill — the
+            // prime suspects for a request-driven leak.
+            topRoutesByHeapGrowth: topRoutes,
+          }),
+        ),
       },
     });
 
     logger.info(
-      { kind, prevUptimeSec, prevRssMb: prevMem?.rssMb },
+      { kind, signal, prevUptimeSec, peakRssMb, topRoutes },
       '[RestartLogger] Restart event recorded',
     );
   } catch (err) {
@@ -200,23 +257,44 @@ function registerHandlers(): void {
   if (_handlersRegistered) return;
   _handlersRegistered = true;
 
-  process.once('SIGTERM', () => {
+  // PM2 stops a process with SIGINT, manual `pm2 restart` / OS shutdown use
+  // SIGTERM/SIGHUP. We record all three the same way: write a shutdown record
+  // with the memory at kill time so the next boot can tell a clean restart
+  // (low memory) apart from a memory-pressure kill (high peak RSS).
+  const onSignal = (signal: 'SIGTERM' | 'SIGINT' | 'SIGHUP') => () => {
+    const mem = currentMem();
+    const peakRssMb = trackPeak(mem);
     writeShutdownSync({
-      reason: 'SIGTERM',
-      mem: currentMem(),
+      reason: signal,
+      mem,
+      peakRssMb,
       uptimeSec: Math.round(process.uptime()),
       timestamp: new Date().toISOString(),
     });
-    logger.info({ uptimeSec: Math.round(process.uptime()) }, '[RestartLogger] SIGTERM received — clean shutdown');
-    // Let PM2 kill after kill_timeout; do NOT call process.exit() here
-  });
+    // If we're already near the limit, grab a snapshot in the kill window
+    // (PM2 kill_timeout gives us a few seconds before SIGKILL).
+    if (mem.rssMb >= SNAPSHOT_RSS_MB) writeHeapSnapshotOnce(`${signal}-high-rss`);
+    try {
+      logger.info({ signal, uptimeSec: Math.round(process.uptime()), rssMb: mem.rssMb, peakRssMb }, '[RestartLogger] Termination signal received');
+    } catch {
+      process.stderr.write(`[RestartLogger] ${signal} received (rss ${mem.rssMb} MB)\n`);
+    }
+    // Do NOT call process.exit(): let the existing graceful-shutdown handlers
+    // ($disconnect) run; PM2 force-kills after kill_timeout if needed.
+  };
+
+  process.once('SIGTERM', onSignal('SIGTERM'));
+  process.once('SIGINT', onSignal('SIGINT'));
+  process.once('SIGHUP', onSignal('SIGHUP'));
 
   process.on('uncaughtException', (err: Error) => {
+    const mem = currentMem();
     writeShutdownSync({
       reason: 'UNCAUGHT_EXCEPTION',
       error: err.message,
       stack: err.stack,
-      mem: currentMem(),
+      mem,
+      peakRssMb: trackPeak(mem),
       uptimeSec: Math.round(process.uptime()),
       timestamp: new Date().toISOString(),
     });
@@ -234,11 +312,13 @@ function registerHandlers(): void {
       reason instanceof Error ? reason.message : String(reason);
     const stack =
       reason instanceof Error ? reason.stack : undefined;
+    const mem = currentMem();
     writeShutdownSync({
       reason: 'UNHANDLED_REJECTION',
       error: message,
       stack,
-      mem: currentMem(),
+      mem,
+      peakRssMb: trackPeak(mem),
       uptimeSec: Math.round(process.uptime()),
       timestamp: new Date().toISOString(),
     });
@@ -271,18 +351,30 @@ export async function initRestartLogger(): Promise<void> {
   const prevState = readJsonSync<StateRecord>(STATE_FILE);
 
   // ── 2. Determine restart kind ──
+  // Peak RSS is the deciding signal: a process that was sitting near the memory
+  // ceiling and then disappeared was almost certainly killed for memory, whether
+  // PM2 did it via a signal or the OS OOM killer did it via SIGKILL.
+  const peakRssMb = Math.max(
+    prevState?.peakRssMb ?? 0,
+    prevState?.mem.rssMb ?? 0,
+    prevShutdown?.peakRssMb ?? 0,
+    prevShutdown?.mem.rssMb ?? 0,
+  );
+  const memoryPressure = peakRssMb >= OOM_RSS_MB;
+
   let kind: RestartKind;
 
   if (!prevState && !prevShutdown) {
     kind = 'FIRST_START';
   } else if (prevShutdown) {
-    if (prevShutdown.reason === 'SIGTERM') kind = 'CLEAN_SHUTDOWN';
-    else if (prevShutdown.reason === 'UNCAUGHT_EXCEPTION') kind = 'CRASH_EXCEPTION';
-    else kind = 'CRASH_REJECTION';
+    if (prevShutdown.reason === 'UNCAUGHT_EXCEPTION') kind = 'CRASH_EXCEPTION';
+    else if (prevShutdown.reason === 'UNHANDLED_REJECTION') kind = 'CRASH_REJECTION';
+    // SIGTERM / SIGINT / SIGHUP: PM2-initiated. High peak RSS ⇒ memory restart,
+    // otherwise a genuinely clean cron/manual restart.
+    else kind = memoryPressure ? 'OOM_SUSPECTED' : 'CLEAN_SHUTDOWN';
   } else {
-    // prevState exists but no shutdown record → ungraceful kill
-    const rssMb = prevState!.mem.rssMb;
-    kind = rssMb >= 700 ? 'OOM_SUSPECTED' : 'UNKNOWN_RESTART';
+    // prevState exists but no shutdown record → hard kill (SIGKILL / OS OOM).
+    kind = memoryPressure ? 'OOM_SUSPECTED' : 'UNKNOWN_RESTART';
   }
 
   // ── 3. Clean up files so next startup starts fresh ──


### PR DESCRIPTION
The process was restarting every ~30s, yet every PROCESS_RESTART event was
logged as "reason unknown" — so every prior fix was a guess. The diagnostics
were structurally unable to capture the cause:

  - process-state.json was written every 60s, but the process died at ~30s, so
    the high-memory run-up to the kill was never persisted. The OOM detector
    (rss >= 700MB) therefore never fired and always fell through to
    UNKNOWN_RESTART.
  - Only SIGTERM was handled, but PM2 restarts via SIGINT — so PM2-initiated
    kills left no shutdown record either.

This makes the next restart explain itself:

  - restart-logger: sample memory every 5s and persist a peak-RSS high-water
    mark; handle SIGINT/SIGHUP alongside SIGTERM (recording memory at kill
    time); classify restarts by peak RSS so a memory kill is reported as
    OOM_SUSPECTED whether PM2 signalled it or the OS OOM killer SIGKILLed it.
  - leak-diagnostics (new): write a one-shot heap snapshot to
    logs/heapsnapshots/ the first time RSS crosses 700MB (and on a high-memory
    kill signal) — the snapshot names the retained objects. Also keeps the
    worst API requests by heap growth.
  - api-utils: attribute per-request heap growth to the route, feeding the
    "topRoutesByHeapGrowth" list into the restart event metadata so a
    request-driven leak names its own endpoint.
  - ecosystem.config.js: add --heapsnapshot-near-heap-limit backstop and raise
    max_memory_restart 800M -> 1200M so the snapshot completes before the kill.

After deploy, the next restart event (and logs/heapsnapshots/) will identify
the exact leak; the targeted fix follows from that evidence.

https://claude.ai/code/session_01HzNmswAZcVpuB65GGJB2YJ