### PR TITLE
Fix task progress computation to filter by buildingId only

### DIFF
--- a/src/lib/services/project-tracker.service.ts
+++ b/src/lib/services/project-tracker.service.ts
@@ -115,7 +115,7 @@ async function computeTaskProgress(
   const tasks = await prisma.task.findMany({
     where: {
       projectId,
-      OR: [{ buildingId }, { buildingId: null }],
+      buildingId,
       mainActivity,
       deletedAt: null,
     },


### PR DESCRIPTION
## Summary
Simplified the task query filter in `computeTaskProgress` to remove unnecessary OR logic that was allowing tasks with null buildingId when a specific buildingId was provided.

## Changes
- **src/lib/services/project-tracker.service.ts**: Changed the task filter from `OR: [{ buildingId }, { buildingId: null }]` to `buildingId` only
  - This ensures that when computing progress for a specific building, only tasks assigned to that building are included
  - Removes the unintended inclusion of unassigned (null buildingId) tasks in the progress calculation

## Implementation Details
The previous OR condition was overly permissive—it would match tasks either assigned to the specified building OR with no building assignment. The corrected filter now strictly matches only tasks with the exact buildingId, improving data accuracy for project progress tracking.

https://claude.ai/code/session_01KJFgSRU7zHBb6YGepXaHdx