### PR TITLE
fix(build): stop server-only db chain leaking into client bundle

### DIFF
--- a/src/app/supply-chain/suppliers/[id]/_page-client.tsx
+++ b/src/app/supply-chain/suppliers/[id]/_page-client.tsx
@@ -18,7 +18,6 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { PaymentTermsBadge } from '@/components/supply-chain/PaymentTermsBadge';
 import { SoaTabContent } from '@/components/supply-chain/SoaTabContent';
 import { EvaluationScoreForm, EMPTY_EVALUATION_FORM, EvaluationFormData } from '@/components/supply-chain/EvaluationScoreForm';
-import { computeWeightedScore, scoreToRating, ratingToOutcome } from '@/lib/services/supply-chain/supplier-portal.service';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 

--- a/src/components/supply-chain/EvaluationScoreForm.tsx
+++ b/src/components/supply-chain/EvaluationScoreForm.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { computeWeightedScore, scoreToRating, ratingToOutcome } from '@/lib/services/supply-chain/supplier-portal.service';
+import { computeWeightedScore, scoreToRating, ratingToOutcome } from '@/lib/services/supply-chain/supplier-evaluation-scoring';
 
 export interface EvaluationFormData {
   evaluation_date: string;

--- a/src/lib/services/supply-chain/supplier-evaluation-scoring.ts
+++ b/src/lib/services/supply-chain/supplier-evaluation-scoring.ts
@@ -1,0 +1,49 @@
+/**
+ * Supplier Evaluation Scoring (ISO9001 Form-002)
+ *
+ * Pure, dependency-free scoring helpers shared by:
+ *  - the supplier-portal service (server)
+ *  - the EvaluationScoreForm client component (browser)
+ *
+ * Keep this module free of any server-only imports (db, fs, v8, …) so it can
+ * be safely bundled into client components without dragging Node built-ins
+ * into the browser bundle.
+ */
+
+// Weight constants (ISO9001 Form-002)
+const WEIGHTS = {
+  quality: 0.25,
+  delivery: 0.20,
+  price: 0.20,
+  service: 0.15,
+  documentation: 0.15,
+  hse: 0.05,
+};
+
+export function computeWeightedScore(scores: {
+  quality: number; delivery: number; price: number;
+  service: number; documentation: number; hse: number;
+}): number {
+  return (
+    scores.quality * 20 * WEIGHTS.quality +
+    scores.delivery * 20 * WEIGHTS.delivery +
+    scores.price * 20 * WEIGHTS.price +
+    scores.service * 20 * WEIGHTS.service +
+    scores.documentation * 20 * WEIGHTS.documentation +
+    scores.hse * 20 * WEIGHTS.hse
+  );
+}
+
+export function scoreToRating(score: number): string {
+  if (score >= 85) return 'A';
+  if (score >= 70) return 'B';
+  if (score >= 55) return 'C';
+  return 'D';
+}
+
+export function ratingToOutcome(rating: string): string {
+  if (rating === 'A') return 'APPROVED';
+  if (rating === 'B') return 'CONDITIONAL';
+  if (rating === 'C') return 'SUSPENDED';
+  return 'REJECTED';
+}

--- a/src/lib/services/supply-chain/supplier-portal.service.ts
+++ b/src/lib/services/supply-chain/supplier-portal.service.ts
@@ -1,6 +1,11 @@
 import prisma from '@/lib/db';
 import { logger } from '@/lib/logger';
 import { v4 as uuidv4 } from 'uuid';
+import {
+  computeWeightedScore,
+  scoreToRating,
+  ratingToOutcome,
+} from './supplier-evaluation-scoring';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -141,45 +146,12 @@ export interface CreatePaymentTermsInput {
 }
 
 // ---------------------------------------------------------------------------
-// Weight constants (ISO9001 Form-002)
+// Evaluation scoring (ISO9001 Form-002)
 // ---------------------------------------------------------------------------
-
-const WEIGHTS = {
-  quality: 0.25,
-  delivery: 0.20,
-  price: 0.20,
-  service: 0.15,
-  documentation: 0.15,
-  hse: 0.05,
-};
-
-export function computeWeightedScore(scores: {
-  quality: number; delivery: number; price: number;
-  service: number; documentation: number; hse: number;
-}): number {
-  return (
-    scores.quality * 20 * WEIGHTS.quality +
-    scores.delivery * 20 * WEIGHTS.delivery +
-    scores.price * 20 * WEIGHTS.price +
-    scores.service * 20 * WEIGHTS.service +
-    scores.documentation * 20 * WEIGHTS.documentation +
-    scores.hse * 20 * WEIGHTS.hse
-  );
-}
-
-export function scoreToRating(score: number): string {
-  if (score >= 85) return 'A';
-  if (score >= 70) return 'B';
-  if (score >= 55) return 'C';
-  return 'D';
-}
-
-export function ratingToOutcome(rating: string): string {
-  if (rating === 'A') return 'APPROVED';
-  if (rating === 'B') return 'CONDITIONAL';
-  if (rating === 'C') return 'SUSPENDED';
-  return 'REJECTED';
-}
+// Pure scoring helpers live in a dependency-free module so they can be shared
+// with client components without pulling the server-only db chain into the
+// browser bundle. Re-exported here for backward-compatible imports.
+export { computeWeightedScore, scoreToRating, ratingToOutcome };
 
 // ---------------------------------------------------------------------------
 // Supplier List


### PR DESCRIPTION
The supplier evaluation client components imported computeWeightedScore,
scoreToRating and ratingToOutcome from supplier-portal.service, which
transitively imports db.ts -> db-connection-pool -> leak-diagnostics
(uses fs/v8). This dragged Node built-ins into the client bundle and
broke 'next build' with 'Can't resolve fs/v8'.

Extract the pure scoring helpers into a dependency-free module
supplier-evaluation-scoring.ts and import them there from the client
components. The service re-exports them for backward-compatible imports.