### PR TITLE
Fix SearchableSelect dropdown positioning to open upward

### DIFF
--- a/src/components/tasks-client.tsx
+++ b/src/components/tasks-client.tsx
@@ -174,7 +174,7 @@ function SearchableSelect({
         <ChevronDown className="size-3 shrink-0 text-slate-400" />
       </button>
       {open && (
-        <div className="absolute top-full left-0 mt-1 z-50 w-56 rounded-lg border bg-white shadow-lg">
+        <div className="absolute bottom-full left-0 mb-1 z-50 w-56 rounded-lg border bg-white shadow-lg">
           <div className="p-2 border-b">
             <input
               autoFocus


### PR DESCRIPTION
## Summary
Changed the SearchableSelect dropdown menu to open upward instead of downward by swapping the positioning classes from `top-full mt-1` to `bottom-full mb-1`.

## Changes
- Updated dropdown container positioning in `src/components/tasks-client.tsx`
  - Changed from `top-full left-0 mt-1` (opens below trigger) to `bottom-full left-0 mb-1` (opens above trigger)
  - This prevents the dropdown from being cut off when the select is near the bottom of the viewport

## Implementation Details
The SearchableSelect component now positions its dropdown menu above the trigger button instead of below it. This improves UX when the component is used in constrained vertical spaces by ensuring the dropdown menu remains visible and accessible.

https://claude.ai/code/session_01TBy9kwCRVhercafCSTDjRR