### PR TITLE
Simplify CEO task visibility filter logic

### DIFF
--- a/src/app/api/tasks/dashboard/route.ts
+++ b/src/app/api/tasks/dashboard/route.ts
@@ -29,7 +29,7 @@ export async function GET() {
   // Fetch all tasks (non-CEO tasks unless user has manage_ceo_tasks)
   const canManageCeoTasks = userPermissions.includes('tasks.manage_ceo_tasks');
   const tasks = await prisma.task.findMany({
-    where: canManageCeoTasks ? {} : { OR: [{ isCeoTask: false }, { isCeoTask: null }] },
+    where: canManageCeoTasks ? {} : { isCeoTask: false },
     select: {
       id: true,
       assignedToId: true,

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -74,7 +74,7 @@ export async function GET(req: Request) {
         ],
       },
       // CEO task visibility: only users with manage_ceo_tasks can see CEO tasks
-      canManageCeoTasks ? {} : { OR: [{ isCeoTask: false }, { isCeoTask: null }] },
+      canManageCeoTasks ? {} : { isCeoTask: false },
     ];
   } else if (canViewOthers) {
     // Users with tasks.view_others can see other users' tasks but not all tasks
@@ -88,7 +88,7 @@ export async function GET(req: Request) {
         ],
       },
       // Users without manage_ceo_tasks cannot see CEO tasks
-      canManageCeoTasks ? {} : { OR: [{ isCeoTask: false }, { isCeoTask: null }] },
+      canManageCeoTasks ? {} : { isCeoTask: false },
     ];
     // Apply assignedTo filter if specified
     if (assignedTo) {
@@ -102,7 +102,7 @@ export async function GET(req: Request) {
     ];
     // Users without manage_ceo_tasks cannot see CEO tasks even if assigned
     if (!canManageCeoTasks) {
-      whereClause.AND = [{ OR: [{ isCeoTask: false }, { isCeoTask: null }] }];
+      whereClause.AND = [{ isCeoTask: false }];
     }
   }
 


### PR DESCRIPTION
## Summary
Simplified the CEO task visibility filter conditions across task API endpoints by removing redundant `null` checks. The filter now explicitly checks `isCeoTask: false` instead of using an OR condition that includes both `false` and `null` values.

## Changes
- **src/app/api/tasks/route.ts**: Updated three filter conditions (lines 77, 91, 105) to use `{ isCeoTask: false }` instead of `{ OR: [{ isCeoTask: false }, { isCeoTask: null }] }`
- **src/app/api/tasks/dashboard/route.ts**: Updated the dashboard task filter (line 32) with the same simplification

## Implementation Details
This change assumes that the `isCeoTask` column is properly constrained in the database schema (likely with a default value or NOT NULL constraint) such that null values are not expected in normal operation. The simplified filter is more readable and maintains the same functional behavior: users without `tasks.manage_ceo_tasks` permission will only see tasks where `isCeoTask` is explicitly `false`.

This aligns with the principle of explicit, deterministic logic over implicit conditions.

https://claude.ai/code/session_018qHK2oBQMM7Q2YrWyD5yZG