### PR TITLE
feat(hr): Saudi Labor Law unauthorized-absence alerts & escalation (OTS-BL-080)

### DIFF
--- a/prisma/manual_migrations/v45_0_employee_absence_alerts.sql
+++ b/prisma/manual_migrations/v45_0_employee_absence_alerts.sql
@@ -1,0 +1,50 @@
+-- v45.0.0 — Saudi Labor Law Unauthorized-Absence Alerts (OTS-BL-080)
+-- Persisted, scheduled escalation of ANP (ABSENT_NO_PERMISSION) attendance.
+-- Idempotent: creates the EmployeeAbsenceAlert table only if it does not exist.
+
+DROP PROCEDURE IF EXISTS create_employee_absence_alert;
+DELIMITER $$
+CREATE PROCEDURE create_employee_absence_alert()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'EmployeeAbsenceAlert'
+  ) THEN
+    CREATE TABLE `EmployeeAbsenceAlert` (
+      `id`                    CHAR(36)     NOT NULL,
+      `employeeId`            CHAR(36)     NOT NULL,
+      `windowType`            ENUM('CONSECUTIVE','INTERMITTENT') NOT NULL,
+      `kind`                  ENUM('PRE_THRESHOLD','THRESHOLD') NOT NULL,
+      `thresholdDays`         INT          NOT NULL,
+      `anpDays`               INT          NOT NULL,
+      `severity`              VARCHAR(10)  NOT NULL,
+      `recommendedLetterType` VARCHAR(40)  NULL,
+      `status`                ENUM('OPEN','ACKNOWLEDGED','LETTER_LINKED','RESOLVED','DISMISSED') NOT NULL DEFAULT 'OPEN',
+      `periodFrom`            DATE         NOT NULL,
+      `periodTo`              DATE         NOT NULL,
+      `detail`                VARCHAR(500) NOT NULL,
+      `meta`                  JSON         NULL,
+      `dedupeKey`             VARCHAR(180) NOT NULL,
+      `linkedLetterId`        CHAR(36)     NULL,
+      `notifiedAt`            DATETIME(3)  NULL,
+      `acknowledgedById`      CHAR(36)     NULL,
+      `acknowledgedAt`        DATETIME(3)  NULL,
+      `resolvedById`          CHAR(36)     NULL,
+      `resolvedAt`            DATETIME(3)  NULL,
+      `deletedAt`             DATETIME(3)  NULL,
+      `createdAt`             DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+      `updatedAt`             DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+      PRIMARY KEY (`id`),
+      UNIQUE KEY `EmployeeAbsenceAlert_dedupeKey_key` (`dedupeKey`),
+      KEY `EmployeeAbsenceAlert_employeeId_status_idx` (`employeeId`,`status`),
+      KEY `EmployeeAbsenceAlert_status_idx` (`status`),
+      KEY `EmployeeAbsenceAlert_severity_idx` (`severity`),
+      KEY `EmployeeAbsenceAlert_createdAt_idx` (`createdAt`),
+      KEY `EmployeeAbsenceAlert_linkedLetterId_idx` (`linkedLetterId`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+  END IF;
+END$$
+DELIMITER ;
+
+CALL create_employee_absence_alert();
+DROP PROCEDURE IF EXISTS create_employee_absence_alert;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -4565,6 +4565,9 @@ model Employee {
   // 19.16.0 — Circulations
   circulationRecipients HrCirculationRecipient[] @relation("EmployeeCirculationRecipients")
 
+  // Saudi Labor Law unauthorized-absence alerts (OTS-BL-080)
+  absenceAlerts EmployeeAbsenceAlert[] @relation("EmployeeAbsenceAlerts")
+
   // 22.2.0 — IMS Competence Matrix
   competenceEntries ImsCompetenceEntry[]
 
@@ -5894,6 +5897,9 @@ model HrLetter {
   deletedBy    User?     @relation("HrLetterDeletedBy", fields: [deletedById], references: [id])
   deleteReason String?   @db.VarChar(500)
 
+  // OTS-BL-080 — alerts that recommended/linked this disciplinary letter
+  absenceAlerts EmployeeAbsenceAlert[] @relation("AbsenceAlertLetter")
+
   @@index([employeeId])
   @@index([letterType, classification])
   @@index([status])
@@ -5983,6 +5989,76 @@ model HrCirculationRecipient {
   @@index([employeeId])
   @@index([departmentId])
   @@map("HrCirculationRecipient")
+}
+
+// ============================================================================
+// Saudi Labor Law — Unauthorized Absence Alerts & Escalation (OTS-BL-080)
+// ============================================================================
+// Persisted, scheduled escalation of ABSENT_NO_PERMISSION (ANP) attendance.
+// Two ladders per the labour-law policy:
+//   • CONSECUTIVE  — 5 / 10 / 15 unbroken ANP days (weekend-transparent)
+//   • INTERMITTENT — 10 / 20 / 30 ANP days over a rolling trailing 12 months
+// PRE_THRESHOLD alerts fire a few days before each boundary so HR can act in
+// time. THRESHOLD alerts recommend the matching HrLetterType (recommend-only —
+// no letter is issued automatically). Idempotent via the unique dedupeKey.
+
+enum AbsenceWindowType {
+  CONSECUTIVE
+  INTERMITTENT
+}
+
+enum AbsenceAlertKind {
+  PRE_THRESHOLD
+  THRESHOLD
+}
+
+enum AbsenceAlertStatus {
+  OPEN
+  ACKNOWLEDGED
+  LETTER_LINKED
+  RESOLVED
+  DISMISSED
+}
+
+model EmployeeAbsenceAlert {
+  id         String   @id @default(uuid()) @db.Char(36)
+  employeeId String   @db.Char(36)
+  employee   Employee @relation("EmployeeAbsenceAlerts", fields: [employeeId], references: [id])
+
+  windowType    AbsenceWindowType
+  kind          AbsenceAlertKind
+  thresholdDays Int // stage boundary: 5/10/15 (consecutive) or 10/20/30 (intermittent)
+  anpDays       Int // actual ANP day count at detection
+  severity      String  @db.VarChar(10) // LOW | MEDIUM | HIGH
+  recommendedLetterType String? @db.VarChar(40) // HrLetterType value; null for PRE_THRESHOLD
+
+  status     AbsenceAlertStatus @default(OPEN)
+  periodFrom DateTime           @db.Date
+  periodTo   DateTime           @db.Date
+  detail     String             @db.VarChar(500)
+  meta       Json?
+
+  // Deterministic idempotency key — prevents duplicate alerts on daily re-runs.
+  dedupeKey String @unique @db.VarChar(180)
+
+  linkedLetterId String?   @db.Char(36)
+  linkedLetter   HrLetter? @relation("AbsenceAlertLetter", fields: [linkedLetterId], references: [id])
+
+  notifiedAt       DateTime?
+  acknowledgedById String?   @db.Char(36)
+  acknowledgedAt   DateTime?
+  resolvedById     String?   @db.Char(36)
+  resolvedAt       DateTime?
+
+  deletedAt DateTime?
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+
+  @@index([employeeId, status])
+  @@index([status])
+  @@index([severity])
+  @@index([createdAt])
+  @@map("EmployeeAbsenceAlert")
 }
 
 // ============================================================================

--- a/src/app/api/hr/absence-alerts/[id]/action/route.ts
+++ b/src/app/api/hr/absence-alerts/[id]/action/route.ts
@@ -1,0 +1,123 @@
+/**
+ * POST /api/hr/absence-alerts/[id]/action — act on an absence alert (OTS-BL-080).
+ *
+ * Body: { action: 'acknowledge' | 'resolve' | 'dismiss' | 'create-letter', reason? }
+ *  - acknowledge   OPEN → ACKNOWLEDGED
+ *  - resolve       → RESOLVED
+ *  - dismiss       → DISMISSED (false positive)
+ *  - create-letter creates a PENDING_CEO disciplinary letter of the recommended
+ *    type for the employee and links it (status → LETTER_LINKED). Recommend-only:
+ *    nothing is issued until HR explicitly calls this.
+ *
+ * Gated by hr.analytics.view.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import prisma from '@/lib/db';
+import { withApiContext, logActivity } from '@/lib/api-utils';
+import { checkPermission } from '@/lib/permission-checker';
+import { logger } from '@/lib/logger';
+import { createAlertLetter } from '@/lib/services/hr/create-alert-letter';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+const bodySchema = z.object({
+  action: z.enum(['acknowledge', 'resolve', 'dismiss', 'create-letter']),
+  reason: z.string().max(500).optional(),
+});
+
+/** Human-readable subject/body for an auto-suggested disciplinary letter. */
+function letterTemplate(windowType: string, thresholdDays: number, anpDays: number): { subject: string; content: string } {
+  const windowLabel = windowType === 'CONSECUTIVE' ? 'consecutive' : 'intermittent (over the past 12 months)';
+  return {
+    subject: `Notice regarding unauthorized absence — ${thresholdDays} ${windowType === 'CONSECUTIVE' ? 'consecutive' : ''} days`.replace('  ', ' ').trim(),
+    content:
+      `This letter concerns your unauthorized absence from work. Our records show ${anpDays} ${windowLabel} ` +
+      `day(s) of absence without permission, which has reached the ${thresholdDays}-day threshold under the company's ` +
+      `absence policy and the Saudi Labor Law. You are required to provide a justification. Continued or repeated ` +
+      `unauthorized absence may lead to further disciplinary action up to termination in accordance with the policy.`,
+  };
+}
+
+export const POST = withApiContext(async (req: NextRequest, session, ctx: RouteParams) => {
+  if (!(await checkPermission('hr.analytics.view'))) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const { id } = await ctx.params;
+  const body: unknown = await req.json();
+  const parsed = bodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input', details: parsed.error.flatten() }, { status: 400 });
+  }
+  const { action, reason } = parsed.data;
+  const userId = session!.userId;
+
+  const alert = await prisma.employeeAbsenceAlert.findFirst({
+    where: { id, deletedAt: null },
+    include: { employee: { select: { id: true, fullNameEn: true } } },
+  });
+  if (!alert) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+  try {
+    if (action === 'create-letter') {
+      if (!alert.recommendedLetterType) {
+        return NextResponse.json({ error: 'This alert has no recommended letter (pre-threshold).' }, { status: 422 });
+      }
+      if (alert.linkedLetterId) {
+        return NextResponse.json({ error: 'A letter is already linked to this alert.' }, { status: 409 });
+      }
+
+      const tpl = letterTemplate(alert.windowType, alert.thresholdDays, alert.anpDays);
+      const letter = await createAlertLetter({
+        employeeId: alert.employeeId,
+        letterType: alert.recommendedLetterType,
+        subject: tpl.subject,
+        content: tpl.content,
+        createdById: userId,
+      });
+
+      const updated = await prisma.employeeAbsenceAlert.update({
+        where: { id },
+        data: { linkedLetterId: letter.id, status: 'LETTER_LINKED' },
+        include: { linkedLetter: { select: { id: true, letterNumber: true, letterType: true, status: true } } },
+      });
+
+      await logActivity({
+        action: 'CREATE',
+        entityType: 'EmployeeAbsenceAlert',
+        entityId: id,
+        entityName: `${alert.employee.fullNameEn} — ${alert.recommendedLetterType} (${letter.letterNumber})`,
+        userId,
+        reason: reason ?? `Letter ${letter.letterNumber} created from absence alert`,
+      });
+
+      return NextResponse.json(updated);
+    }
+
+    // Status-only transitions
+    const data =
+      action === 'acknowledge'
+        ? { status: 'ACKNOWLEDGED' as const, acknowledgedById: userId, acknowledgedAt: new Date() }
+        : action === 'resolve'
+          ? { status: 'RESOLVED' as const, resolvedById: userId, resolvedAt: new Date() }
+          : { status: 'DISMISSED' as const, resolvedById: userId, resolvedAt: new Date() };
+
+    const updated = await prisma.employeeAbsenceAlert.update({ where: { id }, data });
+
+    await logActivity({
+      action: 'UPDATE',
+      entityType: 'EmployeeAbsenceAlert',
+      entityId: id,
+      entityName: `${alert.employee.fullNameEn} — ${action}`,
+      userId,
+      reason,
+    });
+
+    return NextResponse.json(updated);
+  } catch (error) {
+    logger.error({ error, id, action }, '[Absence Alerts] Action failed');
+    return NextResponse.json({ error: 'Action failed' }, { status: 500 });
+  }
+});

--- a/src/app/api/hr/absence-alerts/evaluate/route.ts
+++ b/src/app/api/hr/absence-alerts/evaluate/route.ts
@@ -1,0 +1,37 @@
+/**
+ * POST /api/hr/absence-alerts/evaluate — run the absence-escalation engine now.
+ *
+ * Two authorised callers:
+ *   • Cron — Authorization: Bearer <CRON_SECRET> (see CRON_JOB_REGISTRY).
+ *   • Manual — an authenticated user holding hr.analytics.view (UI "Run now").
+ *
+ * Idempotent: re-running never creates duplicate alerts (dedupeKey). (OTS-BL-080)
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { withApiContext } from '@/lib/api-utils';
+import { checkPermission } from '@/lib/permission-checker';
+import { env } from '@/lib/env';
+import { logger } from '@/lib/logger';
+import { evaluateAbsenceEscalations } from '@/lib/services/hr/absence-escalation.service';
+
+export const POST = withApiContext(
+  async (req: NextRequest, session) => {
+    const authHeader = req.headers.get('authorization');
+    const viaCron = !!env.CRON_SECRET && authHeader === `Bearer ${env.CRON_SECRET}`;
+    const viaUser = !viaCron && (await checkPermission('hr.analytics.view'));
+
+    if (!viaCron && !viaUser) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    try {
+      const result = await evaluateAbsenceEscalations({ triggeredById: session?.userId });
+      return NextResponse.json({ ok: true, ...result });
+    } catch (error) {
+      logger.error({ error }, '[Absence Alerts] Evaluation failed');
+      return NextResponse.json({ error: 'Evaluation failed' }, { status: 500 });
+    }
+  },
+  { requireAuth: false },
+);

--- a/src/app/api/hr/absence-alerts/route.ts
+++ b/src/app/api/hr/absence-alerts/route.ts
@@ -1,0 +1,90 @@
+/**
+ * GET /api/hr/absence-alerts — list persisted unauthorized-absence alerts (OTS-BL-080).
+ *
+ * Optional filters: ?status= ?windowType= ?severity= ?kind= ?q= (employee name/employmentId)
+ * Pagination: ?page= ?pageSize=  (sorting is done client-side, paginated-list pattern).
+ * Gated by hr.analytics.view.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import prisma from '@/lib/db';
+import { withApiContext } from '@/lib/api-utils';
+import { checkPermission } from '@/lib/permission-checker';
+import { logger } from '@/lib/logger';
+import type { Prisma } from '@prisma/client';
+
+const querySchema = z.object({
+  status: z.enum(['OPEN', 'ACKNOWLEDGED', 'LETTER_LINKED', 'RESOLVED', 'DISMISSED']).optional(),
+  windowType: z.enum(['CONSECUTIVE', 'INTERMITTENT']).optional(),
+  severity: z.enum(['LOW', 'MEDIUM', 'HIGH']).optional(),
+  kind: z.enum(['PRE_THRESHOLD', 'THRESHOLD']).optional(),
+  q: z.string().max(120).optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce.number().int().min(1).max(500).default(100),
+});
+
+const ALERT_INCLUDE = {
+  employee: { select: { id: true, fullNameEn: true, fullNameAr: true, employmentId: true, occupation: true, section: true } },
+  linkedLetter: { select: { id: true, letterNumber: true, letterType: true, status: true } },
+} satisfies Prisma.EmployeeAbsenceAlertInclude;
+
+export const GET = withApiContext(async (req: NextRequest) => {
+  if (!(await checkPermission('hr.analytics.view'))) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const parsed = querySchema.safeParse(Object.fromEntries(searchParams));
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid query', details: parsed.error.flatten() }, { status: 400 });
+  }
+  const { status, windowType, severity, kind, q, page, pageSize } = parsed.data;
+
+  const where: Prisma.EmployeeAbsenceAlertWhereInput = {
+    deletedAt: null,
+    ...(status ? { status } : {}),
+    ...(windowType ? { windowType } : {}),
+    ...(severity ? { severity } : {}),
+    ...(kind ? { kind } : {}),
+    ...(q
+      ? {
+          employee: {
+            OR: [
+              { fullNameEn: { contains: q } },
+              { fullNameAr: { contains: q } },
+              { employmentId: { contains: q } },
+            ],
+          },
+        }
+      : {}),
+  };
+
+  try {
+    const [total, alerts, openCount, highCount, letterLinkedCount, flaggedEmployees] = await Promise.all([
+      prisma.employeeAbsenceAlert.count({ where }),
+      prisma.employeeAbsenceAlert.findMany({
+        where,
+        include: ALERT_INCLUDE,
+        orderBy: [{ createdAt: 'desc' }],
+        skip: (page - 1) * pageSize,
+        take: pageSize,
+      }),
+      prisma.employeeAbsenceAlert.count({ where: { deletedAt: null, status: 'OPEN' } }),
+      prisma.employeeAbsenceAlert.count({ where: { deletedAt: null, severity: 'HIGH', status: { in: ['OPEN', 'ACKNOWLEDGED'] } } }),
+      prisma.employeeAbsenceAlert.count({ where: { deletedAt: null, status: 'LETTER_LINKED' } }),
+      prisma.employeeAbsenceAlert
+        .findMany({ where: { deletedAt: null, status: { in: ['OPEN', 'ACKNOWLEDGED'] } }, select: { employeeId: true }, distinct: ['employeeId'] })
+        .then((rows) => rows.length),
+    ]);
+
+    return NextResponse.json({
+      alerts,
+      pagination: { page, pageSize, total, totalPages: Math.ceil(total / pageSize) },
+      kpis: { open: openCount, high: highCount, letterLinked: letterLinkedCount, flaggedEmployees },
+    });
+  } catch (error) {
+    logger.error({ error }, '[Absence Alerts] Failed to list alerts');
+    return NextResponse.json({ error: 'Failed to list absence alerts' }, { status: 500 });
+  }
+});

--- a/src/app/api/hr/analytics/absence/route.ts
+++ b/src/app/api/hr/analytics/absence/route.ts
@@ -20,6 +20,7 @@ import { verifySession } from '@/lib/jwt';
 import { checkPermission } from '@/lib/permission-checker';
 import { logger } from '@/lib/logger';
 import prisma from '@/lib/db';
+import { longestStreak } from '@/lib/services/hr/absence-streak';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -91,34 +92,9 @@ function monthKey(d: Date): string {
   return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`;
 }
 
-/** Two ANP dates are part of the same consecutive streak if their gap is ≤ 3 days
- *  (bridges a Fri/Sat/Sun weekend so Thu→Mon counts as consecutive). */
-function isConsecutiveGap(a: Date, b: Date): boolean {
-  const diffMs = b.getTime() - a.getTime();
-  const diffDays = diffMs / 86_400_000;
-  return diffDays > 0 && diffDays <= 3;
-}
-
-/** Find longest run of "consecutive" ANP dates (weekends transparent). */
-function longestStreak(dates: Date[]): { length: number; start: Date; end: Date } | null {
-  if (dates.length === 0) return null;
-  const sorted = [...dates].sort((a, b) => a.getTime() - b.getTime());
-  let best = { length: 1, start: sorted[0], end: sorted[0] };
-  let runStart = sorted[0];
-  let runLen = 1;
-  for (let i = 1; i < sorted.length; i++) {
-    if (isConsecutiveGap(sorted[i - 1], sorted[i])) {
-      runLen++;
-      if (runLen > best.length) {
-        best = { length: runLen, start: runStart, end: sorted[i] };
-      }
-    } else {
-      runStart = sorted[i];
-      runLen = 1;
-    }
-  }
-  return best;
-}
+// Streak helpers (isConsecutiveGap, longestStreak) live in
+// '@/lib/services/hr/absence-streak' so the analytics view and the persisted
+// escalation engine share one weekend-transparent definition.
 
 // ---------------------------------------------------------------------------
 // Main handler

--- a/src/app/hr/absence-alerts/page.tsx
+++ b/src/app/hr/absence-alerts/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { verifySession } from '@/lib/jwt';
+import { getCurrentUserPermissions } from '@/lib/permission-checker';
+import { AbsenceAlertsClient } from '@/components/hr/absence-alerts-client';
+
+export const metadata: Metadata = { title: 'Absence Alerts' };
+
+export default async function AbsenceAlertsPage() {
+  const store = await cookies();
+  const token = store.get(process.env.COOKIE_NAME || 'ots_session')?.value;
+  const session = token ? verifySession(token) : null;
+  if (!session) redirect('/login');
+
+  const perms = await getCurrentUserPermissions();
+  if (!perms.includes('hr.analytics.view')) {
+    redirect('/unauthorized?from=/hr/absence-alerts');
+  }
+
+  return <AbsenceAlertsClient />;
+}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -362,6 +362,7 @@ const navigationSections: NavigationSection[] = [
       { name: 'HR Dashboard', href: '/hr/dashboard', icon: BarChart3, newSince: '2026-04-12' },
       { name: 'HR Monthly Reports', href: '/hr/reports', icon: FileBarChart2, newSince: '2026-05-08' },
       { name: 'Absence Analytics', href: '/hr/analytics', icon: TrendingUp, newSince: '2026-04-18' },
+      { name: 'Absence Alerts', href: '/hr/absence-alerts', icon: ShieldAlert, newSince: '2026-06-05' },
       { name: 'Employees', href: '/hr/employees', icon: Users, newSince: '2026-04-12' },
       { name: 'Organization Chart', href: '/hr/organization-chart', icon: Network, newSince: '2026-05-08' },
       { name: 'Organization Setup', href: '/hr/organization-setup', icon: GitBranch, newSince: '2026-05-08' },

--- a/src/components/hr/absence-alerts-client.tsx
+++ b/src/components/hr/absence-alerts-client.tsx
@@ -1,0 +1,499 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  AlertTriangle,
+  ShieldAlert,
+  Users,
+  FileWarning,
+  Loader2,
+  RefreshCw,
+  Check,
+  X,
+  CheckCircle2,
+  FileText,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+// ---------------------------------------------------------------------------
+// Types (shape returned by GET /api/hr/absence-alerts)
+// ---------------------------------------------------------------------------
+
+interface Alert {
+  id: string;
+  employeeId: string;
+  windowType: 'CONSECUTIVE' | 'INTERMITTENT';
+  kind: 'PRE_THRESHOLD' | 'THRESHOLD';
+  thresholdDays: number;
+  anpDays: number;
+  severity: 'LOW' | 'MEDIUM' | 'HIGH';
+  recommendedLetterType: string | null;
+  status: 'OPEN' | 'ACKNOWLEDGED' | 'LETTER_LINKED' | 'RESOLVED' | 'DISMISSED';
+  periodFrom: string;
+  periodTo: string;
+  detail: string;
+  createdAt: string;
+  linkedLetterId: string | null;
+  employee: { id: string; fullNameEn: string; employmentId: string; occupation: string | null; section: string | null };
+  linkedLetter: { id: string; letterNumber: string; letterType: string; status: string } | null;
+}
+
+interface Kpis {
+  open: number;
+  high: number;
+  letterLinked: number;
+  flaggedEmployees: number;
+}
+
+type StatusFilter = 'ALL' | Alert['status'];
+type WindowFilter = 'ALL' | Alert['windowType'];
+type SeverityFilter = 'ALL' | Alert['severity'];
+
+// ---------------------------------------------------------------------------
+// Presentation helpers
+// ---------------------------------------------------------------------------
+
+const SEVERITY_STYLE: Record<string, string> = {
+  HIGH: 'bg-rose-100 text-rose-700 border-rose-200',
+  MEDIUM: 'bg-amber-100 text-amber-700 border-amber-200',
+  LOW: 'bg-sky-100 text-sky-700 border-sky-200',
+};
+
+const STATUS_STYLE: Record<string, string> = {
+  OPEN: 'bg-rose-100 text-rose-700 border-rose-200',
+  ACKNOWLEDGED: 'bg-amber-100 text-amber-700 border-amber-200',
+  LETTER_LINKED: 'bg-violet-100 text-violet-700 border-violet-200',
+  RESOLVED: 'bg-emerald-100 text-emerald-700 border-emerald-200',
+  DISMISSED: 'bg-slate-100 text-slate-500 border-slate-200',
+};
+
+function fmtDate(s: string): string {
+  return new Date(s).toLocaleDateString('en-SA-u-ca-gregory', { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+function letterLabel(t: string | null): string {
+  return t ? t.replace(/_/g, ' ').toLowerCase().replace(/\b\w/g, (c) => c.toUpperCase()) : '—';
+}
+
+type Tone = 'rose' | 'amber' | 'violet' | 'sky';
+const TONE: Record<Tone, string> = {
+  rose: 'from-rose-50 to-white border-rose-200 text-rose-700',
+  amber: 'from-amber-50 to-white border-amber-200 text-amber-700',
+  violet: 'from-violet-50 to-white border-violet-200 text-violet-700',
+  sky: 'from-sky-50 to-white border-sky-200 text-sky-700',
+};
+
+function KpiTile({
+  label,
+  value,
+  hint,
+  tone,
+  icon: Icon,
+  active,
+  onClick,
+}: {
+  label: string;
+  value: number;
+  hint: string;
+  tone: Tone;
+  icon: React.ElementType;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'rounded-xl border bg-gradient-to-b p-4 text-left shadow-sm transition hover:shadow-md',
+        TONE[tone],
+        active && 'ring-2 ring-offset-1 ring-slate-400',
+      )}
+    >
+      <div className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide opacity-80">
+        <Icon className="h-3.5 w-3.5" />
+        {label}
+      </div>
+      <div className="mt-1 text-3xl font-bold text-slate-900 tabular-nums">{value}</div>
+      <div className="mt-0.5 text-[11px] text-slate-500">{hint}</div>
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sorting
+// ---------------------------------------------------------------------------
+
+type SortKey = 'employee' | 'windowType' | 'anpDays' | 'thresholdDays' | 'severity' | 'status' | 'createdAt';
+const SEVERITY_RANK: Record<string, number> = { HIGH: 3, MEDIUM: 2, LOW: 1 };
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+export function AbsenceAlertsClient() {
+  const [alerts, setAlerts] = useState<Alert[]>([]);
+  const [kpis, setKpis] = useState<Kpis>({ open: 0, high: 0, letterLinked: 0, flaggedEmployees: 0 });
+  const [loading, setLoading] = useState(true);
+  const [running, setRunning] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('ALL');
+  const [windowFilter, setWindowFilter] = useState<WindowFilter>('ALL');
+  const [severityFilter, setSeverityFilter] = useState<SeverityFilter>('ALL');
+  const [search, setSearch] = useState('');
+  const [sort, setSort] = useState<{ key: SortKey; dir: 'asc' | 'desc' }>({ key: 'createdAt', dir: 'desc' });
+
+  const fetchAlerts = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams({ pageSize: '500' });
+      if (statusFilter !== 'ALL') params.set('status', statusFilter);
+      if (windowFilter !== 'ALL') params.set('windowType', windowFilter);
+      if (severityFilter !== 'ALL') params.set('severity', severityFilter);
+      if (search.trim()) params.set('q', search.trim());
+      const res = await fetch(`/api/hr/absence-alerts?${params.toString()}`);
+      if (!res.ok) throw new Error('Failed to load alerts');
+      const data = await res.json();
+      setAlerts(Array.isArray(data.alerts) ? data.alerts : []);
+      if (data.kpis) setKpis(data.kpis);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load alerts');
+      setAlerts([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [statusFilter, windowFilter, severityFilter, search]);
+
+  useEffect(() => {
+    fetchAlerts();
+  }, [fetchAlerts]);
+
+  const runNow = useCallback(async () => {
+    setRunning(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/hr/absence-alerts/evaluate', { method: 'POST' });
+      if (!res.ok) throw new Error('Evaluation failed');
+      await fetchAlerts();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Evaluation failed');
+    } finally {
+      setRunning(false);
+    }
+  }, [fetchAlerts]);
+
+  const act = useCallback(
+    async (id: string, action: 'acknowledge' | 'resolve' | 'dismiss' | 'create-letter') => {
+      if (action === 'create-letter' && !confirm('Create a disciplinary letter for this alert? It will be submitted for CEO approval.')) {
+        return;
+      }
+      setBusyId(id);
+      setError(null);
+      try {
+        const res = await fetch(`/api/hr/absence-alerts/${id}/action`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action }),
+        });
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body.error || 'Action failed');
+        }
+        await fetchAlerts();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Action failed');
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [fetchAlerts],
+  );
+
+  const toggleSort = (key: SortKey) =>
+    setSort((s) => (s.key === key ? { key, dir: s.dir === 'asc' ? 'desc' : 'asc' } : { key, dir: 'asc' }));
+
+  const sorted = useMemo(() => {
+    const arr = [...alerts];
+    const dir = sort.dir === 'asc' ? 1 : -1;
+    arr.sort((a, b) => {
+      switch (sort.key) {
+        case 'employee':
+          return a.employee.fullNameEn.localeCompare(b.employee.fullNameEn) * dir;
+        case 'windowType':
+          return a.windowType.localeCompare(b.windowType) * dir;
+        case 'anpDays':
+          return (a.anpDays - b.anpDays) * dir;
+        case 'thresholdDays':
+          return (a.thresholdDays - b.thresholdDays) * dir;
+        case 'severity':
+          return ((SEVERITY_RANK[a.severity] ?? 0) - (SEVERITY_RANK[b.severity] ?? 0)) * dir;
+        case 'status':
+          return a.status.localeCompare(b.status) * dir;
+        case 'createdAt':
+        default:
+          return (new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()) * dir;
+      }
+    });
+    return arr;
+  }, [alerts, sort]);
+
+  const SortableHeader = ({ col, label, className }: { col: SortKey; label: string; className?: string }) => (
+    <th
+      className={cn(
+        'cursor-pointer select-none px-3 py-2 text-xs font-semibold uppercase tracking-wide text-slate-600 hover:bg-slate-100',
+        className,
+      )}
+      onClick={() => toggleSort(col)}
+    >
+      <span className="flex items-center gap-1">
+        {label}
+        {sort.key === col ? (sort.dir === 'asc' ? '↑' : '↓') : <span className="opacity-30">↕</span>}
+      </span>
+    </th>
+  );
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      {/* Hero */}
+      <div className="border-b bg-gradient-to-r from-slate-700 via-slate-800 to-slate-900 text-white">
+        <div className="px-6 py-7">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <div className="mb-1.5 flex items-center gap-2">
+                <ShieldAlert className="h-5 w-5 opacity-70" />
+                <span className="text-xs font-medium uppercase tracking-wider text-slate-300">HR › Absence Alerts</span>
+              </div>
+              <h1 className="text-2xl font-bold">Unauthorized Absence Alerts</h1>
+              <p className="mt-1 text-sm text-slate-300">
+                Saudi Labor Law escalation — consecutive (5/10/15) and intermittent (10/20/30 over a rolling year)
+                {loading ? '' : ` · ${alerts.length} shown`}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={runNow}
+              disabled={running}
+              className="inline-flex items-center gap-2 rounded-lg border border-white/30 bg-white/10 px-3 py-2 text-sm font-medium hover:bg-white/20 disabled:opacity-60"
+            >
+              {running ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+              Run evaluation now
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-5 p-6">
+        {/* KPI strip — tiles filter the table */}
+        <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+          <KpiTile
+            label="Open alerts"
+            value={kpis.open}
+            hint="Awaiting HR action"
+            tone="rose"
+            icon={AlertTriangle}
+            active={statusFilter === 'OPEN'}
+            onClick={() => setStatusFilter((s) => (s === 'OPEN' ? 'ALL' : 'OPEN'))}
+          />
+          <KpiTile
+            label="High severity"
+            value={kpis.high}
+            hint="Open / acknowledged, HIGH"
+            tone="amber"
+            icon={ShieldAlert}
+            active={severityFilter === 'HIGH'}
+            onClick={() => setSeverityFilter((s) => (s === 'HIGH' ? 'ALL' : 'HIGH'))}
+          />
+          <KpiTile
+            label="Employees flagged"
+            value={kpis.flaggedEmployees}
+            hint="With open/ack alerts"
+            tone="sky"
+            icon={Users}
+            active={false}
+            onClick={() => setStatusFilter('ALL')}
+          />
+          <KpiTile
+            label="Letters linked"
+            value={kpis.letterLinked}
+            hint="Disciplinary letter issued"
+            tone="violet"
+            icon={FileWarning}
+            active={statusFilter === 'LETTER_LINKED'}
+            onClick={() => setStatusFilter((s) => (s === 'LETTER_LINKED' ? 'ALL' : 'LETTER_LINKED'))}
+          />
+        </div>
+
+        {/* Filters */}
+        <div className="flex flex-wrap gap-3">
+          <input
+            placeholder="Search by employee name or ID…"
+            className="min-w-[240px] flex-1 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+          <select
+            className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm"
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value as StatusFilter)}
+          >
+            <option value="ALL">All statuses</option>
+            <option value="OPEN">Open</option>
+            <option value="ACKNOWLEDGED">Acknowledged</option>
+            <option value="LETTER_LINKED">Letter linked</option>
+            <option value="RESOLVED">Resolved</option>
+            <option value="DISMISSED">Dismissed</option>
+          </select>
+          <select
+            className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm"
+            value={windowFilter}
+            onChange={(e) => setWindowFilter(e.target.value as WindowFilter)}
+          >
+            <option value="ALL">All windows</option>
+            <option value="CONSECUTIVE">Consecutive</option>
+            <option value="INTERMITTENT">Intermittent</option>
+          </select>
+          <select
+            className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm"
+            value={severityFilter}
+            onChange={(e) => setSeverityFilter(e.target.value as SeverityFilter)}
+          >
+            <option value="ALL">All severities</option>
+            <option value="HIGH">High</option>
+            <option value="MEDIUM">Medium</option>
+            <option value="LOW">Low</option>
+          </select>
+        </div>
+
+        {error && <div className="rounded-lg border border-rose-200 bg-rose-50 px-4 py-2 text-sm text-rose-700">{error}</div>}
+
+        {/* Table */}
+        <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm">
+          <table className="min-w-full divide-y divide-slate-200">
+            <thead className="bg-slate-50">
+              <tr>
+                <SortableHeader col="employee" label="Employee" />
+                <SortableHeader col="windowType" label="Window" />
+                <SortableHeader col="anpDays" label="ANP Days" className="text-right" />
+                <SortableHeader col="thresholdDays" label="Threshold" className="text-right" />
+                <SortableHeader col="severity" label="Severity" />
+                <SortableHeader col="status" label="Status" />
+                <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-slate-600">Recommended letter</th>
+                <SortableHeader col="createdAt" label="Detected" />
+                <th className="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wide text-slate-600">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {loading ? (
+                <tr>
+                  <td colSpan={9} className="px-3 py-10 text-center text-slate-400">
+                    <Loader2 className="mx-auto h-5 w-5 animate-spin" />
+                  </td>
+                </tr>
+              ) : sorted.length === 0 ? (
+                <tr>
+                  <td colSpan={9} className="px-3 py-10 text-center text-sm text-slate-400">
+                    No absence alerts match the current filters.
+                  </td>
+                </tr>
+              ) : (
+                sorted.map((a) => {
+                  const closed = a.status === 'RESOLVED' || a.status === 'DISMISSED';
+                  return (
+                    <tr key={a.id} className="hover:bg-slate-50">
+                      <td className="px-3 py-2">
+                        <div className="font-medium text-slate-800">{a.employee.fullNameEn}</div>
+                        <div className="text-xs text-slate-400">
+                          {a.employee.employmentId}
+                          {a.employee.occupation ? ` · ${a.employee.occupation}` : ''}
+                        </div>
+                      </td>
+                      <td className="px-3 py-2 text-sm text-slate-600">
+                        {a.windowType === 'CONSECUTIVE' ? 'Consecutive' : 'Intermittent'}
+                        {a.kind === 'PRE_THRESHOLD' && (
+                          <span className="ml-1 rounded bg-slate-100 px-1.5 py-0.5 text-[10px] font-medium text-slate-500">EARLY</span>
+                        )}
+                      </td>
+                      <td className="px-3 py-2 text-right tabular-nums font-semibold text-slate-800">{a.anpDays}</td>
+                      <td className="px-3 py-2 text-right tabular-nums text-slate-500">{a.thresholdDays}</td>
+                      <td className="px-3 py-2">
+                        <span className={cn('rounded-full border px-2 py-0.5 text-[11px] font-medium', SEVERITY_STYLE[a.severity])}>
+                          {a.severity}
+                        </span>
+                      </td>
+                      <td className="px-3 py-2">
+                        <span className={cn('rounded-full border px-2 py-0.5 text-[11px] font-medium', STATUS_STYLE[a.status])}>
+                          {a.status.replace(/_/g, ' ')}
+                        </span>
+                      </td>
+                      <td className="px-3 py-2 text-sm text-slate-600">
+                        {a.linkedLetter ? (
+                          <span className="text-violet-700">{a.linkedLetter.letterNumber}</span>
+                        ) : (
+                          letterLabel(a.recommendedLetterType)
+                        )}
+                      </td>
+                      <td className="px-3 py-2 text-xs text-slate-500">{fmtDate(a.createdAt)}</td>
+                      <td className="px-3 py-2">
+                        <div className="flex items-center justify-end gap-1">
+                          {busyId === a.id ? (
+                            <Loader2 className="h-4 w-4 animate-spin text-slate-400" />
+                          ) : (
+                            <>
+                              {a.status === 'OPEN' && (
+                                <button
+                                  type="button"
+                                  title="Acknowledge"
+                                  onClick={() => act(a.id, 'acknowledge')}
+                                  className="rounded p-1 text-amber-600 hover:bg-amber-50"
+                                >
+                                  <Check className="h-4 w-4" />
+                                </button>
+                              )}
+                              {a.recommendedLetterType && !a.linkedLetterId && !closed && (
+                                <button
+                                  type="button"
+                                  title="Create disciplinary letter"
+                                  onClick={() => act(a.id, 'create-letter')}
+                                  className="rounded p-1 text-violet-600 hover:bg-violet-50"
+                                >
+                                  <FileText className="h-4 w-4" />
+                                </button>
+                              )}
+                              {!closed && (
+                                <button
+                                  type="button"
+                                  title="Resolve"
+                                  onClick={() => act(a.id, 'resolve')}
+                                  className="rounded p-1 text-emerald-600 hover:bg-emerald-50"
+                                >
+                                  <CheckCircle2 className="h-4 w-4" />
+                                </button>
+                              )}
+                              {!closed && (
+                                <button
+                                  type="button"
+                                  title="Dismiss (false positive)"
+                                  onClick={() => act(a.id, 'dismiss')}
+                                  className="rounded p-1 text-slate-400 hover:bg-slate-100"
+                                >
+                                  <X className="h-4 w-4" />
+                                </button>
+                              )}
+                            </>
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -41,6 +41,7 @@ export async function register() {
     const { ContractRemindersScheduler } = await import('@/lib/scheduler/contract-reminders.scheduler');
     const { OpsAgentScheduler } = await import('@/lib/scheduler/ops-agent.scheduler');
     const { AttendanceSyncScheduler } = await import('@/lib/scheduler/attendance-sync.scheduler');
+    const { AbsenceEscalationScheduler } = await import('@/lib/scheduler/absence-escalation.scheduler');
     const { CalibrationReminderScheduler } = await import('@/lib/scheduler/calibration-reminder.scheduler');
     const { HrMonthlyReportScheduler } = await import('@/lib/scheduler/hr-monthly-report.scheduler');
     const { ensureOpsAgentConfig } = await import('@/lib/ops-agent/seeder');
@@ -75,6 +76,10 @@ export async function register() {
 
     // Initialize the daily PTS Attendance & Overtime Sync scheduler (HR module, 19.6.0)
     AttendanceSyncScheduler.initialize();
+
+    // Initialize the daily Absence Escalation scheduler (HR module, OTS-BL-080)
+    // Runs at 07:00 — after the 06:00 attendance sync — to evaluate ANP ladders.
+    AbsenceEscalationScheduler.initialize();
 
     // Initialize the daily Calibration Due Reminder scheduler (IMS module, 22.2.0)
     CalibrationReminderScheduler.initialize();

--- a/src/lib/cron-registry.ts
+++ b/src/lib/cron-registry.ts
@@ -6,6 +6,7 @@ export type CronJobId =
   | 'early-warning'
   | 'ops-agent'
   | 'attendance-sync'
+  | 'absence-escalation'
   | 'calibration-reminder';
 
 export interface CronJobDef {
@@ -105,6 +106,19 @@ export const CRON_JOB_REGISTRY: CronJobDef[] = [
     enabledEnvVar: 'ENABLE_ATTENDANCE_SYNC_SCHEDULER',
     intervalEnvVar: null,
     category: 'sync',
+  },
+  {
+    id: 'absence-escalation',
+    name: 'Absence Escalation Engine',
+    description:
+      'Saudi Labor Law — daily evaluation of unauthorized (ANP) absences. Persists graduated alerts (5/10/15 consecutive; 10/20/30 intermittent over a rolling year) and notifies HR before each disciplinary threshold.',
+    scheduleExpression: '0 7 * * *',
+    scheduleHuman: 'Daily at 07:00 (Asia/Riyadh)',
+    endpoint: '/api/hr/absence-alerts/evaluate',
+    authMode: 'bearer',
+    enabledEnvVar: 'ENABLE_ABSENCE_ESCALATION_SCHEDULER',
+    intervalEnvVar: null,
+    category: 'analysis',
   },
   {
     id: 'calibration-reminder',

--- a/src/lib/navigation-permissions.ts
+++ b/src/lib/navigation-permissions.ts
@@ -229,6 +229,9 @@ export const NAVIGATION_PERMISSIONS: NavigationPermissionMap = {
   // HR Absence Analytics (19.4.0)
   '/hr/analytics': ['hr.analytics.view'],
 
+  // HR Unauthorized-Absence Alerts (OTS-BL-080)
+  '/hr/absence-alerts': ['hr.analytics.view'],
+
   // HR Policies, Onboarding, Training (19.11.0)
   '/hr/policies': ['hr.employee.view'],
   '/hr/onboarding': ['hr.employee.view'],

--- a/src/lib/scheduler/absence-escalation.scheduler.ts
+++ b/src/lib/scheduler/absence-escalation.scheduler.ts
@@ -1,0 +1,104 @@
+import * as cron from 'node-cron';
+import prisma from '@/lib/db';
+import { logger } from '@/lib/logger';
+
+const log = logger.child({ module: 'AbsenceEscalationScheduler' });
+
+const SCHEDULER_CONFIG = {
+  JOB_NAME: 'AbsenceEscalation',
+  // Daily at 07:00 Riyadh — runs AFTER the 06:00 PTS attendance sync so the
+  // ANP data evaluated here is fresh for the day.
+  CRON_EXPRESSION: '0 7 * * *',
+  TIMEZONE: 'Asia/Riyadh',
+};
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __absenceEscalationSchedulerInitialized: boolean | undefined;
+  // eslint-disable-next-line no-var
+  var __absenceEscalationSchedulerTask: cron.ScheduledTask | undefined;
+}
+
+export class AbsenceEscalationScheduler {
+  private static isRunning = false;
+
+  static isEnabled(): boolean {
+    const envValue = process.env.ENABLE_ABSENCE_ESCALATION_SCHEDULER;
+    if (envValue === undefined) {
+      return process.env.NODE_ENV === 'production';
+    }
+    return envValue === 'true' || envValue === '1';
+  }
+
+  static initialize(): void {
+    if (global.__absenceEscalationSchedulerInitialized) {
+      log.info({}, 'Scheduler already initialized, skipping');
+      return;
+    }
+
+    if (!this.isEnabled()) {
+      log.info({ enabled: process.env.ENABLE_ABSENCE_ESCALATION_SCHEDULER }, 'Scheduler disabled');
+      return;
+    }
+
+    if (!cron.validate(SCHEDULER_CONFIG.CRON_EXPRESSION)) {
+      log.error({ cronExpression: SCHEDULER_CONFIG.CRON_EXPRESSION }, 'Invalid cron expression');
+      return;
+    }
+
+    const task = cron.schedule(
+      SCHEDULER_CONFIG.CRON_EXPRESSION,
+      async () => {
+        await this.executeJob();
+      },
+      { timezone: SCHEDULER_CONFIG.TIMEZONE },
+    );
+
+    global.__absenceEscalationSchedulerTask = task;
+    global.__absenceEscalationSchedulerInitialized = true;
+
+    log.info(
+      { cronExpression: SCHEDULER_CONFIG.CRON_EXPRESSION, timezone: SCHEDULER_CONFIG.TIMEZONE },
+      'Absence Escalation scheduler initialized',
+    );
+  }
+
+  private static async executeJob(): Promise<void> {
+    if (this.isRunning) {
+      log.info({}, 'Job already running, skipping');
+      return;
+    }
+
+    this.isRunning = true;
+    try {
+      const ceoUser = await prisma.user.findFirst({
+        where: { role: { name: 'CEO' }, status: 'active' },
+        select: { id: true },
+      });
+
+      const { evaluateAbsenceEscalations } = await import('@/lib/services/hr/absence-escalation.service');
+      const result = await evaluateAbsenceEscalations({ triggeredById: ceoUser?.id });
+      log.info(
+        { evaluated: result.evaluated, created: result.created, notified: result.notified },
+        'Absence escalation cron completed',
+      );
+    } catch (error) {
+      log.error({ error }, 'Absence escalation cron failed');
+    } finally {
+      this.isRunning = false;
+    }
+  }
+
+  static async runNow(): Promise<void> {
+    log.info({}, 'Manual execution triggered');
+    await this.executeJob();
+  }
+
+  static stop(): void {
+    if (global.__absenceEscalationSchedulerTask) {
+      global.__absenceEscalationSchedulerTask.stop();
+    }
+    global.__absenceEscalationSchedulerInitialized = false;
+    log.info({}, 'Scheduler stopped');
+  }
+}

--- a/src/lib/services/hr/absence-escalation.service.ts
+++ b/src/lib/services/hr/absence-escalation.service.ts
@@ -1,0 +1,344 @@
+/**
+ * Saudi Labor Law — Unauthorized-Absence Escalation Engine (OTS-BL-080)
+ *
+ * Evaluates ABSENT_NO_PERMISSION (ANP) attendance for every active employee and
+ * persists graduated `EmployeeAbsenceAlert` rows, notifying HR ahead of each
+ * threshold. Two ladders, per the labour-law policy:
+ *
+ *   CONSECUTIVE  (الغياب المتصل)            5 / 10 / 15 unbroken ANP days
+ *   INTERMITTENT (متقطع خلال السنة)         10 / 20 / 30 ANP days, rolling 12 months
+ *
+ * PRE_THRESHOLD alerts fire a short lead before each boundary so HR can act in
+ * time. THRESHOLD alerts recommend the matching HrLetterType (recommend-only —
+ * no letter is issued automatically). Fully idempotent via the unique dedupeKey,
+ * so the daily cron never creates duplicates.
+ */
+
+import type { Prisma } from '@prisma/client';
+import prisma from '@/lib/db';
+import { logger } from '@/lib/logger';
+import { NotificationService } from '@/lib/services/notification.service';
+import { currentStreak } from '@/lib/services/hr/absence-streak';
+
+const log = logger.child({ module: 'AbsenceEscalation' });
+
+type Severity = 'LOW' | 'MEDIUM' | 'HIGH';
+
+interface LadderStage {
+  days: number;
+  severity: Severity;
+  letterType: string; // HrLetterType value
+}
+
+/** Consecutive-absence ladder (الغياب المتصل). */
+export const CONSECUTIVE_LADDER: LadderStage[] = [
+  { days: 5, severity: 'MEDIUM', letterType: 'FIRST_WARNING' },
+  { days: 10, severity: 'HIGH', letterType: 'FINAL_WARNING' },
+  { days: 15, severity: 'HIGH', letterType: 'DISMISSAL' },
+];
+
+/** Intermittent ANP ladder over a rolling 12 months (متقطع خلال السنة التعاقدية). */
+export const INTERMITTENT_LADDER: LadderStage[] = [
+  { days: 10, severity: 'MEDIUM', letterType: 'ATTENTION' },
+  { days: 20, severity: 'MEDIUM', letterType: 'FIRST_WARNING' },
+  { days: 30, severity: 'HIGH', letterType: 'NON_RENEWAL_NOTICE' },
+];
+
+/** Lead (in ANP days) before a boundary at which a PRE_THRESHOLD alert fires. */
+const CONSECUTIVE_PRE_LEAD = 1;
+const INTERMITTENT_PRE_LEAD = 2;
+
+const ROLLING_WINDOW_DAYS = 365;
+const LOOKBACK_DAYS = 400; // rolling 12 months + slack to capture an ongoing streak
+
+const MS_PER_DAY = 86_400_000;
+
+function isoDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+/** UTC date with the time component stripped. */
+function utcDateOnly(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+}
+
+export interface EvaluateResult {
+  evaluated: number; // employees with ≥1 ANP day considered
+  created: number; // new alerts persisted
+  notified: number; // HR notifications dispatched
+}
+
+interface CandidateAlert {
+  employeeId: string;
+  employeeName: string;
+  windowType: 'CONSECUTIVE' | 'INTERMITTENT';
+  kind: 'PRE_THRESHOLD' | 'THRESHOLD';
+  thresholdDays: number;
+  anpDays: number;
+  severity: Severity;
+  recommendedLetterType: string | null;
+  periodFrom: Date;
+  periodTo: Date;
+  detail: string;
+  meta: Record<string, unknown>;
+  dedupeKey: string;
+}
+
+/**
+ * Build the candidate alerts for one employee from their ANP dates.
+ * Emits, per ladder, every crossed THRESHOLD stage plus a single PRE_THRESHOLD
+ * for the nearest not-yet-reached stage.
+ */
+function buildCandidates(
+  employeeId: string,
+  employeeName: string,
+  anpDates: Date[],
+  asOf: Date,
+): CandidateAlert[] {
+  const out: CandidateAlert[] = [];
+
+  // ---- Consecutive ladder ------------------------------------------------
+  const streak = currentStreak(anpDates);
+  if (streak) {
+    const streakStartIso = isoDate(streak.start);
+    const len = streak.length;
+
+    for (const stage of CONSECUTIVE_LADDER) {
+      if (len >= stage.days) {
+        out.push({
+          employeeId,
+          employeeName,
+          windowType: 'CONSECUTIVE',
+          kind: 'THRESHOLD',
+          thresholdDays: stage.days,
+          anpDays: len,
+          severity: stage.severity,
+          recommendedLetterType: stage.letterType,
+          periodFrom: streak.start,
+          periodTo: streak.end,
+          detail: `${len} consecutive unauthorized-absence days (${streakStartIso} → ${isoDate(streak.end)}) — reached the ${stage.days}-day threshold.`,
+          meta: { streakDays: len, from: streakStartIso, to: isoDate(streak.end), thresholdDays: stage.days },
+          dedupeKey: `consec:${employeeId}:${stage.days}:THRESHOLD:${streakStartIso}`,
+        });
+      }
+    }
+
+    const nextStage = CONSECUTIVE_LADDER.find((s) => len < s.days);
+    if (nextStage && len >= nextStage.days - CONSECUTIVE_PRE_LEAD) {
+      out.push({
+        employeeId,
+        employeeName,
+        windowType: 'CONSECUTIVE',
+        kind: 'PRE_THRESHOLD',
+        thresholdDays: nextStage.days,
+        anpDays: len,
+        severity: 'LOW',
+        recommendedLetterType: null,
+        periodFrom: streak.start,
+        periodTo: streak.end,
+        detail: `${len} consecutive unauthorized-absence days — ${nextStage.days - len} day(s) from the ${nextStage.days}-day threshold (${nextStage.letterType.replace(/_/g, ' ').toLowerCase()}).`,
+        meta: { streakDays: len, approachingThreshold: nextStage.days, recommendedNextLetter: nextStage.letterType },
+        dedupeKey: `consec:${employeeId}:${nextStage.days}:PRE_THRESHOLD:${streakStartIso}`,
+      });
+    }
+  }
+
+  // ---- Intermittent ladder (rolling 12 months) ---------------------------
+  const windowStart = new Date(asOf.getTime() - ROLLING_WINDOW_DAYS * MS_PER_DAY);
+  const inWindow = anpDates.filter((d) => d >= windowStart && d <= asOf);
+  const count = inWindow.length;
+  if (count > 0) {
+    const yearBucket = String(asOf.getUTCFullYear());
+
+    for (const stage of INTERMITTENT_LADDER) {
+      if (count >= stage.days) {
+        out.push({
+          employeeId,
+          employeeName,
+          windowType: 'INTERMITTENT',
+          kind: 'THRESHOLD',
+          thresholdDays: stage.days,
+          anpDays: count,
+          severity: stage.severity,
+          recommendedLetterType: stage.letterType,
+          periodFrom: windowStart,
+          periodTo: asOf,
+          detail: `${count} unauthorized-absence days over the past 12 months — reached the ${stage.days}-day threshold.`,
+          meta: { anpDays: count, windowFrom: isoDate(windowStart), windowTo: isoDate(asOf), thresholdDays: stage.days },
+          dedupeKey: `inter:${employeeId}:${stage.days}:THRESHOLD:${yearBucket}`,
+        });
+      }
+    }
+
+    const nextStage = INTERMITTENT_LADDER.find((s) => count < s.days);
+    if (nextStage && count >= nextStage.days - INTERMITTENT_PRE_LEAD) {
+      out.push({
+        employeeId,
+        employeeName,
+        windowType: 'INTERMITTENT',
+        kind: 'PRE_THRESHOLD',
+        thresholdDays: nextStage.days,
+        anpDays: count,
+        severity: 'LOW',
+        recommendedLetterType: null,
+        periodFrom: windowStart,
+        periodTo: asOf,
+        detail: `${count} unauthorized-absence days over the past 12 months — ${nextStage.days - count} day(s) from the ${nextStage.days}-day threshold.`,
+        meta: { anpDays: count, approachingThreshold: nextStage.days, recommendedNextLetter: nextStage.letterType },
+        dedupeKey: `inter:${employeeId}:${nextStage.days}:PRE_THRESHOLD:${yearBucket}`,
+      });
+    }
+  }
+
+  return out;
+}
+
+/** Active users who can see HR analytics — the absence-alert audience. */
+async function findHrRecipients(): Promise<{ id: string }[]> {
+  return prisma.user.findMany({
+    where: {
+      status: 'active',
+      role: { permissions: { path: '$', string_contains: 'hr.analytics.view' } },
+    },
+    select: { id: true },
+  });
+}
+
+/**
+ * Evaluate all active employees and persist any new absence alerts.
+ * Idempotent — safe to run daily (CLAUDE.md Ops Agent rules).
+ */
+export async function evaluateAbsenceEscalations(
+  params: { triggeredById?: string } = {},
+): Promise<EvaluateResult> {
+  const asOf = utcDateOnly(new Date());
+  const since = new Date(asOf.getTime() - LOOKBACK_DAYS * MS_PER_DAY);
+
+  // 1. Load ANP attendance for active employees over the lookback window.
+  const records = await prisma.attendanceRecord.findMany({
+    where: {
+      workerType: 'EMPLOYEE',
+      status: 'ABSENT_NO_PERMISSION',
+      date: { gte: since, lte: asOf },
+      employee: { status: 'ACTIVE', deletedAt: null },
+    },
+    select: {
+      employeeId: true,
+      date: true,
+      employee: { select: { id: true, fullNameEn: true } },
+    },
+    orderBy: { date: 'asc' },
+    take: 200_000,
+  });
+
+  // 2. Group ANP dates per employee.
+  const byEmployee = new Map<string, { name: string; dates: Date[] }>();
+  for (const rec of records) {
+    if (!rec.employeeId || !rec.employee) continue;
+    let acc = byEmployee.get(rec.employeeId);
+    if (!acc) {
+      acc = { name: rec.employee.fullNameEn, dates: [] };
+      byEmployee.set(rec.employeeId, acc);
+    }
+    acc.dates.push(utcDateOnly(new Date(rec.date)));
+  }
+
+  // 3. Build candidate alerts.
+  const candidates: CandidateAlert[] = [];
+  for (const [employeeId, { name, dates }] of byEmployee) {
+    candidates.push(...buildCandidates(employeeId, name, dates, asOf));
+  }
+
+  if (candidates.length === 0) {
+    log.info({ evaluated: byEmployee.size }, 'Absence escalation: no candidate alerts');
+    return { evaluated: byEmployee.size, created: 0, notified: 0 };
+  }
+
+  // 4. Skip candidates that already exist (idempotency via dedupeKey).
+  const existing = await prisma.employeeAbsenceAlert.findMany({
+    where: { dedupeKey: { in: candidates.map((c) => c.dedupeKey) } },
+    select: { dedupeKey: true },
+  });
+  const existingKeys = new Set(existing.map((e) => e.dedupeKey));
+  const fresh = candidates.filter((c) => !existingKeys.has(c.dedupeKey));
+
+  if (fresh.length === 0) {
+    log.info({ evaluated: byEmployee.size, candidates: candidates.length }, 'Absence escalation: all alerts already exist');
+    return { evaluated: byEmployee.size, created: 0, notified: 0 };
+  }
+
+  // 5. Persist new alerts and collect them for notification.
+  const recipients = await findHrRecipients();
+  const now = new Date();
+  let created = 0;
+  let notified = 0;
+
+  for (const c of fresh) {
+    try {
+      const alert = await prisma.employeeAbsenceAlert.create({
+        data: {
+          employeeId: c.employeeId,
+          windowType: c.windowType,
+          kind: c.kind,
+          thresholdDays: c.thresholdDays,
+          anpDays: c.anpDays,
+          severity: c.severity,
+          recommendedLetterType: c.recommendedLetterType,
+          periodFrom: c.periodFrom,
+          periodTo: c.periodTo,
+          detail: c.detail,
+          meta: c.meta as Prisma.InputJsonValue,
+          dedupeKey: c.dedupeKey,
+          notifiedAt: recipients.length > 0 ? now : null,
+        },
+        select: { id: true },
+      });
+      created++;
+
+      // 6. Notify HR (fire-and-forget per recipient; failures are non-fatal).
+      const windowLabel = c.windowType === 'CONSECUTIVE' ? 'consecutive' : 'intermittent';
+      const title =
+        c.kind === 'PRE_THRESHOLD'
+          ? `Absence approaching ${c.thresholdDays}-day threshold: ${c.employeeName}`
+          : `Absence threshold reached (${c.thresholdDays} ${windowLabel} days): ${c.employeeName}`;
+      for (const r of recipients) {
+        try {
+          await NotificationService.createNotification({
+            userId: r.id,
+            type: 'SYSTEM',
+            title,
+            message: c.detail,
+            relatedEntityType: 'absence_alert',
+            relatedEntityId: alert.id,
+            metadata: {
+              employeeId: c.employeeId,
+              employeeName: c.employeeName,
+              windowType: c.windowType,
+              kind: c.kind,
+              thresholdDays: c.thresholdDays,
+              anpDays: c.anpDays,
+              severity: c.severity,
+              recommendedLetterType: c.recommendedLetterType,
+            },
+          });
+          notified++;
+        } catch (err) {
+          log.warn({ err, userId: r.id, alertId: alert.id }, 'Failed to notify HR about absence alert');
+        }
+      }
+    } catch (err) {
+      // Unique-constraint races (a concurrent run inserted the same key) are expected — skip.
+      const isUnique = typeof err === 'object' && err !== null && 'code' in err && (err as { code: string }).code === 'P2002';
+      if (!isUnique) {
+        log.error({ err, dedupeKey: c.dedupeKey }, 'Failed to persist absence alert');
+      }
+    }
+  }
+
+  log.info(
+    { evaluated: byEmployee.size, candidates: candidates.length, created, notified, triggeredById: params.triggeredById ?? null },
+    'Absence escalation evaluation complete',
+  );
+
+  return { evaluated: byEmployee.size, created, notified };
+}

--- a/src/lib/services/hr/absence-streak.ts
+++ b/src/lib/services/hr/absence-streak.ts
@@ -1,0 +1,67 @@
+/**
+ * Shared ANP (ABSENT_NO_PERMISSION) streak helpers.
+ *
+ * Extracted from the on-demand absence-analytics endpoint so both the
+ * analytics view (`/api/hr/analytics/absence`) and the persisted escalation
+ * engine (`absence-escalation.service`) compute streaks identically.
+ *
+ * "Consecutive" is weekend-transparent: a gap of ≤ 3 days bridges the
+ * Fri/Sat/Sun rest period so Thu→Sun→Mon counts as one streak.
+ */
+
+export interface Streak {
+  length: number;
+  start: Date;
+  end: Date;
+}
+
+const MS_PER_DAY = 86_400_000;
+
+/** Two ANP dates belong to the same streak if their gap is > 0 and ≤ 3 days. */
+export function isConsecutiveGap(a: Date, b: Date): boolean {
+  const diffDays = (b.getTime() - a.getTime()) / MS_PER_DAY;
+  return diffDays > 0 && diffDays <= 3;
+}
+
+/** Longest run of "consecutive" ANP dates over the whole list. */
+export function longestStreak(dates: Date[]): Streak | null {
+  if (dates.length === 0) return null;
+  const sorted = [...dates].sort((a, b) => a.getTime() - b.getTime());
+  let best: Streak = { length: 1, start: sorted[0], end: sorted[0] };
+  let runStart = sorted[0];
+  let runLen = 1;
+  for (let i = 1; i < sorted.length; i++) {
+    if (isConsecutiveGap(sorted[i - 1], sorted[i])) {
+      runLen++;
+      if (runLen > best.length) {
+        best = { length: runLen, start: runStart, end: sorted[i] };
+      }
+    } else {
+      runStart = sorted[i];
+      runLen = 1;
+    }
+  }
+  return best;
+}
+
+/**
+ * The streak that ends at the most recent ANP date — i.e. the employee's
+ * "current" run of unauthorised absence. As the run grows day-by-day the
+ * `start` stays fixed, which is what the escalation engine keys its idempotent
+ * dedupeKey on (so the same streak escalates rather than duplicating).
+ */
+export function currentStreak(dates: Date[]): Streak | null {
+  if (dates.length === 0) return null;
+  const sorted = [...dates].sort((a, b) => a.getTime() - b.getTime());
+  let runStart = sorted[sorted.length - 1];
+  let runLen = 1;
+  for (let i = sorted.length - 1; i > 0; i--) {
+    if (isConsecutiveGap(sorted[i - 1], sorted[i])) {
+      runLen++;
+      runStart = sorted[i - 1];
+    } else {
+      break;
+    }
+  }
+  return { length: runLen, start: runStart, end: sorted[sorted.length - 1] };
+}

--- a/src/lib/services/hr/create-alert-letter.ts
+++ b/src/lib/services/hr/create-alert-letter.ts
@@ -1,0 +1,152 @@
+/**
+ * Create a disciplinary HrLetter from an absence alert (OTS-BL-080).
+ *
+ * Mirrors the official letter lifecycle used by POST /api/hr/letters: the letter
+ * is created as PENDING_CEO with a per-type serial number and the CEO approvers
+ * are notified. Nothing is issued without a human action — HR triggers this from
+ * the alert's "Create letter" button (recommend-only escalation).
+ */
+
+import prisma from '@/lib/db';
+import { logger } from '@/lib/logger';
+import { NotificationService } from '@/lib/services/notification.service';
+
+const log = logger.child({ module: 'AlertLetter' });
+
+/** Resolve the next per-type serial number inside a transaction (config or INT-YY-NNNN fallback). */
+async function resolveLetterNumberInTx(
+  tx: Parameters<Parameters<typeof prisma.$transaction>[0]>[0],
+  letterType: string,
+): Promise<{ number: string; configId?: string; newSeq?: number; newYear?: number }> {
+  let config = null;
+  try {
+    config = await tx.hrLetterSerialConfig.findUnique({ where: { letterType: letterType as never } });
+  } catch {
+    // serial-config table not present — fall through to fallback numbering
+  }
+
+  if (config) {
+    const year = new Date().getFullYear();
+    const twoDigitYear = year.toString().slice(-2);
+    const needsReset = config.resetYearly && config.lastResetYear !== null && config.lastResetYear !== year;
+    const newSeq = needsReset ? 1 : config.currentSeq + 1;
+    const nCount = (config.mask.match(/N+/) ?? ['NNNN'])[0].length;
+    const numStr = newSeq.toString().padStart(nCount, '0');
+    const number = config.mask
+      .replace('{PREFIX}', config.prefix)
+      .replace('{YYYY}', year.toString())
+      .replace('{YY}', twoDigitYear)
+      .replace(/N+/, numStr);
+    return { number, configId: config.id, newSeq, newYear: year };
+  }
+
+  // Fallback: INT-YY-NNNN (internal disciplinary letters)
+  const year = new Date().getFullYear().toString().slice(-2);
+  const pattern = `INT-${year}-%`;
+  let maxSeq = 0;
+  try {
+    const rows = await tx.$queryRaw<{ maxNum: string | null }[]>`
+      SELECT MAX(letterNumber) as maxNum FROM HrLetter WHERE letterNumber LIKE ${pattern}
+    `;
+    const maxNum = rows[0]?.maxNum;
+    if (maxNum) maxSeq = parseInt(maxNum.split('-')[2] ?? '0', 10) || 0;
+  } catch {
+    // HrLetter table not ready — start from 0
+  }
+  return { number: `INT-${year}-${(maxSeq + 1).toString().padStart(4, '0')}` };
+}
+
+/** Active users who can approve CEO-level letters. */
+async function findCeoApprovers(): Promise<{ id: string }[]> {
+  const users = await prisma.user.findMany({
+    where: { status: 'active' },
+    select: { id: true, isAdmin: true, customPermissions: true, role: { select: { permissions: true } } },
+  });
+  const out: { id: string }[] = [];
+  for (const u of users) {
+    const rolePerms = (u.role?.permissions as string[]) || [];
+    const custom = u.customPermissions as { grants?: string[]; revokes?: string[] } | null;
+    const grants = Array.isArray(custom?.grants) ? custom!.grants! : [];
+    const revoked = Array.isArray(custom?.revokes) ? custom!.revokes!.includes('hr.letters.approveCeo') : false;
+    const has = rolePerms.includes('hr.letters.approveCeo') || rolePerms.includes('ALL') || grants.includes('hr.letters.approveCeo') || grants.includes('ALL');
+    if ((u.isAdmin || has) && !revoked) out.push({ id: u.id });
+  }
+  return out;
+}
+
+export interface CreateAlertLetterParams {
+  employeeId: string;
+  letterType: string;
+  subject: string;
+  content: string;
+  createdById: string;
+}
+
+/** Create a PENDING_CEO disciplinary letter and notify CEO approvers. Returns the new letter id + number. */
+export async function createAlertLetter(
+  params: CreateAlertLetterParams,
+): Promise<{ id: string; letterNumber: string }> {
+  const employee = await prisma.employee.findFirst({
+    where: { id: params.employeeId, deletedAt: null },
+    select: { id: true, fullNameEn: true },
+  });
+  if (!employee) throw new Error('Employee not found');
+
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      const result = await prisma.$transaction(async (tx) => {
+        const resolved = await resolveLetterNumberInTx(tx, params.letterType);
+        if (resolved.configId && resolved.newSeq !== undefined && resolved.newYear !== undefined) {
+          try {
+            await tx.hrLetterSerialConfig.update({
+              where: { id: resolved.configId },
+              data: { currentSeq: resolved.newSeq, lastResetYear: resolved.newYear },
+            });
+          } catch {
+            // serial-config update is best-effort
+          }
+        }
+        const letter = await tx.hrLetter.create({
+          data: {
+            letterNumber: resolved.number,
+            letterType: params.letterType as never,
+            classification: 'INTERNAL',
+            language: 'ARABIC',
+            status: 'PENDING_CEO',
+            employeeId: params.employeeId,
+            subject: params.subject,
+            content: params.content,
+            issuedAt: new Date(),
+            createdById: params.createdById,
+          },
+          select: { id: true, letterNumber: true },
+        });
+        return letter;
+      });
+
+      // Notify CEO approvers (fire-and-forget).
+      findCeoApprovers()
+        .then((ceos) => {
+          ceos.forEach((ceo) => {
+            NotificationService.createNotification({
+              userId: ceo.id,
+              type: 'APPROVAL_REQUIRED',
+              title: 'Letter Approval Required',
+              message: `Disciplinary letter ${result.letterNumber} for ${employee.fullNameEn} — awaiting your approval`,
+              relatedEntityType: 'hr_letter',
+              relatedEntityId: result.id,
+            }).catch((err) => log.warn({ err, userId: ceo.id }, 'Failed to notify CEO about alert letter'));
+          });
+        })
+        .catch((err) => log.warn({ err }, 'Failed to resolve CEO approvers'));
+
+      log.info({ letterId: result.id, letterNumber: result.letterNumber, employeeId: params.employeeId }, 'Alert letter created');
+      return result;
+    } catch (error: unknown) {
+      const isUnique = typeof error === 'object' && error !== null && 'code' in error && (error as { code: string }).code === 'P2002';
+      if (isUnique && attempt < 4) continue;
+      throw error;
+    }
+  }
+  throw new Error('Failed to generate a unique letter number');
+}

--- a/src/lib/startup-migrations.ts
+++ b/src/lib/startup-migrations.ts
@@ -298,6 +298,9 @@ const STARTUP_MIGRATIONS = [
 
   // ── v44.2.0 — INV: repair unit_cost + total_cost (v44.1.1 tracked-but-failed) ─
   'v44_2_inv_ledger_cost_repair.sql',
+
+  // ── v45.0.0 — Saudi Labor Law unauthorized-absence alerts (OTS-BL-080) ──────
+  'v45_0_employee_absence_alerts.sql',  // EmployeeAbsenceAlert table (consecutive/intermittent ANP escalation)
 ];
 
 /**


### PR DESCRIPTION
Add a persisted, scheduled escalation engine for ABSENT_NO_PERMISSION (ANP)
attendance so HR is notified before each disciplinary threshold.

- EmployeeAbsenceAlert model + idempotent migration (dedupeKey)
- absence-escalation.service: two ladders — consecutive (5/10/15) and
  intermittent over a rolling 12 months (10/20/30) — with PRE_THRESHOLD
  early warnings and recommended HrLetterType per stage (recommend-only)
- Shared absence-streak helpers (analytics route refactored to reuse them)
- Daily 07:00 scheduler (after attendance sync) + cron registry entry
- APIs: list, [id]/action (acknowledge/resolve/dismiss/create-letter),
  evaluate (cron + manual); all gated by hr.analytics.view
- /hr/absence-alerts page (hero, clickable KPI tiles, sortable table) wired
  into the sidebar and navigation-permissions
- HR notifications dispatched to hr.analytics.view holders

https://claude.ai/code/session_01Lt9m5GD45vCvsFtygp23Go