### PR TITLE
fix: exclude Pending tasks from delay alerts and overdue highlighting

### DIFF
--- a/src/app/api/cron/deadline-reminders/route.ts
+++ b/src/app/api/cron/deadline-reminders/route.ts
@@ -30,7 +30,7 @@ export async function POST(req: NextRequest) {
   const tasks = await prisma.task.findMany({
     where: {
       dueDate: { gte: windowStart, lte: windowEnd },
-      status: { notIn: ['Completed'] },
+      status: { notIn: ['Completed', 'Pending'] },
       assignedToId: { not: null },
     },
     select: {

--- a/src/app/api/notifications/delayed-tasks/route.ts
+++ b/src/app/api/notifications/delayed-tasks/route.ts
@@ -72,7 +72,7 @@ export async function GET(req: Request) {
           lt: now, // Due date is in the past
         },
         status: {
-          not: 'Completed', // Not completed
+          notIn: ['Completed', 'Pending'], // Not completed, not pending (pending tasks haven't started yet)
         },
         deletedAt: null,
         ...userFilter,

--- a/src/components/tasks-client.tsx
+++ b/src/components/tasks-client.tsx
@@ -1162,12 +1162,12 @@ export function TasksClient({ initialTasks, userId, allUsers, allProjects, allBu
   };
 
   const isOverdue = (dueDate: string, status: string) => {
-    if (status === 'Completed') return false;
+    if (status === 'Completed' || status === 'Pending') return false;
     return new Date(dueDate) < new Date();
   };
 
   const getOverdueDays = (dueDate: string, status: string) => {
-    if (status === 'Completed') return 0;
+    if (status === 'Completed' || status === 'Pending') return 0;
     const today = new Date();
     today.setHours(0, 0, 0, 0);
     const due = new Date(dueDate);

--- a/src/lib/services/deadline-scheduler.service.ts
+++ b/src/lib/services/deadline-scheduler.service.ts
@@ -72,7 +72,7 @@ export class DeadlineSchedulerService {
             lte: in48Hours,
           },
           status: {
-            not: 'Completed',
+            notIn: ['Completed', 'Pending'],
           },
           assignedToId: {
             not: null,


### PR DESCRIPTION
Tasks in Pending status have not started yet, so showing them as delayed
or highlighting them red is misleading. This change filters out Pending
tasks from:
- The delayed-tasks API endpoint
- The tasks-client isOverdue/getOverdueDays frontend helpers
- The deadline scheduler service (48h warning cron)
- The deadline-reminders cron job

https://claude.ai/code/session_01DSHHxRzH5h2Agy22631TX1