### PR TITLE
Fix: Repair missing cost columns on inv_stock_ledger (v44.2)

### DIFF
--- a/prisma/manual_migrations/v44_2_inv_ledger_cost_repair.sql
+++ b/prisma/manual_migrations/v44_2_inv_ledger_cost_repair.sql
@@ -1,0 +1,41 @@
+-- v44_2: Ensure unit_cost and total_cost exist on inv_stock_ledger
+-- Re-applies the cost columns that v44_1_inv_ledger_cost previously failed to add
+-- because it referenced the non-existent column name 'reference_no' (snake_case)
+-- instead of the actual 'referenceNo' (camelCase). The original run was tracked as
+-- complete in _startup_migrations despite the ALTER TABLE silently failing.
+
+DROP PROCEDURE IF EXISTS _v44_2_unit_cost;
+DELIMITER $$
+CREATE PROCEDURE _v44_2_unit_cost()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME   = 'inv_stock_ledger'
+      AND COLUMN_NAME  = 'unit_cost'
+  ) THEN
+    ALTER TABLE inv_stock_ledger
+      ADD COLUMN unit_cost DECIMAL(12,4) NULL;
+  END IF;
+END$$
+DELIMITER ;
+CALL _v44_2_unit_cost();
+DROP PROCEDURE IF EXISTS _v44_2_unit_cost;
+
+DROP PROCEDURE IF EXISTS _v44_2_total_cost;
+DELIMITER $$
+CREATE PROCEDURE _v44_2_total_cost()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME   = 'inv_stock_ledger'
+      AND COLUMN_NAME  = 'total_cost'
+  ) THEN
+    ALTER TABLE inv_stock_ledger
+      ADD COLUMN total_cost DECIMAL(12,2) NULL;
+  END IF;
+END$$
+DELIMITER ;
+CALL _v44_2_total_cost();
+DROP PROCEDURE IF EXISTS _v44_2_total_cost;

--- a/src/lib/startup-migrations.ts
+++ b/src/lib/startup-migrations.ts
@@ -295,6 +295,9 @@ const STARTUP_MIGRATIONS = [
 
   // ── v44.1.1 — INV: unit_cost + total_cost on inv_stock_ledger ────────────────
   'v44_1_inv_ledger_cost.sql',
+
+  // ── v44.2.0 — INV: repair unit_cost + total_cost (v44.1.1 tracked-but-failed) ─
+  'v44_2_inv_ledger_cost_repair.sql',
 ];
 
 /**


### PR DESCRIPTION
## Summary
Adds a repair migration to correct a silent failure in v44.1.1 where cost columns (`unit_cost` and `total_cost`) were not added to `inv_stock_ledger` due to an incorrect column name reference in the original migration.

## Changes
- **New migration**: `v44_2_inv_ledger_cost_repair.sql`
  - Adds idempotent stored procedures to conditionally add `unit_cost` (DECIMAL 12,4) and `total_cost` (DECIMAL 12,2) columns if they don't already exist
  - Uses the standard MySQL-compatible conditional DDL pattern (stored procedure + information_schema check)
  - Follows naming convention with `_v44_2_` prefix for procedure names

- **Updated startup migrations**: `src/lib/startup-migrations.ts`
  - Registers the new repair migration to run after v44.1.1
  - Includes explanatory comment noting this repairs a tracked-but-failed migration

## Implementation Details
The original v44.1.1 migration silently failed because it referenced the non-existent column name `reference_no` (snake_case) instead of the actual `referenceNo` (camelCase). The migration was marked complete in `_startup_migrations` despite the ALTER TABLE failing. This repair migration ensures the columns are present on all environments by checking `information_schema.COLUMNS` before attempting to add them.

https://claude.ai/code/session_01VNWzKKjosZsSqATEscgsLw